### PR TITLE
Fix chromedp shutdown temporary file race condition

### DIFF
--- a/biloba.go
+++ b/biloba.go
@@ -122,7 +122,10 @@ func SpinUpChrome(ginkgoT GinkgoTInterface, options ...chromedp.ExecAllocatorOpt
 	}
 
 	os.WriteFile(gooseConfigPath(ginkgoT.ParallelProcess()), cc.encode(), 0744)
-	ginkgoT.DeferCleanup(os.Remove, gooseConfigPath(ginkgoT.ParallelProcess()))
+	ginkgoT.DeferCleanup(func() error {
+		chromedp.Cancel(browserCtx)
+		return os.Remove(gooseConfigPath(ginkgoT.ParallelProcess()))
+	})
 
 	return cc
 }


### PR DESCRIPTION
In some situations, cleanup of an otherwise successful test suite fails with the error

`[FAILED] DeferCleanup callback returned error: unlinkat /tmp/ginkgo$RANDOMID/Default: directory not empty`

reported to be at

`$GOPATH/pkg/mod/github.com/onsi/ginkgo/v2@v2.14.0/internal/testingtproxy/testing_t_proxy.go:153`

As best I can tell, this is a result of the spawned chrome instance writing a temporary file after ginkgo attempts to run a `DeferCleanup`-ed `os.Remove` on its directory as a result of a race condition.

This patch, at least empirically, fixes this by calling `chromedp.Cancel` which, according to its docstring, ensures chrome is cleaned up before returning.

As a test, a test suite which would previously fail with this error at a rate of about 1 in 10 was run with `--until-it-fails` for 10 minutes without error. Removing this line and running again resulted in a failure within a minute.