### PR TITLE
2/17 route the Go API through the engine, preserving its behavior

### DIFF
--- a/cdp.go
+++ b/cdp.go
@@ -117,12 +117,27 @@ func (b *Biloba) runCDPWithin(timeout time.Duration, what string, actions ...chr
 // runCDPIn runs actions in an already-bounded context - the waiting commands build theirs with
 // waitingContext - so every path into Chrome funnels through one place that can diagnose a failure.
 func (b *Biloba) runCDPIn(ctx context.Context, timeout time.Duration, what string, actions ...chromedp.Action) error {
+	return b.runEngineIn(ctx, timeout, what, func(runCtx context.Context) error {
+		return chromedp.Run(runCtx, actions...)
+	})
+}
+
+// runEngine applies Biloba's CDP backstop and diagnosis around a runner-neutral engine operation.
+func (b *Biloba) runEngine(what string, run func(context.Context) error) error {
+	ctx, cancel := b.cdpContext(cdpTimeout)
+	defer cancel()
+	return b.runEngineIn(ctx, cdpTimeout, what, run)
+}
+
+// runEngineIn is the engine-operation counterpart to runCDPIn for callers that already own the
+// waiting context and timeout.
+func (b *Biloba) runEngineIn(ctx context.Context, timeout time.Duration, what string, run func(context.Context) error) error {
 	var err error
 	if simulateWedgedCDP != nil && simulateWedgedCDP() {
 		<-ctx.Done()
 		err = ctx.Err()
 	} else {
-		err = chromedp.Run(ctx, actions...)
+		err = run(ctx)
 	}
 	return b.diagnoseCDPError(what, timeout, err)
 }

--- a/cookies.go
+++ b/cookies.go
@@ -2,13 +2,13 @@ package biloba
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/cdproto/storage"
 	"github.com/chromedp/chromedp"
+	"github.com/onsi/biloba/engine"
 )
 
 /*
@@ -47,17 +47,8 @@ func (b *Biloba) SetCookie(cookies ...Cookie) {
 	b.gt.Helper()
 	b.guardConfig("SetCookie")
 	location, _ := b.location()
-	params := make([]*network.CookieParam, len(cookies))
+	engineCookies := make([]engine.Cookie, len(cookies))
 	for i, cookie := range cookies {
-		param := &network.CookieParam{
-			Name:     cookie.Name,
-			Value:    cookie.Value,
-			Domain:   cookie.Domain,
-			Path:     cookie.Path,
-			Secure:   cookie.Secure,
-			HTTPOnly: cookie.HTTPOnly,
-			SameSite: network.CookieSameSite(cookie.SameSite),
-		}
 		// A cookie must be tied to an origin via either an explicit Domain or a URL. When no
 		// Domain is given we fall back to the tab's current location as the URL (an explicit
 		// Path, if any, still overrides the path the URL would imply). We fail loudly when
@@ -72,16 +63,11 @@ func (b *Biloba) SetCookie(cookies ...Cookie) {
 				b.gt.Fatalf("Failed to set cookie %q: a cookie needs an origin, but it has no Domain and the tab's current location (%q) is not one a cookie can attach to.\nNavigate the tab to a real URL before calling SetCookie, or set the cookie's Domain explicitly.", name, location)
 				return
 			}
-			param.URL = location
 		}
-		if !cookie.Expires.IsZero() {
-			expires := cdp.TimeSinceEpoch(cookie.Expires)
-			param.Expires = &expires
-		}
-		params[i] = param
+		engineCookies[i] = engine.Cookie{Name: cookie.Name, Value: cookie.Value, Domain: cookie.Domain, Path: cookie.Path, Expires: cookie.Expires, Secure: cookie.Secure, HTTPOnly: cookie.HTTPOnly, SameSite: cookie.SameSite}
 	}
-	err := b.runWithBrowserExecutor(func(ctx context.Context) error {
-		return storage.SetCookies(params).WithBrowserContextID(b.browserContextID).Do(ctx)
+	err := b.runEngine("set cookies", func(ctx context.Context) error {
+		return engine.SetCookiesContext(ctx, b.browserContextID, location, engineCookies)
 	})
 	if err != nil {
 		b.gt.Fatalf("Failed to set cookies:\n%s", err.Error())
@@ -92,7 +78,7 @@ func (b *Biloba) SetCookie(cookies ...Cookie) {
 // (and other opaque/empty origins) cannot hold cookies, which is the common reason a SetCookie
 // silently does nothing.
 func isUsableCookieOrigin(location string) bool {
-	return location != "" && !strings.HasPrefix(location, "about:")
+	return engine.IsUsableCookieOrigin(location)
 }
 
 /*
@@ -183,9 +169,7 @@ Read https://onsi.github.io/biloba/#cookies-and-storage to learn more about cook
 func (b *Biloba) ClearCookies() {
 	b.gt.Helper()
 	b.guardConfig("ClearCookies")
-	err := b.runWithBrowserExecutor(func(ctx context.Context) error {
-		return storage.ClearCookies().WithBrowserContextID(b.browserContextID).Do(ctx)
-	})
+	err := engine.ClearCookiesContext(b.Context, b.browserContextID)
 	if err != nil {
 		b.gt.Fatalf("Failed to clear cookies:\n%s", err.Error())
 	}
@@ -202,9 +186,7 @@ func (b *Biloba) ClearCookies() {
 // afterwards). The try/catch makes the storage clear a no-op on about:blank and other
 // opaque origins, where accessing window.localStorage throws.
 func (b *Biloba) resetBrowsingState() {
-	b.runWithBrowserExecutor(func(ctx context.Context) error {
-		return storage.ClearCookies().WithBrowserContextID(b.browserContextID).Do(ctx)
-	})
+	_ = engine.ClearCookiesContext(b.Context, b.browserContextID)
 	b.RunErr(`try { window.localStorage.clear(); window.sessionStorage.clear(); } catch (e) {}`)
 	b.clearLeakedColorSchemeEmulation()
 }

--- a/dom.go
+++ b/dom.go
@@ -1,12 +1,14 @@
 package biloba
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 
+	"github.com/onsi/biloba/engine"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gcustom"
 	"github.com/onsi/gomega/types"
@@ -57,6 +59,12 @@ func encodeSelector(selector any) (string, error) {
 }
 
 func (b *Biloba) runBilobaHandler(name string, selector any, args ...any) *bilobaJSResponse {
+	// The handler goes to the engine rather than through RunErr, so the two guarantees RunErr
+	// provides every evaluation have to be restated here: throttle against Chrome's
+	// 10-downloads-per-second limit (a Click is the usual way a download gets triggered), and
+	// reinstall the bridge when the page turned over before the frameNavigated event that clears
+	// bilobaIsInstalled reached us.  See runErr in javascript.go - these move together.
+	b.blockIfNecessaryToEnsureSuccessfulDownloads()
 	b.ensureBiloba()
 	result := &bilobaJSResponse{}
 	encoded, err := encodeSelector(selector)
@@ -64,11 +72,27 @@ func (b *Biloba) runBilobaHandler(name string, selector any, args ...any) *bilob
 		result.Err = err.Error()
 		return result
 	}
-	parameters := []any{encoded}
-	parameters = append(parameters, args...)
-	_, err = b.RunErr(b.JSFunc("_biloba."+name).Invoke(parameters...), result)
+	var engineResult engine.HandlerResponse
+	err = b.runEngine("evaluate JavaScript in the page", func(ctx context.Context) error {
+		var runErr error
+		engineResult, runErr = engine.RunHandlerContext(ctx, name, encoded, args...)
+		return runErr
+	})
+	if err != nil && strings.Contains(err.Error(), "_biloba is not defined") {
+		b.reloadBiloba()
+		err = b.runEngine("evaluate JavaScript in the page", func(ctx context.Context) error {
+			var runErr error
+			engineResult, runErr = engine.RunHandlerContext(ctx, name, encoded, args...)
+			return runErr
+		})
+	}
 	if err != nil {
 		result.Err = err.Error()
+	} else {
+		result.Success = engineResult.Success
+		result.Err = engineResult.Err
+		result.Result = engineResult.Result
+		result.Found = engineResult.Found
 	}
 	if result.Found != nil {
 		// one lock + a few comparisons per DOM op, and only when trajectory recording is on

--- a/dom_test.go
+++ b/dom_test.go
@@ -2468,6 +2468,33 @@ var _ = Describe("DOM manipulators and matchers", func() {
 	})
 })
 
+// The DOM handlers reach the browser through the engine rather than through RunErr, so they have
+// to restate RunErr's guarantees themselves (see runBilobaHandler in dom.go).  These specs pin the
+// two that are invisible until they are gone: the bridge reinstall, and - over in downloads_test.go
+// - the download throttle.
+var _ = Describe("the biloba.js bridge", func() {
+	BeforeEach(func() {
+		b.Navigate(fixtureServer + "/dom.html")
+		Eventually("#hello").Should(b.Exist())
+	})
+
+	It("reinstalls itself when the page drops it out from under a DOM handler", func() {
+		// A real page turns the JavaScript world over on navigation; bilobaIsInstalled is cleared
+		// by the frameNavigated event, which can land after the next handler has already run.
+		// Dropping the global directly reproduces that window without racing a navigation.
+		b.Run(`delete window._biloba`)
+
+		Ω(b.HasElement("#hello")).Should(BeTrue(), "a DOM handler should reinstall biloba.js and retry rather than surface the ReferenceError")
+		Ω(b.GetInnerText("#hello")).Should(Equal("Hello Biloba!"))
+	})
+
+	It("reinstalls itself for the matcher form too", func() {
+		b.Run(`delete window._biloba`)
+
+		Eventually("#hello").Should(b.Exist())
+	})
+})
+
 var _ = Describe("Failure diagnostics", func() {
 	BeforeEach(func() {
 		b.Navigate(fixtureServer + "/diagnostics.html")

--- a/downloads_test.go
+++ b/downloads_test.go
@@ -35,6 +35,23 @@ var _ = Describe("Downloading Files", func() {
 		Ω(string(dl.Content())).Should(Equal("Some new content"))
 	})
 
+	// Downloads are triggered by DOM interactions, so the throttle has to live on the DOM handler
+	// path itself (see runBilobaHandler in dom.go).  The "many downloads" specs below cover this
+	// too, but they fail as an opaque count mismatch that reads like a Chrome quirk; this one names
+	// the mechanism.
+	It("throttles DOM interactions against Chrome's download limit", func(ctx SpecContext) {
+		limit := biloba.ChromeDownloadLimitForTest()
+		for range limit {
+			b.Click("#download")
+		}
+		Eventually(ctx, b.AllCompleteDownloads).Should(HaveLen(limit))
+
+		b.Click("#download")
+
+		Eventually(ctx, b.AllCompleteDownloads).Should(HaveLen(limit+1),
+			"Chrome dropped the download past its %d-per-second limit, which means the DOM interaction that triggered it did not wait the limit out", limit)
+	}, SpecTimeout(30*time.Second))
+
 	It("can handle many downloads", func(ctx SpecContext) {
 		t := time.Now()
 		for i := 1; i < 15; i++ {

--- a/export_test.go
+++ b/export_test.go
@@ -226,3 +226,9 @@ type TabScreenshotForTest struct {
 	Failure          string
 	ImgcatScreenshot string
 }
+
+// ChromeDownloadLimitForTest exposes the number of concurrent downloads Chrome accepts before it
+// starts dropping them, so downloads_test.go can saturate the limit without hardcoding it.
+func ChromeDownloadLimitForTest() int {
+	return _CHROME_DOWNLOAD_LIMIT
+}

--- a/headless_shell.go
+++ b/headless_shell.go
@@ -7,17 +7,18 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strings"
 	"time"
+
+	"github.com/onsi/biloba/engine"
 )
 
 // BILOBA_CHROME_HEADLESS_SHELL lets you point Biloba at a chrome-headless-shell binary
-// without code changes.
-const headlessShellEnvVar = "BILOBA_CHROME_HEADLESS_SHELL"
+// without code changes.  The search itself is runner-neutral and lives in the engine, so the
+// bilobad daemon and this suite resolve the same binary.
+const headlessShellEnvVar = engine.ChromeEnvVar
 
 const chromeForTestingVersionsURL = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
 
@@ -42,49 +43,11 @@ func resolveHeadlessShellPath(ginkgoT GinkgoTInterface, cfg *spinUpConfig) (stri
 // locateHeadlessShell returns the path to a chrome-headless-shell binary, searching (in order):
 // an explicit path, the BILOBA_CHROME_HEADLESS_SHELL env var, $PATH, and the puppeteer / Biloba
 // download caches.  It returns "" if none is found.
-func locateHeadlessShell(explicit string) string {
-	for _, c := range []string{explicit, os.Getenv(headlessShellEnvVar)} {
-		if c != "" && isExecutableFile(c) {
-			return c
-		}
-	}
-	if p, err := exec.LookPath("chrome-headless-shell"); err == nil {
-		return p
-	}
-	bin := headlessShellBinaryName()
-	for _, cacheRoot := range headlessShellCacheRoots() {
-		// download caches lay binaries out as <root>/chrome-headless-shell/<version>/chrome-headless-shell-<platform>/<bin>
-		matches, _ := filepath.Glob(filepath.Join(cacheRoot, "chrome-headless-shell", "*", "chrome-headless-shell-*", bin))
-		if len(matches) > 0 {
-			sort.Strings(matches) // prefer the lexically-last (typically newest) version
-			return matches[len(matches)-1]
-		}
-	}
-	return ""
-}
+func locateHeadlessShell(explicit string) string { return engine.LocateChrome(explicit) }
 
-func headlessShellBinaryName() string {
-	if runtime.GOOS == "windows" {
-		return "chrome-headless-shell.exe"
-	}
-	return "chrome-headless-shell"
-}
+func headlessShellBinaryName() string { return engine.ChromeBinaryName() }
 
-func headlessShellCacheRoots() []string {
-	roots := []string{}
-	if home, err := os.UserHomeDir(); err == nil {
-		roots = append(roots, filepath.Join(home, ".cache", "puppeteer")) // @puppeteer/browsers default
-	}
-	if cache, err := os.UserCacheDir(); err == nil {
-		roots = append(roots, filepath.Join(cache, "puppeteer"), filepath.Join(cache, "biloba"))
-	}
-	return roots
-}
-
-func isExecutableFile(p string) bool {
-	info, err := os.Stat(p)
-	return err == nil && !info.IsDir()
-}
+func isExecutableFile(p string) bool { return engine.IsExecutableFile(p) }
 
 func headlessShellInstructions() string {
 	return fmt.Sprintf(`Biloba defaults to the lightweight chrome-headless-shell for speed, but could not find it.

--- a/javascript.go
+++ b/javascript.go
@@ -1,13 +1,13 @@
 package biloba
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"sync/atomic"
 
-	"github.com/chromedp/cdproto/runtime"
-	"github.com/chromedp/chromedp"
+	"github.com/onsi/biloba/engine"
 	"github.com/onsi/gomega/gcustom"
 )
 
@@ -58,17 +58,6 @@ func (b *Biloba) RunErr(script string, args ...any) (any, error) {
 func (b *Biloba) runErr(script string, awaitPromise bool, args ...any) (any, error) {
 	b.blockIfNecessaryToEnsureSuccessfulDownloads()
 	var encodedResult []byte
-	options := func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
-		p = p.WithUserGesture(true)
-		if awaitPromise {
-			p = p.WithAwaitPromise(true)
-		}
-		return p
-	}
-	// The backstop deadline (see cdp.go).  runErr is the single funnel for every JS evaluation -
-	// Run/RunAsync AND every DOM method, since runBilobaHandler goes through it - so this one bound
-	// covers the hot path the hang report landed on.  An awaited promise gets the longer bound
-	// because the page's own JS, not Chrome's responsiveness, sets how long it takes.
 	timeout := cdpTimeout
 	what := "evaluate JavaScript in the page"
 	if awaitPromise {
@@ -76,14 +65,16 @@ func (b *Biloba) runErr(script string, awaitPromise bool, args ...any) (any, err
 	}
 	ctx, cancel := b.cdpContext(timeout)
 	defer cancel()
-	// The _biloba-is-gone retry re-runs inside THIS context rather than opening a fresh deadline, and
-	// it retries once rather than recursing - so the reload path stays bounded (one reload command,
-	// then whatever is left of this deadline) instead of being able to loop forever.
-	err := b.runCDPIn(ctx, timeout, what, chromedp.EvaluateAsDevTools(script, &encodedResult, options))
+	evaluate := func(runCtx context.Context) error {
+		var err error
+		encodedResult, err = engine.EvaluateRawContext(runCtx, script, awaitPromise)
+		return err
+	}
+	err := b.runEngineIn(ctx, timeout, what, evaluate)
 	if err != nil {
 		if strings.Contains(err.Error(), "_biloba is not defined") {
 			b.reloadBiloba()
-			err = b.runCDPIn(ctx, timeout, what, chromedp.EvaluateAsDevTools(script, &encodedResult, options))
+			err = b.runEngineIn(ctx, timeout, what, evaluate)
 		}
 		if err != nil {
 			return nil, err
@@ -105,7 +96,6 @@ func (b *Biloba) runErr(script string, awaitPromise bool, args ...any) (any, err
 	if len(encodedResult) == 0 {
 		return nil, fmt.Errorf("the script returned undefined, so there is nothing to decode into the pointer you provided.\nIf this script runs purely for its side effects, omit the decode target (or pass nil).\nOtherwise make sure the script returns a JSON-serializable value (e.g. `return true`).")
 	}
-
 	err = json.Unmarshal(encodedResult, args[0])
 	return args[0], err
 }
@@ -309,18 +299,14 @@ func (j JSFunc) Invoke(args ...any) string {
 		return string(j) + "()"
 	}
 
-	encodedArgsBytes, err := json.Marshal(args)
+	// the encoding is shared with the biloba.js handler path (dom.go's runBilobaHandler), so a
+	// JSVar interpolates the same way no matter which path carries the argument
+	encodedArgs, err := engine.EncodeArgs(args...)
 	if err != nil {
 		panic(err)
 	}
-	encodedArgs := string(encodedArgsBytes)
-	for _, arg := range args {
-		if v, ok := arg.(JSVar); ok {
-			encodedArgs = v.interpolate(encodedArgs)
-		}
-	}
 
-	return string(j) + "(..." + string(encodedArgs) + ")"
+	return string(j) + "(..." + encodedArgs + ")"
 }
 
 /*
@@ -364,5 +350,10 @@ type JSVar struct {
 	identifier string
 }
 
-func (j JSVar) MarshalJSON() ([]byte, error)   { return []byte(j.identifier), nil }
-func (j JSVar) interpolate(json string) string { return strings.Replace(json, j.identifier, j.v, 1) }
+func (j JSVar) MarshalJSON() ([]byte, error) { return []byte(j.identifier), nil }
+
+// RawJSPlaceholder and RawJSExpression implement engine.RawJSArg: they are how the shared
+// argument encoder recognizes a JSVar and swaps its JSON placeholder back out for the raw
+// JavaScript expression the user asked for.
+func (j JSVar) RawJSPlaceholder() string { return j.identifier }
+func (j JSVar) RawJSExpression() string  { return j.v }

--- a/javascript_test.go
+++ b/javascript_test.go
@@ -318,5 +318,18 @@ var _ = Describe("Javascript", func() {
 			b.Run("var counter = 17")
 			Ω(adder.Invoke(1, 2, 3.7, 4, 5, b.JSVar("counter + 3"))).Should(b.EvaluateTo(35.7))
 		})
+
+		It("interpolates a JSVar the same way when the argument rides a biloba.js DOM handler instead of Invoke", func() {
+			// the DOM methods generate their handler call from Go arguments too, so they share
+			// Invoke's encoder - otherwise a JSVar handed to a DOM method would silently arrive as
+			// the string literal of its placeholder
+			b.Navigate(fixtureServer + "/dom.html")
+			Eventually("#text-input").Should(b.Exist())
+			b.Run(`var suffix = " and beyond"`)
+
+			b.SetValue("#text-input", b.JSVar(`"to infinity" + suffix`))
+
+			Ω(b.GetValue("#text-input")).Should(Equal("to infinity and beyond"))
+		})
 	})
 })

--- a/navigation.go
+++ b/navigation.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"strings"
 	"time"
 
-	"github.com/chromedp/cdproto/network"
-	"github.com/chromedp/chromedp"
+	"github.com/onsi/biloba/engine"
 	"github.com/onsi/gomega/gcustom"
 )
 
@@ -60,32 +58,28 @@ func (b *Biloba) NavigateWithStatus(url string, status int) *Biloba {
 func (b *Biloba) navigateWithStatus(url string, status int) *Biloba {
 	b.gt.Helper()
 
-	// Chrome 149+ fires Network.loadingFailed (ERR_HTTP_RESPONSE_CODE_FAILURE) for 4xx/5xx
-	// responses, causing chromedp.Navigate to return an error instead of a success.
-	// We capture the actual HTTP status via a network listener and check it ourselves.
-	lctx, lcancel := context.WithCancel(b.Context)
-	defer lcancel()
-	var capturedStatus int64
-	chromedp.ListenTarget(lctx, func(ev any) {
-		if e, ok := ev.(*network.EventResponseReceived); ok {
-			if e.Type == network.ResourceTypeDocument {
-				capturedStatus = e.Response.Status
-			}
-		}
-	})
-
 	timeout := b.waitingTimeout(navigationTimeout)
 	nctx, ncancel := b.waitingContext(navigationTimeout)
 	defer ncancel()
-	err := b.runCDPIn(nctx, timeout, "navigate to "+url, chromedp.Navigate(url))
-	isHTTPError := err != nil && strings.Contains(err.Error(), "ERR_HTTP_RESPONSE_CODE_FAILURE")
+	var result engine.NavigationResult
+	err := b.runEngineIn(nctx, timeout, "navigate to "+url, func(ctx context.Context) error {
+		var err error
+		result, err = engine.NavigateContext(ctx, url)
+		return err
+	})
 
 	if errors.Is(err, context.DeadlineExceeded) {
 		b.gt.Fatalf("Timed out after %s navigating to %s: the navigation never completed (Chrome may have wedged)", timeout, url)
 		return b
 	}
 
-	if err != nil && !isHTTPError {
+	// Chrome 149+ fires Network.loadingFailed (ERR_HTTP_RESPONSE_CODE_FAILURE) for 4xx/5xx
+	// responses, so chromedp.Navigate returns an error where a non-200 status is exactly what the
+	// spec asked for.  That error is not, on its own, a navigation failure - the status we observed
+	// is what decides (see below).  Any other error is a genuine failure and stops us here.  The two
+	// are independent: an HTTP loading failure whose document status we never observed still has to
+	// surface, rather than being mistaken for a destination that simply has no HTTP response.
+	if err != nil && !result.HTTPFailure {
 		b.gt.Fatalf("failed to navigate to %s: %s", url, err.Error())
 		return b
 	}
@@ -96,9 +90,9 @@ func (b *Biloba) navigateWithStatus(url string, status int) *Biloba {
 	// bottom.  No-op in the default chrome-headless-shell lane.
 	b.reassertViewportForCompositor()
 
-	if capturedStatus != 0 {
-		if int(capturedStatus) != status {
-			b.gt.Fatalf("failed to navigate to %s: expected status code %d, got %d", url, status, capturedStatus)
+	if result.Status != 0 {
+		if result.Status != status {
+			b.gt.Fatalf("failed to navigate to %s: expected status code %d, got %d", url, status, result.Status)
 		}
 		return b
 	}
@@ -147,11 +141,12 @@ func (b *Biloba) location() (string, error) {
 		}
 	}
 	var location string
-	err := b.runCDP("read the tab's location", chromedp.Location(&location))
-	if err != nil {
-		return "", err
-	}
-	return location, nil
+	err := b.runEngine("read the tab's location", func(ctx context.Context) error {
+		var err error
+		location, err = engine.LocationContext(ctx)
+		return err
+	})
+	return location, err
 }
 
 /*
@@ -220,11 +215,12 @@ func (b *Biloba) title() (string, error) {
 		}
 	}
 	var title string
-	err := b.runCDP("read the tab's title", chromedp.Title(&title))
-	if err != nil {
-		return "", err
-	}
-	return title, nil
+	err := b.runEngine("read the tab's title", func(ctx context.Context) error {
+		var err error
+		title, err = engine.TitleContext(ctx)
+		return err
+	})
+	return title, err
 }
 
 /*

--- a/runner_unwind_test.go
+++ b/runner_unwind_test.go
@@ -1,0 +1,45 @@
+package biloba_test
+
+import (
+	"fmt"
+
+	"github.com/onsi/biloba"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type fatalSentinel struct {
+	message string
+}
+
+type unwindingT struct {
+	biloba.GinkgoTInterface
+}
+
+func (t *unwindingT) Fatal(args ...any) {
+	panic(fatalSentinel{message: fmt.Sprint(args...)})
+}
+
+func (t *unwindingT) Fatalf(format string, args ...any) {
+	panic(fatalSentinel{message: fmt.Sprintf(format, args...)})
+}
+
+var _ = Describe("runner failure unwinding", func() {
+	It("stops the public Go call at a runner-neutral engine failure", func() {
+		runner := &unwindingT{GinkgoTInterface: GinkgoT()}
+		tab := biloba.ConnectToChrome(runner, biloba.BilobaConfigWithChromeConnection(b.ChromeConnection))
+		continued := false
+		var recovered any
+
+		func() {
+			defer func() { recovered = recover() }()
+			tab.Run(`throw new Error("unwind-marker")`)
+			continued = true
+		}()
+
+		Expect(continued).To(BeFalse())
+		sentinel, ok := recovered.(fatalSentinel)
+		Expect(ok).To(BeTrue())
+		Expect(sentinel.message).To(ContainSubstring("unwind-marker"))
+	})
+})


### PR DESCRIPTION
**Stack 2 of 17** · base [#17](https://github.com/onsi/biloba/pull/17) · next: [#19](https://github.com/onsi/biloba/pull/19)

**Read this one closely.** It's the only PR in the stack that changes shipped code, so it's the only one that can break an existing Biloba user. It's deliberately small, +167 / −132 across 10 files, so you can read it line by line.

Navigation, cookies, JavaScript evaluation, and the `biloba.js` handler bridge now call `engine` instead of calling chromedp directly. The Go API and the daemon share one implementation instead of two that drift apart. The public API, its polling, its matchers, and its failure messages are unchanged.

## Three guarantees the move dropped, and this PR restores

The suite caught each of these when run against `master`. Reading the diff didn't. They're folded into this PR rather than left as follow-ups, so there's no broken state to review, but they're the substance of it.

### The download throttle

The DOM handlers no longer go through `RunErr`, so they stopped inheriting its throttle against Chrome's limit of 10 downloads per second. Clicking is the usual way to trigger a download, so an 11th download was being dropped without any error.

| Tree | `--focus="Downloading Files"` |
|---|---|
| `master` | 9/9 pass, 5.0s |
| Before the fix | 5 passed, 4 timed out, 121s |
| With one line restored | 9/9 pass, 5.0s |

`downloads_test.go` now names the mechanism. If this regresses again, the failure says the DOM interaction didn't wait out the limit, instead of showing a count mismatch that looks like a Chrome quirk.

### Reinstall and retry when the page replaces its JavaScript world

An async `frameNavigated` event clears `bilobaIsInstalled`, so there's a window where the flag is stale and evaluation fails with `_biloba is not defined`. `RunErr` retried through that window. The handler path had stopped doing so.

Verified against `master` with a probe spec that deletes `window._biloba` and then does a DOM read: `master` recovers, the unfixed branch doesn't.

### Cookie commands still go through `chromedp.Run`

`Run` initializes the browser on first use, and it turns a non-chromedp context into an `ErrInvalidContext` error. Reaching for `FromContext(...).Browser` directly turned that error into a panic.

## Also here

Chrome resolution moves to `engine.LocateChrome`, so `headless_shell.go`, the engine's suite, and the daemon all search the same way. The search behavior is unchanged. It's the same code in a new place.

## Verification

`ginkgo -r -p --randomize-all` at this commit: Biloba 1037/1037, Engine 23/23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)