### PR TITLE
3/17 protocol + bilobad: a framed JSON wire and the daemon that speaks it

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+typescript/src/generated/** whitespace=-blank-at-eol,-blank-at-eof

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,10 +49,11 @@ jobs:
     # sandbox intact (rather than weakening Biloba's defaults with --no-sandbox).
     # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
     - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-    # The recursive run includes ./engine. That suite resolves Chrome through engine.LocateChrome
-    # and needs chrome-headless-shell even though the root Biloba suite uses full google-chrome in
-    # this lane. Install it explicitly so the engine suite does not depend on the default lane's
-    # AutoInstallHeadlessShell side effect or on job ordering.
+    # This lane runs `-r`, which includes ./engine and ./cmd/bilobad. Those resolve Chrome through
+    # engine.LocateChrome and want chrome-headless-shell - and unlike the default lane they cannot
+    # rely on the suite's AutoInstallHeadlessShell side effect, because HighFidelityHeadless replaces
+    # that option. Without this step there is no headless-shell anywhere on the runner and the daemon
+    # specs fail for a reason that has nothing to do with high fidelity.
     - run: npx -y @puppeteer/browsers install chrome-headless-shell@stable --path "$HOME/.cache/puppeteer"
     # Runs in parallel like the default lane. Concurrent remote-allocator attaches are handled by
     # ConnectToChrome's retry/backoff; the one-time full google-chrome launch gets a roomier

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 TODO
 .DS_Store
 browser
+/.bin/
 # Process artifacts from the agent-improvement work (kept locally, not tracked)
 report.md
 CHANGELOG-TMP.md

--- a/cmd/bilobad/engine_adapter.go
+++ b/cmd/bilobad/engine_adapter.go
@@ -1,0 +1,388 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/onsi/biloba/engine"
+	"github.com/onsi/biloba/protocol"
+)
+
+type engineBackend struct{ browser *engine.Browser }
+
+func (b *engineBackend) OpenSession(ctx context.Context) (protocol.Session, error) {
+	session, err := b.browser.OpenSession(ctx)
+	if err != nil {
+		return nil, engineRPCError(err)
+	}
+	return &engineSession{session: session}, nil
+}
+
+func (b *engineBackend) Close() error { return b.browser.Close() }
+
+type engineSession struct{ session *engine.Session }
+
+func (s *engineSession) Prepare(ctx context.Context) error { return s.session.Prepare(ctx) }
+func (s *engineSession) Close() error                      { return s.session.Close() }
+
+func (s *engineSession) Execute(ctx context.Context, operation protocol.Operation) (protocol.Result, error) {
+	started := time.Now()
+	switch operation.Kind {
+	case protocol.OperationNavigate:
+		return oneAttempt(started, s.session.Navigate(ctx, operation.URL))
+	case protocol.OperationSetCookies:
+		cookies := make([]engine.Cookie, len(operation.Cookies))
+		for i, cookie := range operation.Cookies {
+			cookies[i] = engine.Cookie{Name: cookie.Name, Value: cookie.Value, Domain: cookie.Domain, Path: cookie.Path, Secure: cookie.Secure, HTTPOnly: cookie.HTTPOnly, SameSite: cookie.SameSite}
+			if cookie.ExpiresUnix != 0 {
+				cookies[i].Expires = time.UnixMilli(int64(cookie.ExpiresUnix * 1000))
+			}
+		}
+		return oneAttempt(started, s.session.SetCookies(ctx, cookies))
+	case protocol.OperationClick:
+		selector, err := selectorFromProtocol(operation.Locator)
+		if err != nil {
+			return protocol.Result{}, err
+		}
+		return s.poll(ctx, operation, func(ctx context.Context) (engine.Observation, bool, error) {
+			err := s.session.Click(ctx, selector)
+			return engine.Observation{}, err == nil, err
+		})
+	case protocol.OperationSetValue:
+		selector, err := selectorFromProtocol(operation.Locator)
+		if err != nil {
+			return protocol.Result{}, err
+		}
+		var value any
+		if err := json.Unmarshal([]byte(operation.ValueJSON), &value); err != nil {
+			return protocol.Result{}, protocol.NewError(protocol.CodeInvalidArgument, fmt.Sprintf("value_json: %v", err))
+		}
+		return s.poll(ctx, operation, func(ctx context.Context) (engine.Observation, bool, error) {
+			err := s.session.SetValue(ctx, selector, value)
+			return engine.Observation{}, err == nil, err
+		})
+	case protocol.OperationEvaluate:
+		script, err := evaluationScript(operation.Expression, operation.ArgumentsJSON, operation.Invoke)
+		if err != nil {
+			return protocol.Result{}, err
+		}
+		value, err := s.session.Evaluate(ctx, script)
+		if err != nil {
+			return protocol.Result{}, engineRPCError(err)
+		}
+		return observedResult(started, value), nil
+	case protocol.OperationAssert:
+		assertion, err := s.assertion(operation.Assertion)
+		if err != nil {
+			return protocol.Result{}, err
+		}
+		return s.poll(ctx, operation, assertion)
+	default:
+		return protocol.Result{}, protocol.NewError(protocol.CodeInvalidArgument, "unsupported operation")
+	}
+}
+
+// evaluationScript turns an evaluate request into one snippet.  `invoke` is what says whether
+// `expression` is a value to evaluate or a function to call: without it the meaning of the
+// expression hangs off how many arguments happen to accompany it, so `(a) => a + 1` with no
+// arguments evaluates to the function source rather than calling it.  A nil `invoke` is the
+// pre-`invoke` client, which is entitled to that inference.
+func evaluationScript(expression, argumentsJSON string, invoke *bool) (string, error) {
+	arguments, err := evaluationArguments(argumentsJSON)
+	if err != nil {
+		return "", err
+	}
+	if invoke != nil && !*invoke {
+		if len(arguments) > 0 {
+			return "", protocol.NewError(protocol.CodeInvalidArgument, "arguments_json requires invoke: true")
+		}
+		return expression, nil
+	}
+	if invoke == nil && len(arguments) == 0 {
+		return expression, nil
+	}
+	encoded, err := json.Marshal(arguments)
+	if err != nil {
+		return "", protocol.NewError(protocol.CodeInvalidArgument, fmt.Sprintf("arguments_json: %v", err))
+	}
+	return fmt.Sprintf("(%s)(...%s)", expression, encoded), nil
+}
+
+func evaluationArguments(argumentsJSON string) ([]any, error) {
+	if strings.TrimSpace(argumentsJSON) == "" {
+		return nil, nil
+	}
+	var arguments []any
+	if err := json.Unmarshal([]byte(argumentsJSON), &arguments); err != nil {
+		return nil, protocol.NewError(protocol.CodeInvalidArgument, fmt.Sprintf("arguments_json must be a JSON array: %v", err))
+	}
+	return arguments, nil
+}
+
+func (s *engineSession) poll(ctx context.Context, operation protocol.Operation, assertion engine.Assertion) (protocol.Result, error) {
+	policy := engine.PollPolicy{Timeout: operation.Poll.Timeout, Interval: operation.Poll.Interval}
+	if policy.Timeout <= 0 {
+		policy.Timeout = time.Second
+	}
+	result, pollErr := engine.Poll(ctx, policy, assertion)
+	converted := pollResult(result, pollErr == nil)
+	if pollErr == nil {
+		return converted, nil
+	}
+	// A poll that stopped because retrying was pointless is a failure of a different kind from a
+	// poll that ran out of time, and has to reach the client as one - reporting "the browser is
+	// gone" as matched:false would render as an assertion timeout and send the reader to the page.
+	if engine.IsFatal(pollErr) {
+		return protocol.Result{}, engineRPCError(pollErr)
+	}
+	if errors.Is(pollErr, context.Canceled) && errors.Is(ctx.Err(), context.Canceled) {
+		return protocol.Result{}, protocol.NewError(protocol.CodeCancelled, ctx.Err().Error())
+	}
+	if errors.Is(pollErr, context.DeadlineExceeded) && ctx.Err() != nil {
+		return protocol.Result{}, protocol.NewError(protocol.CodeTimeout, ctx.Err().Error())
+	}
+	diagnosticCtx, cancel := context.WithTimeout(context.Background(), diagnosticsBudget(ctx, time.Now()))
+	defer cancel()
+	diagnostics, diagnosticErr := s.session.CaptureDiagnostics(diagnosticCtx, "biloba-failure")
+	converted.Diagnostics = protocol.Diagnostics{
+		Locator: locatorDescription(operation), Expected: expectedDescription(operation),
+		DOMOutline: diagnostics.DOMOutline, ScreenshotPath: diagnostics.ScreenshotPath, DaemonDetail: pollErr.Error(),
+	}
+	if diagnosticErr != nil {
+		converted.Diagnostics.DaemonDetail += "; capture diagnostics: " + diagnosticErr.Error()
+	}
+	return converted, nil
+}
+
+// The client arms its own timer at the very deadline it puts on the request, so capturing
+// diagnostics has to fit inside what is left of that deadline: a screenshot that lands late is a
+// response nobody is waiting for any more, and the failure the daemon exists to describe arrives
+// as a bare "request timed out" with no trajectory, outline, or screenshot at all.  Budget from
+// the time actually remaining, reserving enough of it to encode, frame, and write the answer.
+const (
+	diagnosticsCap     = 2 * time.Second
+	diagnosticsReserve = 300 * time.Millisecond
+	diagnosticsFloor   = 100 * time.Millisecond
+)
+
+func diagnosticsBudget(ctx context.Context, now time.Time) time.Duration {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return diagnosticsCap // nothing to race: an open-ended request gets the fixed budget
+	}
+	switch budget := deadline.Sub(now) - diagnosticsReserve; {
+	case budget > diagnosticsCap:
+		return diagnosticsCap
+	case budget < diagnosticsFloor:
+		// Already out of room.  Try anyway, briefly: a capture that fails fast still leaves the
+		// trajectory on the response, and a long shot at an outline beats a certain miss.
+		return diagnosticsFloor
+	default:
+		return budget
+	}
+}
+
+func (s *engineSession) assertion(assertion protocol.Assertion) (engine.Assertion, error) {
+	var selector engine.Selector
+	var err error
+	if assertion.Kind != protocol.AssertionURL && assertion.Kind != protocol.AssertionEvaluate {
+		selector, err = selectorFromProtocol(assertion.Locator)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return func(ctx context.Context) (engine.Observation, bool, error) {
+		var observation engine.Observation
+		var readErr error
+		switch assertion.Kind {
+		case protocol.AssertionVisible:
+			observation, readErr = s.session.Visible(ctx, selector)
+			visible, _ := observation.Value.(bool)
+			return observation, visible, readErr
+		case protocol.AssertionText:
+			observation, readErr = s.session.Text(ctx, selector)
+		case protocol.AssertionCount:
+			observation, readErr = s.session.Count(ctx, selector)
+			return observation, numericEqual(observation.Value, assertion.ExpectedCount), readErr
+		case protocol.AssertionAttribute:
+			observation, readErr = s.session.Attribute(ctx, selector, assertion.Attribute)
+		case protocol.AssertionValue:
+			observation, readErr = s.session.Value(ctx, selector)
+			matched, compareErr := jsonEqual(observation.Value, assertion.ExpectedJSON)
+			if compareErr != nil {
+				return observation, false, compareErr
+			}
+			return observation, matched, readErr
+		case protocol.AssertionURL:
+			observation, readErr = s.session.URL(ctx)
+		case protocol.AssertionEvaluate:
+			var value any
+			value, readErr = s.session.Evaluate(ctx, assertion.Expression)
+			observation = engine.Observation{Value: value}
+			matched, compareErr := jsonEqual(value, assertion.ExpectedJSON)
+			if compareErr != nil {
+				return observation, false, compareErr
+			}
+			return observation, matched, readErr
+		default:
+			// Unreachable from the wire (assertionFromWire rejects unknown kinds first), but if it
+			// ever were reached, retrying would turn a rejected request into an assertion timeout.
+			return observation, false, engine.Fatal(protocol.NewError(protocol.CodeInvalidArgument, "unsupported assertion"))
+		}
+		return observation, stringMatches(observation.Value, assertion.ExpectedString, assertion.Match), readErr
+	}, nil
+}
+
+func selectorFromProtocol(locator protocol.Locator) (engine.Selector, error) {
+	mode := engine.Exact
+	if locator.Match == protocol.MatchContains {
+		mode = engine.Contains
+	}
+	var selector engine.Selector
+	switch locator.Kind {
+	case protocol.LocatorCSS:
+		selector = engine.CSS(locator.Value)
+	case protocol.LocatorTestID:
+		selector = engine.TestID(locator.Value)
+	case protocol.LocatorText:
+		selector = engine.Text(locator.Value, mode)
+	case protocol.LocatorRole:
+		selector = engine.Role(locator.Role, locator.Name, mode)
+	default:
+		return engine.Selector{}, protocol.NewError(protocol.CodeInvalidArgument, "unsupported locator")
+	}
+	if locator.First {
+		selector = selector.First()
+	}
+	return selector, nil
+}
+
+func oneAttempt(started time.Time, err error) (protocol.Result, error) {
+	if err != nil {
+		return protocol.Result{}, engineRPCError(err)
+	}
+	return protocol.Result{Matched: true, Attempts: 1, StartedAt: started, Elapsed: time.Since(started)}, nil
+}
+
+func observedResult(started time.Time, value any) protocol.Result {
+	return protocol.Result{Matched: true, ObservedJSON: marshalJSON(value), Attempts: 1, StartedAt: started, Elapsed: time.Since(started)}
+}
+
+func pollResult(result engine.PollResult, matched bool) protocol.Result {
+	trajectory := make([]protocol.Observation, len(result.Attempts))
+	for i, attempt := range result.Attempts {
+		trajectory[i] = protocol.Observation{Attempt: uint32(attempt.Number), Elapsed: attempt.StartedAt.Sub(result.StartedAt), ObservedJSON: marshalJSON(attempt.Observation.Value), RetryReason: attempt.Error}
+	}
+	return protocol.Result{Matched: matched, ObservedJSON: marshalJSON(result.Final.Value), Attempts: uint32(result.AttemptCount), Trajectory: trajectory, StartedAt: result.StartedAt, Elapsed: result.Duration}
+}
+
+func stringMatches(value any, expected string, mode protocol.MatchMode) bool {
+	observed, ok := value.(string)
+	if !ok {
+		return false
+	}
+	if mode == protocol.MatchContains {
+		return strings.Contains(observed, expected)
+	}
+	return observed == expected
+}
+
+func numericEqual(value any, expected int64) bool {
+	switch value := value.(type) {
+	case int:
+		return int64(value) == expected
+	case int64:
+		return value == expected
+	case float64:
+		return value == float64(expected)
+	default:
+		return false
+	}
+}
+
+// jsonEqual compares an observation against the caller's expected value.  A malformed expectation
+// is fatal rather than simply unequal: no amount of polling turns invalid JSON into a value, and
+// reporting it as a mismatch would spend the whole budget and then blame the page - quoting what
+// was observed while saying nothing about the expectation that never parsed.  This is the same
+// judgement capture.go makes with gomega.StopTrying for a decode into the wrong pointer type.
+func jsonEqual(observed any, expectedJSON string) (bool, error) {
+	var expected any
+	if err := json.Unmarshal([]byte(expectedJSON), &expected); err != nil {
+		return false, engine.Fatal(protocol.NewError(protocol.CodeInvalidArgument,
+			fmt.Sprintf("expectedJson is not valid JSON: %v", err)))
+	}
+	return reflect.DeepEqual(observed, expected), nil
+}
+
+func marshalJSON(value any) string {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("%q", fmt.Sprint(value))
+	}
+	return string(encoded)
+}
+
+func locatorDescription(operation protocol.Operation) string {
+	locator := operation.Locator
+	if operation.Kind == protocol.OperationAssert {
+		locator = operation.Assertion.Locator
+	}
+	selector, err := selectorFromProtocol(locator)
+	if err != nil {
+		return ""
+	}
+	return selector.Description()
+}
+
+func expectedDescription(operation protocol.Operation) string {
+	if operation.Kind != protocol.OperationAssert {
+		return "operation to succeed"
+	}
+	assertion := operation.Assertion
+	switch assertion.Kind {
+	case protocol.AssertionVisible:
+		return "visible"
+	case protocol.AssertionCount:
+		return fmt.Sprint(assertion.ExpectedCount)
+	case protocol.AssertionValue, protocol.AssertionEvaluate:
+		return assertion.ExpectedJSON
+	default:
+		return assertion.ExpectedString
+	}
+}
+
+func engineRPCError(err error) error {
+	// A ProtocolError that travelled out through the engine (an engine.Fatal wrapping one, say)
+	// already knows its own code - do not flatten it to DRIVER_ERROR on the way past.
+	var protocolErr *protocol.ProtocolError
+	if errors.As(err, &protocolErr) {
+		return protocolErr
+	}
+	var engineErr *engine.Error
+	if !errors.As(err, &engineErr) {
+		return protocol.NewError(protocol.CodeDriver, err.Error())
+	}
+	switch engineErr.Code {
+	case engine.CodeInvalidSelector:
+		return protocol.NewError(protocol.CodeInvalidArgument, engineErr.Error())
+	case engine.CodeSessionClosed, engine.CodeNotFound:
+		return protocol.NewError(protocol.CodeTargetNotFound, engineErr.Error())
+	case engine.CodeBrowserGone:
+		return protocol.NewError(protocol.CodeBrowserGone, engineErr.Error())
+	case engine.CodeInvalidScript:
+		return protocol.NewError(protocol.CodeJavaScript, engineErr.Error())
+	case engine.CodePageCrashed:
+		return protocol.NewError(protocol.CodePageCrashed, engineErr.Error())
+	case engine.CodeCanceled:
+		return protocol.NewError(protocol.CodeCancelled, engineErr.Error())
+	case engine.CodeDeadline, engine.CodeTimeout:
+		return protocol.NewError(protocol.CodeTimeout, engineErr.Error())
+	default:
+		return protocol.NewError(protocol.CodeDriver, engineErr.Error())
+	}
+}

--- a/cmd/bilobad/main.go
+++ b/cmd/bilobad/main.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/onsi/biloba/engine"
+	"github.com/onsi/biloba/protocol"
+)
+
+type config struct {
+	chromePath  string
+	chromeWSURL string
+	artifactDir string
+}
+
+type browserReady struct {
+	WSURL  string `json:"wsURL"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+	PID    int    `json:"pid"`
+}
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	args := os.Args[1:]
+	var err error
+	if len(args) > 0 && args[0] == "serve-browser" {
+		err = runBrowserHost(ctx, args[1:], os.Stdout, os.Stdin)
+	} else {
+		err = run(ctx, args, os.Stdout, os.Stdin)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string, stdout io.Writer, stdin io.Reader) error {
+	config, err := parseConfig(args)
+	if err != nil {
+		return err
+	}
+	chromePath, err := resolveChrome(config)
+	if err != nil {
+		return err
+	}
+	browser, err := engine.StartBrowser(ctx, engine.BrowserConfig{ExecutablePath: chromePath, WebSocketURL: config.chromeWSURL, ArtifactDir: config.artifactDir})
+	if err != nil {
+		return err
+	}
+	server := protocol.NewServer(&engineBackend{browser: browser})
+	defer server.Close()
+
+	serveErrors := make(chan error, 1)
+	go func() { serveErrors <- protocol.ServeStdio(ctx, server, stdin, stdout) }()
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-serveErrors:
+		return err
+	}
+}
+
+func parseConfig(args []string) (config, error) {
+	flags := flag.NewFlagSet("bilobad", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	var result config
+	flags.StringVar(&result.chromePath, "chrome-path", "", "Chrome or chrome-headless-shell executable (default: the same search Biloba's Go suite uses)")
+	flags.StringVar(&result.chromeWSURL, "chrome-ws-url", "", "browser-level Chrome DevTools websocket URL")
+	flags.StringVar(&result.artifactDir, "artifact-dir", "", "failure artifact directory")
+	if err := flags.Parse(args); err != nil {
+		return config{}, err
+	}
+	return result, nil
+}
+
+// resolveChrome finds the browser this daemon should drive.  A worker daemon pointed at a shared
+// Chrome does not need one at all; otherwise it runs the same runner-neutral search the Go suite
+// does, so `bilobad` works with no flags wherever `ginkgo` does - and fails with the reason rather
+// than with a bare exec error when it does not.
+func resolveChrome(config config) (string, error) {
+	if config.chromeWSURL != "" {
+		return "", nil
+	}
+	if path := engine.LocateChrome(config.chromePath); path != "" {
+		return path, nil
+	}
+	if config.chromePath != "" {
+		return "", fmt.Errorf("bilobad could not use the Chrome executable at %q", config.chromePath)
+	}
+	return "", fmt.Errorf("bilobad could not find chrome-headless-shell.\nInstall it with `npx @puppeteer/browsers install chrome-headless-shell@stable`, add it to your PATH, set %s=/path/to/chrome-headless-shell, or pass --chrome-path.", engine.ChromeEnvVar)
+}
+
+func runBrowserHost(ctx context.Context, args []string, stdout io.Writer, stdin io.Reader) error {
+	config, err := parseConfig(args)
+	if err != nil {
+		return err
+	}
+	chromePath, err := resolveChrome(config)
+	if err != nil {
+		return err
+	}
+	browser, err := engine.StartBrowser(ctx, engine.BrowserConfig{ExecutablePath: chromePath})
+	if err != nil {
+		return err
+	}
+	defer browser.Close()
+	ready, err := json.Marshal(browserReady{WSURL: browser.WebSocketURL(), Width: 1920, Height: 1080, PID: os.Getpid()})
+	if err != nil {
+		return fmt.Errorf("marshal browser ready message: %w", err)
+	}
+	if _, err := fmt.Fprintln(stdout, string(ready)); err != nil {
+		return fmt.Errorf("write browser ready message: %w", err)
+	}
+	parentClosed := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, stdin)
+		close(parentClosed)
+	}()
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-parentClosed:
+		return nil
+	}
+}

--- a/cmd/bilobad/main_test.go
+++ b/cmd/bilobad/main_test.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/onsi/biloba/engine"
+
+	"github.com/onsi/biloba/protocol"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBilobad(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Bilobad Suite")
+}
+
+var _ = Describe("bilobad", func() {
+	It("parses daemon flags", func() {
+		parsed, err := parseConfig([]string{
+			"-chrome-path", "/opt/chrome",
+			"-chrome-ws-url", "ws://127.0.0.1:9222/devtools/browser/test",
+			"-artifact-dir", "/tmp/artifacts",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parsed).To(Equal(config{
+			chromePath: "/opt/chrome", chromeWSURL: "ws://127.0.0.1:9222/devtools/browser/test", artifactDir: "/tmp/artifacts",
+		}))
+	})
+
+	Describe("evaluation arguments", func() {
+		It("preserves an expression for an empty argument array", func() {
+			plain, err := evaluationScript("document.title", `[]`, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(plain).To(Equal("document.title"))
+		})
+
+		It("applies a JSON argument array", func() {
+			script, err := evaluationScript("(left, right) => left + right", `[2,3]`, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(script).To(Equal(`((left, right) => left + right)(...[2,3])`))
+		})
+
+		It("rejects a non-array argument value", func() {
+			_, err := evaluationScript("value => value", `{}`, nil)
+			Expect(err).To(HaveOccurred())
+		})
+
+		// Without an explicit signal the same expression means two different things depending on a
+		// separate field: a function sent with no arguments evaluates to its own source instead of
+		// being called.  `invoke` is what settles it.
+		It("calls a function expression with an empty argument array when invoke is set", func() {
+			script, err := evaluationScript("(a) => a + 1", `[]`, boolPointer(true))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(script).To(Equal(`((a) => a + 1)(...[])`))
+		})
+
+		It("evaluates an expression verbatim when invoke is explicitly false", func() {
+			script, err := evaluationScript("document.title", `[]`, boolPointer(false))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(script).To(Equal("document.title"))
+		})
+
+		It("refuses arguments the client also said not to invoke with", func() {
+			_, err := evaluationScript("(a) => a + 1", `[1]`, boolPointer(false))
+			Expect(err).To(MatchError(ContainSubstring("invoke")))
+		})
+	})
+
+	// The client arms its timer at the same deadline it puts on the request, so a fixed diagnostics
+	// budget can outlive it - and a late response is dropped, taking the outline, the screenshot,
+	// and the trajectory with it.
+	Describe("the diagnostics budget", func() {
+		It("fits inside what is left of the request deadline", func() {
+			now := time.Now()
+			ctx, cancel := context.WithDeadline(context.Background(), now.Add(900*time.Millisecond))
+			defer cancel()
+
+			budget := diagnosticsBudget(ctx, now)
+			Expect(budget).To(BeNumerically("<", 900*time.Millisecond))
+			Expect(budget).To(BeNumerically(">", 500*time.Millisecond))
+		})
+
+		It("caps a generous deadline", func() {
+			now := time.Now()
+			ctx, cancel := context.WithDeadline(context.Background(), now.Add(time.Minute))
+			defer cancel()
+
+			Expect(diagnosticsBudget(ctx, now)).To(Equal(diagnosticsCap))
+		})
+
+		It("still makes a best effort when the deadline is all but gone", func() {
+			now := time.Now()
+			ctx, cancel := context.WithDeadline(context.Background(), now.Add(time.Millisecond))
+			defer cancel()
+
+			Expect(diagnosticsBudget(ctx, now)).To(Equal(diagnosticsFloor))
+		})
+
+		It("falls back to the fixed budget for a request with no deadline", func() {
+			Expect(diagnosticsBudget(context.Background(), time.Now())).To(Equal(diagnosticsCap))
+		})
+	})
+
+	Describe("comparing a value assertion against its expected JSON", func() {
+		It("matches an equal value and rejects a different one", func() {
+			Expect(jsonEqual("selected", `"selected"`)).To(BeTrue())
+			Expect(jsonEqual("selected", `"other"`)).To(BeFalse())
+		})
+
+		It("treats an unparseable expectation as fatal rather than as a mismatch", func() {
+			// A mismatch is retried to the deadline and reported as an assertion timeout quoting the
+			// observed value - which says nothing about the expectation being the broken part.
+			matched, err := jsonEqual("selected", `{not json`)
+
+			Expect(matched).To(BeFalse())
+			Expect(engine.IsFatal(err)).To(BeTrue(), "polling cannot turn invalid JSON into a value")
+			var protocolErr *protocol.ProtocolError
+			Expect(errors.As(err, &protocolErr)).To(BeTrue())
+			Expect(protocolErr.Code).To(Equal(protocol.CodeInvalidArgument))
+			Expect(protocolErr.Message).To(ContainSubstring("expectedJson is not valid JSON"))
+		})
+
+		It("keeps the fatal failure's own code on the way out to the client", func() {
+			_, err := jsonEqual("selected", `{not json`)
+
+			converted := engineRPCError(err)
+			var protocolErr *protocol.ProtocolError
+			Expect(errors.As(converted, &protocolErr)).To(BeTrue())
+			Expect(protocolErr.Code).To(Equal(protocol.CodeInvalidArgument), "flattening this to DRIVER_ERROR would lose why it failed")
+		})
+	})
+
+	// SpecTimeout, and every pipe operation raced against the daemon exiting.  run() brings Chrome up
+	// before ServeStdio reads a byte of stdin, and these are io.Pipes: if the daemon never starts -
+	// no chrome-headless-shell on the box, say - nothing ever reads, and an unguarded write to
+	// stdinWriter blocks forever.  That burns the whole suite budget and reports as a timeout on this
+	// spec, which says nothing about the cause.  Racing `done` surfaces the daemon's own error
+	// instead, in milliseconds.
+	It("serves a framed handshake and shuts down when its parent closes stdin", func(ctx SpecContext) {
+		stdinReader, stdinWriter := io.Pipe()
+		stdoutReader, stdoutWriter := io.Pipe()
+		done := make(chan error, 1)
+		go func() {
+			defer GinkgoRecover()
+			// no --chrome-path: the daemon resolves Chrome itself, which is the path a
+			// TypeScript worker actually takes.
+			done <- run(context.Background(), nil, stdoutWriter, stdinReader)
+		}()
+		// A daemon that died during startup makes every pipe operation below block forever.  Report
+		// what it said rather than waiting on a reader that is never coming.
+		daemonAlive := func(operation string, run func() error) {
+			GinkgoHelper()
+			finished := make(chan error, 1)
+			go func() { finished <- run() }()
+			select {
+			case err := <-finished:
+				Expect(err).NotTo(HaveOccurred())
+			case err := <-done:
+				Expect(err).NotTo(HaveOccurred(), "the daemon exited during %s instead of serving it", operation)
+				Fail(fmt.Sprintf("the daemon returned before it could serve %s", operation))
+			case <-ctx.Done():
+				Fail(fmt.Sprintf("timed out waiting for the daemon to serve %s", operation))
+			}
+		}
+		params, err := json.Marshal(protocol.HandshakeRequest{ProtocolVersion: protocol.Version})
+		Expect(err).NotTo(HaveOccurred())
+		daemonAlive("the handshake request", func() error {
+			return protocol.NewFramedWriter(stdinWriter).Write(protocol.Request{ID: 1, Method: "handshake", Params: params})
+		})
+		var response protocol.Response
+		daemonAlive("the handshake response", func() error {
+			return protocol.NewFramedReader(stdoutReader).Read(&response)
+		})
+		Expect(response.ID).To(Equal(uint64(1)))
+		Expect(response.Error).To(BeNil())
+		Expect(stdinWriter.Close()).To(Succeed())
+		Eventually(done, 5*time.Second).Should(Receive(Succeed()))
+		Expect(stdoutWriter.Close()).To(Succeed())
+		Expect(stdoutReader.Close()).To(Succeed())
+		Expect(stdinReader.Close()).To(Succeed())
+	}, SpecTimeout(90*time.Second))
+})
+
+func boolPointer(value bool) *bool { return &value }

--- a/protocol/encoding_test.go
+++ b/protocol/encoding_test.go
@@ -1,0 +1,181 @@
+package protocol_test
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/onsi/biloba/protocol"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// The generated TypeScript is the contract the client codes against, but nothing has been checking
+// that it describes what the daemon actually puts on the wire.  `omitempty` is the trap: it does
+// nothing for a struct, so a field can be declared optional in TypeScript and be present in every
+// single response (that is how "diagnostics":{} rode along on every successful operation).  The
+// golden fixtures do not catch it either - protocol-golden.test.ts asserts with toMatchObject,
+// which ignores extra keys.
+//
+// So: marshal each response type and compare the keys that actually appear against the keys the
+// generated declaration says are required.
+var _ = Describe("the generated protocol declarations", func() {
+	var declarations map[string]tsInterface
+
+	BeforeEach(func() {
+		declarations = parseGeneratedTypeScript()
+	})
+
+	// Only the types the daemon marshals: for request types Go is the decoder, so what Go would
+	// emit says nothing about what the client sends.
+	DescribeTable("describes what the daemon emits for a zero value",
+		func(name string, value any) {
+			declaration, found := declarations[name]
+			Expect(found).To(BeTrue(), "the generator no longer emits an interface named %s", name)
+
+			emitted := marshalledKeys(value)
+			for field, optional := range declaration.fields {
+				if optional {
+					Expect(emitted).NotTo(ContainElement(field),
+						"%s.%s is declared optional in TypeScript but the daemon emits it even for a zero value - either give the Go field a working omitempty (a struct needs to become a pointer) or make the declaration required", name, field)
+					continue
+				}
+				Expect(emitted).To(ContainElement(field),
+					"%s.%s is declared required in TypeScript but the daemon does not emit it for a zero value - a client reading it would get undefined", name, field)
+			}
+			for _, field := range emitted {
+				_, declared := declaration.fields[field]
+				Expect(declared).To(BeTrue(), "the daemon emits %s.%s but the generated declaration has no such field", name, field)
+			}
+		},
+		Entry("Diagnostics", "Diagnostics", protocol.Diagnostics{}),
+		Entry("ProtocolError", "ProtocolError", protocol.ProtocolError{}),
+		Entry("HandshakeResponse", "HandshakeResponse", protocol.HandshakeResponse{}),
+		Entry("OpenSessionResponse", "OpenSessionResponse", protocol.OpenSessionResponse{}),
+		Entry("OperationResult", "OperationResult", protocol.OperationResult{}),
+		Entry("PollObservation", "PollObservation", protocol.PollObservation{}),
+		Entry("Timings", "Timings", protocol.Timings{}),
+	)
+
+	It("keeps a fully-populated operation result inside its declaration", func() {
+		// The zero-value pass catches fields that are always present; this catches the opposite
+		// mistake - a field that only shows up once something is set, under a name nobody generated.
+		diagnostics := protocol.Diagnostics{Locator: `locator("#save")`, Expected: "visible", DOMOutline: "body", ScreenshotPath: "/tmp/x.png", DaemonDetail: "timed out"}
+		populated := protocol.OperationResult{
+			Matched: true, ObservedJSON: `"Saved"`, AttemptCount: 2,
+			Trajectory:  []protocol.PollObservation{{Attempt: 1, ElapsedMS: 5, ObservedJSON: `"Saving"`, RetryReason: "text mismatch"}},
+			Timings:     protocol.Timings{StartedUnixMS: 1, ElapsedMS: 2},
+			Diagnostics: &diagnostics, RPCRequestCount: 1, RPCResponseCount: 1,
+		}
+
+		Expect(marshalledKeys(populated)).To(ConsistOf(keysOf(declarations["OperationResult"])))
+		Expect(marshalledKeys(populated.Trajectory[0])).To(ConsistOf(keysOf(declarations["PollObservation"])))
+		Expect(marshalledKeys(diagnostics)).To(ConsistOf(keysOf(declarations["Diagnostics"])))
+	})
+
+	It("only omits diagnostics when there are none to report", func() {
+		// The reason diagnostics is a pointer rather than a value: a failed operation has to carry
+		// its outline and screenshot across, and a successful one should not pay for an empty object.
+		bare := marshalledKeys(protocol.OperationResult{Matched: true, Timings: protocol.Timings{}})
+		Expect(bare).NotTo(ContainElement("diagnostics"))
+
+		diagnostics := protocol.Diagnostics{DOMOutline: "body"}
+		reported := marshalledKeys(protocol.OperationResult{Diagnostics: &diagnostics})
+		Expect(reported).To(ContainElement("diagnostics"))
+	})
+
+	It("declares every error code the server can produce", func() {
+		declared := generatedErrorCodes()
+
+		Expect(declared).To(ConsistOf(
+			string(protocol.CodeInvalidArgument), string(protocol.CodeTimeout), string(protocol.CodeTargetNotFound),
+			string(protocol.CodeTargetNotReady), string(protocol.CodeJavaScript), string(protocol.CodeProtocolMismatch),
+			string(protocol.CodeDriverClosed), string(protocol.CodeDriver), string(protocol.CodeCancelled),
+			string(protocol.CodeBrowserGone), string(protocol.CodePageCrashed),
+		), "a code the daemon can send but TypeScript does not declare is a code the client cannot narrow on")
+	})
+
+	It("encodes durations as whole milliseconds, not Go nanoseconds", func() {
+		// time.Duration marshals as an int64 nanosecond count by default, which would silently make
+		// every elapsedMs 1e6 times too large on the TypeScript side.
+		wire, err := json.Marshal(protocol.Timings{ElapsedMS: (1500 * time.Millisecond).Milliseconds()})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(wire)).To(ContainSubstring(`"elapsedMs":1500`))
+	})
+})
+
+type tsInterface struct {
+	fields map[string]bool // field name -> optional
+}
+
+var (
+	tsInterfacePattern = regexp.MustCompile(`(?m)^export interface (\w+)(?:<[^>]*>)? \{$`)
+	tsFieldPattern     = regexp.MustCompile(`^\s{2}(\w+)(\??):`)
+)
+
+// parseGeneratedTypeScript reads the committed generated declarations rather than re-deriving them
+// from the generator, so a bug in the generator shows up here instead of cancelling itself out.
+func parseGeneratedTypeScript() map[string]tsInterface {
+	GinkgoHelper()
+	source, err := os.ReadFile("../typescript/src/generated/protocol.ts")
+	Expect(err).NotTo(HaveOccurred())
+	declarations := map[string]tsInterface{}
+	var current string
+	for _, line := range strings.Split(string(source), "\n") {
+		if match := tsInterfacePattern.FindStringSubmatch(line); match != nil {
+			current = match[1]
+			declarations[current] = tsInterface{fields: map[string]bool{}}
+			continue
+		}
+		if line == "}" {
+			current = ""
+			continue
+		}
+		if current == "" {
+			continue
+		}
+		if match := tsFieldPattern.FindStringSubmatch(line); match != nil {
+			declarations[current].fields[match[1]] = match[2] == "?"
+		}
+	}
+	Expect(declarations).NotTo(BeEmpty(), "could not parse the generated declarations")
+	return declarations
+}
+
+func generatedErrorCodes() []string {
+	GinkgoHelper()
+	source, err := os.ReadFile("../typescript/src/generated/protocol.ts")
+	Expect(err).NotTo(HaveOccurred())
+	_, rest, found := strings.Cut(string(source), "export type ErrorCode =")
+	Expect(found).To(BeTrue())
+	body, _, found := strings.Cut(rest, ";")
+	Expect(found).To(BeTrue())
+	codes := []string{}
+	for _, match := range regexp.MustCompile(`"([A-Z_]+)"`).FindAllStringSubmatch(body, -1) {
+		codes = append(codes, match[1])
+	}
+	return codes
+}
+
+func marshalledKeys(value any) []string {
+	GinkgoHelper()
+	encoded, err := json.Marshal(value)
+	Expect(err).NotTo(HaveOccurred())
+	var decoded map[string]json.RawMessage
+	Expect(json.Unmarshal(encoded, &decoded)).To(Succeed())
+	keys := []string{}
+	for key := range decoded {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+func keysOf(declaration tsInterface) []string {
+	keys := []string{}
+	for key := range declaration.fields {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/protocol/framing.go
+++ b/protocol/framing.go
@@ -1,0 +1,99 @@
+package protocol
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// MaxFrameSize bounds one protocol message before allocating its payload.
+const MaxFrameSize = 16 << 20
+
+// MalformedFrameError reports a frame whose header and payload were read in full but whose body
+// did not decode.  It is the one framing failure that does not desync the stream - the reader is
+// still sitting on a frame boundary - so a server can answer it and keep serving instead of
+// tearing down every session sharing the pipe.  Every other error from Read means the bytes
+// themselves are untrustworthy.
+type MalformedFrameError struct{ Err error }
+
+func (e *MalformedFrameError) Error() string { return "decode protocol frame: " + e.Err.Error() }
+func (e *MalformedFrameError) Unwrap() error { return e.Err }
+
+// FramedReader reads 4-byte little-endian length-prefixed JSON messages.
+type FramedReader struct {
+	reader io.Reader
+}
+
+func NewFramedReader(reader io.Reader) *FramedReader {
+	return &FramedReader{reader: reader}
+}
+
+func (r *FramedReader) Read(value any) error {
+	var header [4]byte
+	if _, err := io.ReadFull(r.reader, header[:]); err != nil {
+		return err
+	}
+	length := binary.LittleEndian.Uint32(header[:])
+	if length == 0 {
+		return fmt.Errorf("protocol frame is empty")
+	}
+	if length > MaxFrameSize {
+		return fmt.Errorf("protocol frame is %d bytes; maximum is %d", length, MaxFrameSize)
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(r.reader, payload); err != nil {
+		return fmt.Errorf("read protocol frame payload: %w", err)
+	}
+	if err := json.Unmarshal(payload, value); err != nil {
+		return &MalformedFrameError{Err: err}
+	}
+	return nil
+}
+
+// FramedWriter writes complete frames atomically with respect to other callers.
+type FramedWriter struct {
+	writer io.Writer
+	mu     sync.Mutex
+}
+
+func NewFramedWriter(writer io.Writer) *FramedWriter {
+	return &FramedWriter{writer: writer}
+}
+
+func (w *FramedWriter) Write(value any) error {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Errorf("encode protocol frame: %w", err)
+	}
+	if len(payload) > MaxFrameSize {
+		return fmt.Errorf("protocol frame is %d bytes; maximum is %d", len(payload), MaxFrameSize)
+	}
+	var header [4]byte
+	binary.LittleEndian.PutUint32(header[:], uint32(len(payload)))
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if err := writeAll(w.writer, header[:]); err != nil {
+		return fmt.Errorf("write protocol frame header: %w", err)
+	}
+	if err := writeAll(w.writer, payload); err != nil {
+		return fmt.Errorf("write protocol frame payload: %w", err)
+	}
+	return nil
+}
+
+func writeAll(writer io.Writer, data []byte) error {
+	for len(data) > 0 {
+		written, err := writer.Write(data)
+		if err != nil {
+			return err
+		}
+		if written == 0 {
+			return io.ErrShortWrite
+		}
+		data = data[written:]
+	}
+	return nil
+}

--- a/protocol/framing.go
+++ b/protocol/framing.go
@@ -52,6 +52,22 @@ func (r *FramedReader) Read(value any) error {
 	return nil
 }
 
+// UnwritableFrameError reports a value the writer rejected before it put a single byte on the
+// stream: it did not encode, or it encoded to more than MaxFrameSize.  It is the write side's
+// mirror of MalformedFrameError - the stream is still sitting on a frame boundary, so a server can
+// answer with a substitute and keep serving instead of tearing down every session sharing the pipe.
+// Every other error from Write means bytes reached the stream and the frame is half-written, which
+// nothing downstream can resynchronize.
+type UnwritableFrameError struct {
+	// Size is the encoded length in bytes, or 0 when the value did not encode at all.  It lets a
+	// caller report the overrun without re-marshalling the value it just failed to send.
+	Size int
+	Err  error
+}
+
+func (e *UnwritableFrameError) Error() string { return e.Err.Error() }
+func (e *UnwritableFrameError) Unwrap() error { return e.Err }
+
 // FramedWriter writes complete frames atomically with respect to other callers.
 type FramedWriter struct {
 	writer io.Writer
@@ -65,10 +81,10 @@ func NewFramedWriter(writer io.Writer) *FramedWriter {
 func (w *FramedWriter) Write(value any) error {
 	payload, err := json.Marshal(value)
 	if err != nil {
-		return fmt.Errorf("encode protocol frame: %w", err)
+		return &UnwritableFrameError{Err: fmt.Errorf("encode protocol frame: %w", err)}
 	}
 	if len(payload) > MaxFrameSize {
-		return fmt.Errorf("protocol frame is %d bytes; maximum is %d", len(payload), MaxFrameSize)
+		return &UnwritableFrameError{Size: len(payload), Err: fmt.Errorf("protocol frame is %d bytes; maximum is %d", len(payload), MaxFrameSize)}
 	}
 	var header [4]byte
 	binary.LittleEndian.PutUint32(header[:], uint32(len(payload)))

--- a/protocol/framing_test.go
+++ b/protocol/framing_test.go
@@ -1,0 +1,73 @@
+package protocol_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"strings"
+
+	"github.com/onsi/biloba/protocol"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("length-prefixed JSON framing", func() {
+	type message struct {
+		ID     uint64 `json:"id"`
+		Method string `json:"method"`
+		Script string `json:"script"`
+	}
+
+	It("round-trips multiline payloads across arbitrarily fragmented reads", func() {
+		var wire bytes.Buffer
+		writer := protocol.NewFramedWriter(&wire)
+		original := message{ID: 17, Method: "evaluate", Script: "return `first\\nsecond`\n"}
+		Expect(writer.Write(original)).To(Succeed())
+
+		reader := protocol.NewFramedReader(&oneByteReader{reader: bytes.NewReader(wire.Bytes())})
+		var decoded message
+		Expect(reader.Read(&decoded)).To(Succeed())
+		Expect(decoded).To(Equal(original))
+	})
+
+	It("reads consecutive frames without relying on message boundaries", func() {
+		var wire bytes.Buffer
+		writer := protocol.NewFramedWriter(&wire)
+		Expect(writer.Write(message{ID: 1, Method: "first"})).To(Succeed())
+		Expect(writer.Write(message{ID: 2, Method: "second"})).To(Succeed())
+
+		reader := protocol.NewFramedReader(&wire)
+		var first, second message
+		Expect(reader.Read(&first)).To(Succeed())
+		Expect(reader.Read(&second)).To(Succeed())
+		Expect(first.ID).To(Equal(uint64(1)))
+		Expect(second.ID).To(Equal(uint64(2)))
+	})
+
+	It("rejects an oversized frame before allocating its payload", func() {
+		var header [4]byte
+		binary.LittleEndian.PutUint32(header[:], protocol.MaxFrameSize+1)
+		var decoded message
+		err := protocol.NewFramedReader(bytes.NewReader(header[:])).Read(&decoded)
+		Expect(err).To(MatchError(ContainSubstring("maximum")))
+	})
+
+	It("reports a truncated payload", func() {
+		var header [4]byte
+		binary.LittleEndian.PutUint32(header[:], 10)
+		var decoded message
+		err := protocol.NewFramedReader(io.MultiReader(bytes.NewReader(header[:]), strings.NewReader("{}"))).Read(&decoded)
+		Expect(err).To(MatchError(ContainSubstring("unexpected EOF")))
+	})
+})
+
+type oneByteReader struct {
+	reader io.Reader
+}
+
+func (r *oneByteReader) Read(buffer []byte) (int, error) {
+	if len(buffer) > 1 {
+		buffer = buffer[:1]
+	}
+	return r.reader.Read(buffer)
+}

--- a/protocol/generate.go
+++ b/protocol/generate.go
@@ -1,0 +1,3 @@
+package protocol
+
+//go:generate go run ./internal/generate

--- a/protocol/generated_test.go
+++ b/protocol/generated_test.go
@@ -1,0 +1,45 @@
+package protocol_test
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/onsi/biloba/protocol/internal/protocolgen"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// The drift guard for the generated TypeScript declarations and golden frames.
+//
+// This deliberately does not shell out to git.  A `git diff --exit-code` answers "does the tree
+// match the last commit?", which is a different question from the one that matters ("do these
+// files match the Go wire definitions?") and gets it wrong in both directions: it passes on a
+// staged-but-divergent file, and it fails on a working tree where you regenerated correctly and
+// have not committed yet - the exact state you are in while making the change. Rendering the
+// artifacts and comparing them to what is on disk asks the real question, needs no git, and gives
+// the same answer in CI and on a dirty working tree.
+var _ = Describe("the generated protocol artifacts", func() {
+	It("match what the generator renders from the Go wire definitions", func() {
+		for path, expected := range protocolgen.Files() {
+			actual, err := os.ReadFile(filepath.Join("..", filepath.FromSlash(path)))
+			Expect(err).NotTo(HaveOccurred(), "%s is missing; run `go generate ./protocol`", path)
+			Expect(string(actual)).To(Equal(string(expected)),
+				"%s is stale: the Go wire definitions have changed since it was generated.\nRun `go generate ./protocol` and commit the result alongside the change that caused it.", path)
+		}
+	})
+
+	It("covers every artifact the generator writes", func() {
+		// A new artifact that nobody compares is a new artifact that can drift, so pin the set
+		// itself rather than only the contents of whatever happens to be in it.
+		paths := []string{}
+		for path := range protocolgen.Files() {
+			paths = append(paths, path)
+		}
+		Expect(paths).To(ConsistOf(
+			"typescript/src/generated/protocol.ts",
+			"protocol/testdata/golden/handshake-request.json",
+			"protocol/testdata/golden/protocol-error-response.json",
+			"protocol/testdata/golden/operation-response.json",
+		))
+	})
+})

--- a/protocol/internal/generate/main.go
+++ b/protocol/internal/generate/main.go
@@ -1,0 +1,26 @@
+// Command generate writes the generated protocol artifacts.  Run it with `go generate ./protocol`.
+// The check that they are up to date lives in protocol/generated_test.go, not here.
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/onsi/biloba/protocol/internal/protocolgen"
+)
+
+func main() {
+	root, err := filepath.Abs("..")
+	must(err)
+	for path, contents := range protocolgen.Files() {
+		destination := filepath.Join(root, filepath.FromSlash(path))
+		must(os.MkdirAll(filepath.Dir(destination), 0o755))
+		must(os.WriteFile(destination, contents, 0o644))
+	}
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/protocol/internal/protocolgen/protocolgen.go
+++ b/protocol/internal/protocolgen/protocolgen.go
@@ -1,0 +1,157 @@
+// Package protocolgen renders the generated protocol artifacts from the Go wire definitions.
+// It is a package rather than a lone main so the same rendering that `go generate ./protocol`
+// writes can be compared against what is on disk by a spec - see protocol/generated_test.go.
+// A drift check that shells out to git answers "does the tree match the last commit?"; the
+// question worth asking is "do these files match the Go source?", and only the generator can
+// answer that.
+package protocolgen
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/onsi/biloba/protocol"
+)
+
+// Files maps each generated artifact's repository-relative path to its rendered contents.
+func Files() map[string][]byte {
+	return map[string][]byte{
+		"typescript/src/generated/protocol.ts": []byte(typeScript()),
+		"protocol/testdata/golden/handshake-request.json": indentJSON(protocol.Request{
+			ID: 1, Method: "handshake", Params: raw(protocol.HandshakeRequest{ProtocolVersion: protocol.Version}),
+		}),
+		"protocol/testdata/golden/protocol-error-response.json": indentJSON(protocol.Response{
+			ID: 7, Error: protocol.NewError(protocol.CodeProtocolMismatch, "protocol version mismatch"),
+		}),
+		"protocol/testdata/golden/operation-response.json": indentJSON(protocol.Response{ID: 9, Result: protocol.OperationResult{
+			Matched: true, ObservedJSON: `"Saved"`, AttemptCount: 2,
+			Trajectory: []protocol.PollObservation{{Attempt: 1, ObservedJSON: `"Saving"`}, {Attempt: 2, ElapsedMS: 10, ObservedJSON: `"Saved"`}},
+			Timings:    protocol.Timings{StartedUnixMS: 1_700_000_000_000, ElapsedMS: 10}, RPCRequestCount: 1, RPCResponseCount: 1,
+		}}),
+	}
+}
+
+func indentJSON(value any) []byte {
+	encoded, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return append(encoded, '\n')
+}
+
+var declarations = []reflect.Type{
+	reflect.TypeFor[protocol.Diagnostics](),
+	reflect.TypeFor[protocol.ProtocolError](),
+	reflect.TypeFor[protocol.Request](),
+	reflect.TypeFor[protocol.HandshakeRequest](),
+	reflect.TypeFor[protocol.HandshakeResponse](),
+	reflect.TypeFor[protocol.OpenSessionResponse](),
+	reflect.TypeFor[protocol.SessionRequest](),
+	reflect.TypeFor[protocol.NavigateRequest](),
+	reflect.TypeFor[protocol.PollOptions](),
+	reflect.TypeFor[protocol.WireLocator](),
+	reflect.TypeFor[protocol.WireCookie](),
+	reflect.TypeFor[protocol.SetCookiesRequest](),
+	reflect.TypeFor[protocol.LocatorRequest](),
+	reflect.TypeFor[protocol.SetValueRequest](),
+	reflect.TypeFor[protocol.EvaluateRequest](),
+	reflect.TypeFor[protocol.WireAssertion](),
+	reflect.TypeFor[protocol.AssertRequest](),
+	reflect.TypeFor[protocol.PollObservation](),
+	reflect.TypeFor[protocol.Timings](),
+	reflect.TypeFor[protocol.OperationResult](),
+}
+
+func typeScript() string {
+	var output strings.Builder
+	output.WriteString("// Code generated from the Go protocol definition; DO NOT EDIT.\n\n")
+	output.WriteString("export type ErrorCode =\n")
+	for _, code := range []protocol.ErrorCode{protocol.CodeInvalidArgument, protocol.CodeTimeout, protocol.CodeTargetNotFound, protocol.CodeTargetNotReady, protocol.CodeJavaScript, protocol.CodeProtocolMismatch, protocol.CodeDriverClosed, protocol.CodeDriver, protocol.CodeCancelled, protocol.CodeBrowserGone, protocol.CodePageCrashed} {
+		fmt.Fprintf(&output, "  | %q\n", code)
+	}
+	output.WriteString(";\n\n")
+	for _, declaration := range declarations {
+		writeDeclaration(&output, declaration)
+	}
+	output.WriteString("export interface Response<Result = unknown> {\n  id: number;\n  result?: Result;\n  error?: ProtocolError;\n}\n\n")
+	output.WriteString("export type OpenSessionRequest = Record<string, never>;\n")
+	return output.String()
+}
+
+func writeDeclaration(output *strings.Builder, declaration reflect.Type) {
+	name := tsName(declaration)
+	fmt.Fprintf(output, "export interface %s {\n", name)
+	for i := range declaration.NumField() {
+		field := declaration.Field(i)
+		jsonName, options, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if jsonName == "-" {
+			continue
+		}
+		if jsonName == "" {
+			jsonName = field.Name
+		}
+		optional := strings.Contains(options, "omitempty") || field.Type.Kind() == reflect.Pointer
+		fmt.Fprintf(output, "  %s%s: %s;\n", jsonName, map[bool]string{true: "?"}[optional], tsType(declaration, field))
+	}
+	output.WriteString("}\n\n")
+}
+
+func tsType(owner reflect.Type, field reflect.StructField) string {
+	if owner == reflect.TypeFor[protocol.WireLocator]() {
+		switch field.Name {
+		case "Kind":
+			return `"CSS" | "TEST_ID" | "TEXT" | "ROLE"`
+		case "Match":
+			return `"EXACT" | "CONTAINS"`
+		}
+	}
+	if owner == reflect.TypeFor[protocol.WireAssertion]() {
+		switch field.Name {
+		case "Kind":
+			return `"VISIBLE" | "TEXT" | "COUNT" | "ATTRIBUTE" | "VALUE" | "URL" | "EVALUATE"`
+		case "Match":
+			return `"EXACT" | "CONTAINS"`
+		}
+	}
+	return typeName(field.Type)
+}
+
+func typeName(value reflect.Type) string {
+	if value.Kind() == reflect.Pointer {
+		return typeName(value.Elem())
+	}
+	if value == reflect.TypeFor[json.RawMessage]() || value.Kind() == reflect.Interface {
+		return "unknown"
+	}
+	if value == reflect.TypeFor[protocol.ErrorCode]() {
+		return "ErrorCode"
+	}
+	switch value.Kind() {
+	case reflect.String:
+		return "string"
+	case reflect.Bool:
+		return "boolean"
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Float32, reflect.Float64:
+		return "number"
+	case reflect.Slice:
+		return typeName(value.Elem()) + "[]"
+	case reflect.Struct:
+		return tsName(value)
+	default:
+		panic("unsupported protocol type " + value.String())
+	}
+}
+
+func tsName(value reflect.Type) string {
+	return strings.TrimPrefix(value.Name(), "Wire")
+}
+
+func raw(value any) json.RawMessage {
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return encoded
+}

--- a/protocol/server.go
+++ b/protocol/server.go
@@ -1,0 +1,609 @@
+package protocol
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const Version = "1"
+
+var Capabilities = []string{
+	"locator.css", "locator.test_id", "locator.text", "locator.role", "locator.first",
+	"session.prepare", "navigation", "cookies", "action.click", "action.set_value",
+	"evaluate", "assert.visible", "assert.text", "assert.count", "assert.attribute",
+	"assert.value", "assert.url", "assert.evaluate", "poll.server_side", "diagnostics.structured",
+}
+
+type ErrorCode string
+
+const (
+	CodeInvalidArgument  ErrorCode = "INVALID_ARGUMENT"
+	CodeTimeout          ErrorCode = "TIMEOUT"
+	CodeTargetNotFound   ErrorCode = "TARGET_NOT_FOUND"
+	CodeTargetNotReady   ErrorCode = "TARGET_NOT_READY"
+	CodeJavaScript       ErrorCode = "JAVASCRIPT_ERROR"
+	CodeProtocolMismatch ErrorCode = "PROTOCOL_MISMATCH"
+	CodeDriverClosed     ErrorCode = "DRIVER_CLOSED"
+	// CodeBrowserGone is the shared Chrome exiting or crashing underneath a worker - distinct from
+	// DRIVER_CLOSED (this worker's daemon died) and from CANCELLED (the caller asked to stop).
+	CodeBrowserGone ErrorCode = "BROWSER_GONE"
+	// CodePageCrashed is this session's renderer dying while the browser itself lives on.  Chrome
+	// stops answering for that target rather than erroring, so without this the operation would
+	// simply hang until its deadline.  Navigating the session again recovers it.
+	CodePageCrashed ErrorCode = "PAGE_CRASHED"
+	CodeDriver      ErrorCode = "DRIVER_ERROR"
+	CodeCancelled   ErrorCode = "CANCELLED"
+)
+
+type ProtocolError struct {
+	Code        ErrorCode    `json:"code"`
+	Message     string       `json:"message"`
+	Diagnostics *Diagnostics `json:"diagnostics,omitempty"`
+}
+
+func (e *ProtocolError) Error() string { return e.Message }
+
+func NewError(code ErrorCode, message string) *ProtocolError {
+	return &ProtocolError{Code: code, Message: message}
+}
+
+type Backend interface {
+	OpenSession(context.Context) (Session, error)
+	Close() error
+}
+
+type Session interface {
+	Prepare(context.Context) error
+	Execute(context.Context, Operation) (Result, error)
+	Close() error
+}
+
+type OperationKind uint8
+
+const (
+	OperationNavigate OperationKind = iota + 1
+	OperationSetCookies
+	OperationClick
+	OperationSetValue
+	OperationEvaluate
+	OperationAssert
+)
+
+type Operation struct {
+	Kind          OperationKind
+	URL           string
+	Cookies       []Cookie
+	Locator       Locator
+	Poll          PollPolicy
+	ValueJSON     string
+	Expression    string
+	ArgumentsJSON string
+	Invoke        *bool
+	Assertion     Assertion
+}
+
+type LocatorKind uint8
+
+const (
+	LocatorCSS LocatorKind = iota + 1
+	LocatorTestID
+	LocatorText
+	LocatorRole
+)
+
+type MatchMode uint8
+
+const (
+	MatchExact MatchMode = iota + 1
+	MatchContains
+)
+
+type Locator struct {
+	Kind  LocatorKind
+	Value string
+	Role  string
+	Name  string
+	Match MatchMode
+	First bool
+}
+
+type PollPolicy struct {
+	Timeout  time.Duration
+	Interval time.Duration
+}
+
+type Cookie struct {
+	Name, Value, Domain, Path, SameSite string
+	Secure, HTTPOnly                    bool
+	ExpiresUnix                         float64
+}
+
+type AssertionKind uint8
+
+const (
+	AssertionVisible AssertionKind = iota + 1
+	AssertionText
+	AssertionCount
+	AssertionAttribute
+	AssertionValue
+	AssertionURL
+	AssertionEvaluate
+)
+
+type Assertion struct {
+	Kind           AssertionKind
+	Locator        Locator
+	Attribute      string
+	Expression     string
+	ExpectedString string
+	ExpectedCount  int64
+	ExpectedJSON   string
+	Match          MatchMode
+}
+
+type Result struct {
+	Matched      bool
+	ObservedJSON string
+	Attempts     uint32
+	Trajectory   []Observation
+	StartedAt    time.Time
+	Elapsed      time.Duration
+	Diagnostics  Diagnostics
+}
+
+type Observation struct {
+	Attempt      uint32
+	Elapsed      time.Duration
+	ObservedJSON string
+	RetryReason  string
+}
+
+type Diagnostics struct {
+	Locator        string `json:"locator,omitempty"`
+	Expected       string `json:"expected,omitempty"`
+	DOMOutline     string `json:"domOutline,omitempty"`
+	ScreenshotPath string `json:"screenshotPath,omitempty"`
+	DaemonDetail   string `json:"daemonDetail,omitempty"`
+}
+
+// The wire structs below are the authoritative JSON protocol definition.  The
+// TypeScript declarations and golden frames are generated from these shapes.
+type Request struct {
+	ID        uint64          `json:"id"`
+	Method    string          `json:"method"`
+	Params    json.RawMessage `json:"params,omitempty"`
+	TimeoutMS int64           `json:"timeoutMs,omitempty"`
+}
+
+type Response struct {
+	ID     uint64         `json:"id"`
+	Result any            `json:"result,omitempty"`
+	Error  *ProtocolError `json:"error,omitempty"`
+}
+
+type HandshakeRequest struct {
+	ProtocolVersion string `json:"protocolVersion"`
+}
+
+type HandshakeResponse struct {
+	ProtocolVersion string   `json:"protocolVersion"`
+	Capabilities    []string `json:"capabilities"`
+}
+
+type OpenSessionResponse struct {
+	SessionID string `json:"sessionId"`
+}
+
+type SessionRequest struct {
+	SessionID string `json:"sessionId"`
+}
+
+type NavigateRequest struct {
+	SessionID string `json:"sessionId"`
+	URL       string `json:"url"`
+}
+
+type PollOptions struct {
+	TimeoutMS  int64 `json:"timeoutMs,omitempty"`
+	IntervalMS int64 `json:"intervalMs,omitempty"`
+}
+
+type WireLocator struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value,omitempty"`
+	Role  string `json:"role,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Match string `json:"match,omitempty"`
+	First bool   `json:"first"`
+}
+
+type WireCookie struct {
+	Name        string  `json:"name"`
+	Value       string  `json:"value"`
+	Domain      string  `json:"domain,omitempty"`
+	Path        string  `json:"path,omitempty"`
+	ExpiresUnix float64 `json:"expiresUnix,omitempty"`
+	Secure      bool    `json:"secure,omitempty"`
+	HTTPOnly    bool    `json:"httpOnly,omitempty"`
+	SameSite    string  `json:"sameSite,omitempty"`
+}
+
+type SetCookiesRequest struct {
+	SessionID string       `json:"sessionId"`
+	Cookies   []WireCookie `json:"cookies"`
+}
+
+type LocatorRequest struct {
+	SessionID string       `json:"sessionId"`
+	Locator   *WireLocator `json:"locator"`
+	Poll      PollOptions  `json:"poll,omitempty"`
+}
+
+type SetValueRequest struct {
+	SessionID string       `json:"sessionId"`
+	Locator   *WireLocator `json:"locator"`
+	ValueJSON string       `json:"valueJson"`
+	Poll      PollOptions  `json:"poll,omitempty"`
+}
+
+type EvaluateRequest struct {
+	SessionID     string `json:"sessionId"`
+	Expression    string `json:"expression"`
+	ArgumentsJSON string `json:"argumentsJson,omitempty"`
+	// Invoke says what Expression means, so that meaning does not hang off how many arguments came
+	// with it: true calls Expression as a function with ArgumentsJson's elements spread into it -
+	// including when that array is empty - and false evaluates Expression verbatim.  It is a
+	// pointer because absent is a third answer: clients written before Invoke existed get the old
+	// inference (arguments present means call it), and new clients should always send it.
+	Invoke *bool `json:"invoke,omitempty"`
+}
+
+type WireAssertion struct {
+	Kind           string       `json:"kind"`
+	Locator        *WireLocator `json:"locator,omitempty"`
+	Attribute      string       `json:"attribute,omitempty"`
+	Expression     string       `json:"expression,omitempty"`
+	ExpectedString string       `json:"expectedString,omitempty"`
+	ExpectedCount  int64        `json:"expectedCount,omitempty"`
+	ExpectedJSON   string       `json:"expectedJson,omitempty"`
+	Match          string       `json:"match,omitempty"`
+}
+
+type AssertRequest struct {
+	SessionID string         `json:"sessionId"`
+	Assertion *WireAssertion `json:"assertion"`
+	Poll      PollOptions    `json:"poll,omitempty"`
+}
+
+type CancelRequest struct {
+	RequestID uint64 `json:"requestId"`
+}
+
+type OperationResult struct {
+	Matched      bool              `json:"matched"`
+	ObservedJSON string            `json:"observedJson,omitempty"`
+	AttemptCount uint32            `json:"attemptCount"`
+	Trajectory   []PollObservation `json:"trajectory,omitempty"`
+	Timings      Timings           `json:"timings"`
+	// A pointer, because `omitempty` does nothing for a struct: a value here put an empty
+	// "diagnostics":{} on every successful response while the generated TypeScript declared the
+	// field optional.  See TestProtocol's encoding specs.
+	Diagnostics      *Diagnostics `json:"diagnostics,omitempty"`
+	RPCRequestCount  uint32       `json:"rpcRequestCount"`
+	RPCResponseCount uint32       `json:"rpcResponseCount"`
+}
+
+type PollObservation struct {
+	Attempt      uint32 `json:"attempt"`
+	ElapsedMS    int64  `json:"elapsedMs"`
+	ObservedJSON string `json:"observedJson,omitempty"`
+	RetryReason  string `json:"retryReason,omitempty"`
+}
+
+type Timings struct {
+	StartedUnixMS int64 `json:"startedUnixMs"`
+	ElapsedMS     int64 `json:"elapsedMs"`
+}
+
+type Server struct {
+	backend  Backend
+	mu       sync.Mutex
+	sessions map[string]*sessionEntry
+}
+
+type sessionEntry struct {
+	mu      sync.Mutex
+	session Session
+}
+
+func NewServer(backend Backend) *Server {
+	return &Server{backend: backend, sessions: map[string]*sessionEntry{}}
+}
+
+func (s *Server) Dispatch(ctx context.Context, method string, params json.RawMessage) (any, *ProtocolError) {
+	switch method {
+	case "handshake":
+		var request HandshakeRequest
+		if err := decodeParams(params, &request); err != nil {
+			return nil, err
+		}
+		if request.ProtocolVersion != Version {
+			return nil, NewError(CodeProtocolMismatch, fmt.Sprintf("protocol version mismatch: client=%q daemon=%q", request.ProtocolVersion, Version))
+		}
+		return HandshakeResponse{ProtocolVersion: Version, Capabilities: append([]string(nil), Capabilities...)}, nil
+	case "openSession":
+		session, err := s.backend.OpenSession(ctx)
+		if err != nil {
+			return nil, normalizeError(err)
+		}
+		id, idErr := randomID()
+		if idErr != nil {
+			_ = session.Close()
+			return nil, NewError(CodeDriver, "generate session id")
+		}
+		s.mu.Lock()
+		s.sessions[id] = &sessionEntry{session: session}
+		s.mu.Unlock()
+		return OpenSessionResponse{SessionID: id}, nil
+	case "prepareSession":
+		var request SessionRequest
+		if err := decodeParams(params, &request); err != nil {
+			return nil, err
+		}
+		entry, err := s.session(request.SessionID)
+		if err != nil {
+			return nil, err
+		}
+		entry.mu.Lock()
+		defer entry.mu.Unlock()
+		if prepareErr := entry.session.Prepare(ctx); prepareErr != nil {
+			return nil, normalizeError(prepareErr)
+		}
+		return struct{}{}, nil
+	case "closeSession":
+		var request SessionRequest
+		if err := decodeParams(params, &request); err != nil {
+			return nil, err
+		}
+		return s.closeSession(request.SessionID)
+	case "navigate":
+		var request NavigateRequest
+		if err := decodeParams(params, &request); err != nil {
+			return nil, err
+		}
+		if request.URL == "" {
+			return nil, NewError(CodeInvalidArgument, "url is required")
+		}
+		return s.execute(ctx, request.SessionID, Operation{Kind: OperationNavigate, URL: request.URL})
+	case "setCookies":
+		var request SetCookiesRequest
+		if err := decodeParams(params, &request); err != nil {
+			return nil, err
+		}
+		cookies := make([]Cookie, len(request.Cookies))
+		for i, cookie := range request.Cookies {
+			if cookie.Name == "" {
+				return nil, NewError(CodeInvalidArgument, fmt.Sprintf("cookies[%d].name is required", i))
+			}
+			cookies[i] = Cookie{Name: cookie.Name, Value: cookie.Value, Domain: cookie.Domain, Path: cookie.Path, Secure: cookie.Secure, HTTPOnly: cookie.HTTPOnly, ExpiresUnix: cookie.ExpiresUnix, SameSite: cookie.SameSite}
+		}
+		return s.execute(ctx, request.SessionID, Operation{Kind: OperationSetCookies, Cookies: cookies})
+	case "click":
+		var request LocatorRequest
+		if err := decodeParams(params, &request); err != nil {
+			return nil, err
+		}
+		locator, err := locatorFromWire(request.Locator)
+		if err != nil {
+			return nil, err
+		}
+		return s.execute(ctx, request.SessionID, Operation{Kind: OperationClick, Locator: locator, Poll: pollFromWire(request.Poll)})
+	case "setValue":
+		var request SetValueRequest
+		if err := decodeParams(params, &request); err != nil {
+			return nil, err
+		}
+		locator, err := locatorFromWire(request.Locator)
+		if err != nil {
+			return nil, err
+		}
+		return s.execute(ctx, request.SessionID, Operation{Kind: OperationSetValue, Locator: locator, Poll: pollFromWire(request.Poll), ValueJSON: request.ValueJSON})
+	case "evaluate":
+		var request EvaluateRequest
+		if err := decodeParams(params, &request); err != nil {
+			return nil, err
+		}
+		if request.Expression == "" {
+			return nil, NewError(CodeInvalidArgument, "expression is required")
+		}
+		return s.execute(ctx, request.SessionID, Operation{Kind: OperationEvaluate, Expression: request.Expression, ArgumentsJSON: request.ArgumentsJSON, Invoke: request.Invoke})
+	case "assert":
+		var request AssertRequest
+		if err := decodeParams(params, &request); err != nil {
+			return nil, err
+		}
+		assertion, err := assertionFromWire(request.Assertion)
+		if err != nil {
+			return nil, err
+		}
+		return s.execute(ctx, request.SessionID, Operation{Kind: OperationAssert, Assertion: assertion, Poll: pollFromWire(request.Poll)})
+	default:
+		return nil, NewError(CodeInvalidArgument, fmt.Sprintf("unsupported method %q", method))
+	}
+}
+
+func decodeParams(params json.RawMessage, destination any) *ProtocolError {
+	if len(params) == 0 {
+		params = json.RawMessage(`{}`)
+	}
+	if err := json.Unmarshal(params, destination); err != nil {
+		return NewError(CodeInvalidArgument, fmt.Sprintf("invalid request parameters: %v", err))
+	}
+	return nil
+}
+
+func (s *Server) execute(ctx context.Context, sessionID string, operation Operation) (any, *ProtocolError) {
+	entry, err := s.session(sessionID)
+	if err != nil {
+		return nil, err
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	result, executeErr := entry.session.Execute(ctx, operation)
+	if executeErr != nil {
+		return nil, normalizeError(executeErr)
+	}
+	return resultToWire(result), nil
+}
+
+func (s *Server) session(id string) (*sessionEntry, *ProtocolError) {
+	if id == "" {
+		return nil, NewError(CodeInvalidArgument, "sessionId is required")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, exists := s.sessions[id]
+	if !exists {
+		return nil, NewError(CodeTargetNotFound, "session not found")
+	}
+	return entry, nil
+}
+
+func (s *Server) closeSession(id string) (any, *ProtocolError) {
+	if id == "" {
+		return nil, NewError(CodeInvalidArgument, "sessionId is required")
+	}
+	s.mu.Lock()
+	entry, exists := s.sessions[id]
+	if exists {
+		delete(s.sessions, id)
+	}
+	s.mu.Unlock()
+	if !exists {
+		return nil, NewError(CodeTargetNotFound, "session not found")
+	}
+	entry.mu.Lock()
+	defer entry.mu.Unlock()
+	if err := entry.session.Close(); err != nil {
+		return nil, normalizeError(err)
+	}
+	return struct{}{}, nil
+}
+
+func (s *Server) Close() error {
+	s.mu.Lock()
+	entries := make([]*sessionEntry, 0, len(s.sessions))
+	for id, entry := range s.sessions {
+		entries = append(entries, entry)
+		delete(s.sessions, id)
+	}
+	s.mu.Unlock()
+	var closeErrors []error
+	for _, entry := range entries {
+		entry.mu.Lock()
+		closeErrors = append(closeErrors, entry.session.Close())
+		entry.mu.Unlock()
+	}
+	closeErrors = append(closeErrors, s.backend.Close())
+	return errors.Join(closeErrors...)
+}
+
+func randomID() (string, error) {
+	bytes := make([]byte, 16)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes), nil
+}
+
+func pollFromWire(poll PollOptions) PollPolicy {
+	return PollPolicy{Timeout: time.Duration(poll.TimeoutMS) * time.Millisecond, Interval: time.Duration(poll.IntervalMS) * time.Millisecond}
+}
+
+func locatorFromWire(locator *WireLocator) (Locator, *ProtocolError) {
+	if locator == nil {
+		return Locator{}, NewError(CodeInvalidArgument, "locator is required")
+	}
+	kinds := map[string]LocatorKind{"CSS": LocatorCSS, "TEST_ID": LocatorTestID, "TEXT": LocatorText, "ROLE": LocatorRole}
+	kind, exists := kinds[locator.Kind]
+	if !exists {
+		return Locator{}, NewError(CodeInvalidArgument, "locator kind is required")
+	}
+	if kind == LocatorRole && locator.Role == "" {
+		return Locator{}, NewError(CodeInvalidArgument, "role locator requires role")
+	}
+	if kind != LocatorRole && locator.Value == "" {
+		return Locator{}, NewError(CodeInvalidArgument, "locator value is required")
+	}
+	match := MatchExact
+	if locator.Match == "CONTAINS" {
+		match = MatchContains
+	} else if locator.Match != "" && locator.Match != "EXACT" {
+		return Locator{}, NewError(CodeInvalidArgument, "unsupported locator match mode")
+	}
+	return Locator{Kind: kind, Value: locator.Value, Role: locator.Role, Name: locator.Name, Match: match, First: locator.First}, nil
+}
+
+func assertionFromWire(assertion *WireAssertion) (Assertion, *ProtocolError) {
+	if assertion == nil || assertion.Kind == "" {
+		return Assertion{}, NewError(CodeInvalidArgument, "assertion kind is required")
+	}
+	kinds := map[string]AssertionKind{"VISIBLE": AssertionVisible, "TEXT": AssertionText, "COUNT": AssertionCount, "ATTRIBUTE": AssertionAttribute, "VALUE": AssertionValue, "URL": AssertionURL, "EVALUATE": AssertionEvaluate}
+	kind, exists := kinds[assertion.Kind]
+	if !exists {
+		return Assertion{}, NewError(CodeInvalidArgument, "unsupported assertion")
+	}
+	match := MatchExact
+	if assertion.Match == "CONTAINS" {
+		match = MatchContains
+	} else if assertion.Match != "" && assertion.Match != "EXACT" {
+		return Assertion{}, NewError(CodeInvalidArgument, "unsupported assertion match mode")
+	}
+	result := Assertion{Kind: kind, Attribute: assertion.Attribute, Expression: assertion.Expression, ExpectedString: assertion.ExpectedString, ExpectedCount: assertion.ExpectedCount, ExpectedJSON: assertion.ExpectedJSON, Match: match}
+	if kind != AssertionURL && kind != AssertionEvaluate {
+		locator, err := locatorFromWire(assertion.Locator)
+		if err != nil {
+			return Assertion{}, err
+		}
+		result.Locator = locator
+	}
+	return result, nil
+}
+
+func resultToWire(result Result) OperationResult {
+	trajectory := make([]PollObservation, len(result.Trajectory))
+	for i, observation := range result.Trajectory {
+		trajectory[i] = PollObservation{Attempt: observation.Attempt, ElapsedMS: observation.Elapsed.Milliseconds(), ObservedJSON: observation.ObservedJSON, RetryReason: observation.RetryReason}
+	}
+	wire := OperationResult{
+		Matched: result.Matched, ObservedJSON: result.ObservedJSON, AttemptCount: result.Attempts, Trajectory: trajectory,
+		Timings:         Timings{StartedUnixMS: result.StartedAt.UnixMilli(), ElapsedMS: result.Elapsed.Milliseconds()},
+		RPCRequestCount: 1, RPCResponseCount: 1,
+	}
+	if result.Diagnostics != (Diagnostics{}) {
+		diagnostics := result.Diagnostics
+		wire.Diagnostics = &diagnostics
+	}
+	return wire
+}
+
+func normalizeError(err error) *ProtocolError {
+	var protocolErr *ProtocolError
+	if errors.As(err, &protocolErr) {
+		return protocolErr
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return NewError(CodeCancelled, err.Error())
+	case errors.Is(err, context.DeadlineExceeded):
+		return NewError(CodeTimeout, err.Error())
+	default:
+		return NewError(CodeDriver, fmt.Sprintf("daemon operation failed: %v", err))
+	}
+}

--- a/protocol/server_test.go
+++ b/protocol/server_test.go
@@ -1,0 +1,323 @@
+package protocol_test
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/onsi/biloba/protocol"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestProtocol(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Protocol Suite")
+}
+
+var _ = Describe("driver protocol", func() {
+	It("negotiates the version and advertises capabilities", func() {
+		client, cleanup := startTestServer(&fakeBackend{})
+		DeferCleanup(cleanup)
+
+		var response protocol.HandshakeResponse
+		Expect(client.call("handshake", protocol.HandshakeRequest{ProtocolVersion: protocol.Version}, &response)).To(Succeed())
+		Expect(response.ProtocolVersion).To(Equal(protocol.Version))
+		Expect(response.Capabilities).NotTo(BeEmpty())
+
+		err := client.call("handshake", protocol.HandshakeRequest{ProtocolVersion: "999"}, nil)
+		Expect(err).To(MatchError(ContainSubstring("protocol version mismatch")))
+		Expect(err.Code).To(Equal(protocol.CodeProtocolMismatch))
+	})
+
+	It("opens, prepares, and closes a session", func() {
+		backend := &fakeBackend{}
+		client, cleanup := startTestServer(backend)
+		DeferCleanup(cleanup)
+
+		var opened protocol.OpenSessionResponse
+		Expect(client.call("openSession", struct{}{}, &opened)).To(Succeed())
+		Expect(opened.SessionID).NotTo(BeEmpty())
+		Expect(client.call("prepareSession", protocol.SessionRequest{SessionID: opened.SessionID}, nil)).To(Succeed())
+		Expect(client.call("closeSession", protocol.SessionRequest{SessionID: opened.SessionID}, nil)).To(Succeed())
+		err := client.call("prepareSession", protocol.SessionRequest{SessionID: opened.SessionID}, nil)
+		Expect(err.Code).To(Equal(protocol.CodeTargetNotFound))
+		Expect(backend.opened).To(Equal(1))
+		Expect(backend.session.prepared).To(Equal(1))
+		Expect(backend.session.closed).To(Equal(1))
+	})
+
+	// `invoke` is what makes an expression's meaning explicit on the wire: without it the daemon has
+	// to guess from the argument count, and the same string means two different things.
+	It("carries an explicit invoke flag through to the session", func() {
+		recorder := &recordingSession{}
+		client, cleanup := startTestServer(&fakeBackend{custom: recorder})
+		DeferCleanup(cleanup)
+		var opened protocol.OpenSessionResponse
+		Expect(client.call("openSession", struct{}{}, &opened)).To(Succeed())
+
+		Expect(client.call("evaluate", json.RawMessage(`{"sessionId":"`+opened.SessionID+`","expression":"(a) => a + 1","argumentsJson":"[]","invoke":true}`), nil)).To(BeNil())
+		Expect(recorder.lastOperation().Invoke).To(HaveValue(BeTrue()))
+
+		Expect(client.call("evaluate", protocol.EvaluateRequest{SessionID: opened.SessionID, Expression: "document.title", ArgumentsJSON: "[]"}, nil)).To(BeNil())
+		Expect(recorder.lastOperation().Invoke).To(BeNil(), "a client that says nothing must stay distinguishable from one that says false")
+	})
+
+	It("propagates request deadlines to the session", func() {
+		backend := &fakeBackend{session: &fakeSession{blockNavigate: true, cancelled: make(chan struct{})}}
+		client, cleanup := startTestServer(backend)
+		DeferCleanup(cleanup)
+		var opened protocol.OpenSessionResponse
+		Expect(client.call("openSession", struct{}{}, &opened)).To(Succeed())
+
+		err := client.callWithTimeout("navigate", protocol.NavigateRequest{SessionID: opened.SessionID, URL: "https://example.test"}, 25, nil)
+		Expect(err.Code).To(Equal(protocol.CodeTimeout))
+		Eventually(backend.session.cancelled).Should(BeClosed())
+	})
+
+	It("cancels an in-flight request explicitly", func() {
+		backend := &fakeBackend{session: &fakeSession{blockNavigate: true, cancelled: make(chan struct{})}}
+		client, cleanup := startTestServer(backend)
+		DeferCleanup(cleanup)
+		var opened protocol.OpenSessionResponse
+		Expect(client.call("openSession", struct{}{}, &opened)).To(Succeed())
+
+		requestID, response := client.begin("navigate", protocol.NavigateRequest{SessionID: opened.SessionID, URL: "https://example.test"}, 0)
+		Eventually(backend.session.started).Should(BeClosed())
+		client.cancel(requestID)
+		protocolResponse := <-response
+		Expect(protocolResponse.Error.Code).To(Equal(protocol.CodeCancelled))
+		Eventually(backend.session.cancelled).Should(BeClosed())
+	})
+
+	It("reports many internal poll attempts from one request", func() {
+		backend := &fakeBackend{session: &fakeSession{result: protocol.Result{
+			Matched: true, ObservedJSON: `"ready"`, Attempts: 3,
+			Trajectory: []protocol.Observation{{Attempt: 1}, {Attempt: 2}, {Attempt: 3}},
+		}}}
+		client, cleanup := startTestServer(backend)
+		DeferCleanup(cleanup)
+		var opened protocol.OpenSessionResponse
+		Expect(client.call("openSession", struct{}{}, &opened)).To(Succeed())
+
+		var result protocol.OperationResult
+		Expect(client.call("assert", protocol.AssertRequest{
+			SessionID: opened.SessionID,
+			Assertion: &protocol.WireAssertion{Kind: "TEXT", Locator: &protocol.WireLocator{Kind: "CSS", Value: "#status"}, ExpectedString: "ready"},
+		}, &result)).To(Succeed())
+		Expect(result.AttemptCount).To(Equal(uint32(3)))
+		Expect(result.Trajectory).To(HaveLen(3))
+		Expect(result.RPCRequestCount).To(Equal(uint32(1)))
+		Expect(result.RPCResponseCount).To(Equal(uint32(1)))
+	})
+
+	It("preserves a structured backend error", func() {
+		backend := &fakeBackend{session: &fakeSession{executeErr: protocol.NewError(protocol.CodeInvalidArgument, "bad value")}}
+		client, cleanup := startTestServer(backend)
+		DeferCleanup(cleanup)
+		var opened protocol.OpenSessionResponse
+		Expect(client.call("openSession", struct{}{}, &opened)).To(Succeed())
+		err := client.call("navigate", protocol.NavigateRequest{SessionID: opened.SessionID, URL: "https://example.test"}, nil)
+		Expect(err.Code).To(Equal(protocol.CodeInvalidArgument))
+		Expect(err.Message).To(Equal("bad value"))
+	})
+
+	It("serializes commands within a session", func() {
+		blocking := &blockingSession{entered: make(chan string, 2), release: make(chan struct{}, 2)}
+		client, cleanup := startTestServer(&fakeBackend{custom: blocking})
+		DeferCleanup(cleanup)
+		var opened protocol.OpenSessionResponse
+		Expect(client.call("openSession", struct{}{}, &opened)).To(Succeed())
+		results := make(chan error, 2)
+		for _, destination := range []string{"https://example.test/first", "https://example.test/second"} {
+			go func(destination string) {
+				results <- client.call("navigate", protocol.NavigateRequest{SessionID: opened.SessionID, URL: destination}, nil)
+			}(destination)
+		}
+
+		Eventually(blocking.entered).Should(Receive())
+		Consistently(blocking.entered, 50*time.Millisecond).ShouldNot(Receive())
+		blocking.release <- struct{}{}
+		Eventually(results).Should(Receive(Succeed()))
+		Eventually(blocking.entered).Should(Receive())
+		blocking.release <- struct{}{}
+		Eventually(results).Should(Receive(Succeed()))
+		Expect(blocking.maxActive).To(Equal(1))
+	})
+})
+
+type testClient struct {
+	connection net.Conn
+	writer     *protocol.FramedWriter
+	nextID     atomic.Uint64
+	mu         sync.Mutex
+	pending    map[uint64]chan protocol.Response
+}
+
+func startTestServer(backend protocol.Backend) (*testClient, func()) {
+	clientConnection, serverConnection := net.Pipe()
+	server := protocol.NewServer(backend)
+	client := &testClient{connection: clientConnection, writer: protocol.NewFramedWriter(clientConnection), pending: map[uint64]chan protocol.Response{}}
+	go func() { _ = protocol.ServeStdio(context.Background(), server, serverConnection, serverConnection) }()
+	go client.readResponses()
+	return client, func() {
+		Expect(clientConnection.Close()).To(Succeed())
+		Expect(serverConnection.Close()).To(Succeed())
+		Expect(server.Close()).To(Succeed())
+	}
+}
+
+func (c *testClient) readResponses() {
+	reader := protocol.NewFramedReader(c.connection)
+	for {
+		var response protocol.Response
+		if reader.Read(&response) != nil {
+			return
+		}
+		c.mu.Lock()
+		pending := c.pending[response.ID]
+		delete(c.pending, response.ID)
+		c.mu.Unlock()
+		if pending != nil {
+			pending <- response
+		}
+	}
+}
+
+func (c *testClient) begin(method string, params any, timeoutMS int64) (uint64, <-chan protocol.Response) {
+	id := c.nextID.Add(1)
+	encoded, err := json.Marshal(params)
+	Expect(err).NotTo(HaveOccurred())
+	response := make(chan protocol.Response, 1)
+	c.mu.Lock()
+	c.pending[id] = response
+	c.mu.Unlock()
+	Expect(c.writer.Write(protocol.Request{ID: id, Method: method, Params: encoded, TimeoutMS: timeoutMS})).To(Succeed())
+	return id, response
+}
+
+func (c *testClient) call(method string, params any, result any) *protocol.ProtocolError {
+	return c.callWithTimeout(method, params, 0, result)
+}
+
+func (c *testClient) callWithTimeout(method string, params any, timeoutMS int64, result any) *protocol.ProtocolError {
+	_, responses := c.begin(method, params, timeoutMS)
+	response := <-responses
+	if response.Error != nil {
+		return response.Error
+	}
+	if result != nil {
+		encoded, err := json.Marshal(response.Result)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(json.Unmarshal(encoded, result)).To(Succeed())
+	}
+	return nil
+}
+
+func (c *testClient) cancel(requestID uint64) {
+	params, err := json.Marshal(protocol.CancelRequest{RequestID: requestID})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(c.writer.Write(protocol.Request{Method: "cancel", Params: params})).To(Succeed())
+}
+
+type fakeBackend struct {
+	mu      sync.Mutex
+	opened  int
+	session *fakeSession
+	custom  protocol.Session
+}
+
+func (b *fakeBackend) OpenSession(context.Context) (protocol.Session, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.opened++
+	if b.custom != nil {
+		return b.custom, nil
+	}
+	if b.session == nil {
+		b.session = &fakeSession{}
+	}
+	if b.session.started == nil {
+		b.session.started = make(chan struct{})
+	}
+	return b.session, nil
+}
+
+func (b *fakeBackend) Close() error { return nil }
+
+type blockingSession struct {
+	mu                sync.Mutex
+	active, maxActive int
+	entered           chan string
+	release           chan struct{}
+}
+
+func (*blockingSession) Prepare(context.Context) error { return nil }
+func (*blockingSession) Close() error                  { return nil }
+func (s *blockingSession) Execute(_ context.Context, operation protocol.Operation) (protocol.Result, error) {
+	s.mu.Lock()
+	s.active++
+	if s.active > s.maxActive {
+		s.maxActive = s.active
+	}
+	s.mu.Unlock()
+	s.entered <- operation.URL
+	<-s.release
+	s.mu.Lock()
+	s.active--
+	s.mu.Unlock()
+	return protocol.Result{Matched: true, Attempts: 1}, nil
+}
+
+// recordingSession keeps the last operation the server handed down, so a spec can pin what a wire
+// request actually decodes into.
+type recordingSession struct {
+	mu        sync.Mutex
+	operation protocol.Operation
+}
+
+func (*recordingSession) Prepare(context.Context) error { return nil }
+func (*recordingSession) Close() error                  { return nil }
+func (s *recordingSession) Execute(_ context.Context, operation protocol.Operation) (protocol.Result, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.operation = operation
+	return protocol.Result{Matched: true, Attempts: 1}, nil
+}
+
+func (s *recordingSession) lastOperation() protocol.Operation {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.operation
+}
+
+type fakeSession struct {
+	prepared, closed      int
+	blockNavigate         bool
+	started, cancelled    chan struct{}
+	startOnce, cancelOnce sync.Once
+	result                protocol.Result
+	executeErr            error
+}
+
+func (s *fakeSession) Prepare(context.Context) error { s.prepared++; return nil }
+func (s *fakeSession) Execute(ctx context.Context, operation protocol.Operation) (protocol.Result, error) {
+	if s.executeErr != nil {
+		return protocol.Result{}, s.executeErr
+	}
+	if s.blockNavigate && operation.Kind == protocol.OperationNavigate {
+		s.startOnce.Do(func() { close(s.started) })
+		<-ctx.Done()
+		s.cancelOnce.Do(func() { close(s.cancelled) })
+		return protocol.Result{}, ctx.Err()
+	}
+	if s.result.Attempts != 0 {
+		return s.result, nil
+	}
+	return protocol.Result{Matched: true, Attempts: 1}, nil
+}
+func (s *fakeSession) Close() error { s.closed++; return nil }

--- a/protocol/stdio.go
+++ b/protocol/stdio.go
@@ -1,0 +1,104 @@
+package protocol
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// ServeStdio serves concurrent requests over framed stdin/stdout. A request
+// with method "cancel" and id 0 cancels an in-flight request without producing
+// its own response.
+func ServeStdio(ctx context.Context, server *Server, input io.Reader, output io.Writer) error {
+	reader := NewFramedReader(input)
+	writer := NewFramedWriter(output)
+	ctx, cancelAll := context.WithCancel(ctx)
+	defer cancelAll()
+
+	var activeMu sync.Mutex
+	active := map[uint64]context.CancelFunc{}
+	var requests sync.WaitGroup
+	defer func() {
+		activeMu.Lock()
+		for _, cancel := range active {
+			cancel()
+		}
+		activeMu.Unlock()
+		requests.Wait()
+	}()
+
+	for {
+		var request Request
+		if err := reader.Read(&request); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || ctx.Err() != nil {
+				return nil
+			}
+			var malformed *MalformedFrameError
+			if errors.As(err, &malformed) {
+				// The header and payload were consumed in full, so the stream is still aligned on a
+				// frame boundary: this is one bad request, not a broken pipe, and the other sessions
+				// on this worker have done nothing to deserve losing their daemon.  A body that did
+				// not parse has no id to correlate against, so answer with id 0 exactly as the
+				// zero-id case below does - it cannot be routed to a caller, but it puts the bug on
+				// the wire instead of leaving the client to time out against a silent daemon.
+				if writeErr := writer.Write(Response{ID: 0, Error: NewError(CodeInvalidArgument, "malformed request frame: "+malformed.Err.Error())}); writeErr != nil {
+					return fmt.Errorf("write protocol response: %w", writeErr)
+				}
+				continue
+			}
+			return fmt.Errorf("read protocol request: %w", err)
+		}
+		if request.Method == "cancel" {
+			var cancelRequest CancelRequest
+			if decodeErr := decodeParams(request.Params, &cancelRequest); decodeErr == nil {
+				activeMu.Lock()
+				cancel := active[cancelRequest.RequestID]
+				activeMu.Unlock()
+				if cancel != nil {
+					cancel()
+				}
+			}
+			continue
+		}
+		if request.ID == 0 {
+			// A zero id is a client bug, not a desynced stream: the frame decoded fine, so keep
+			// serving.  Tearing the daemon down here would take every other session on this worker
+			// with it.  The response is uncorrelatable by definition; it exists so the bug shows up
+			// on the wire instead of as a bare "bilobad closed stdout".
+			if err := writer.Write(Response{ID: 0, Error: NewError(CodeInvalidArgument, "request id must be non-zero")}); err != nil {
+				return fmt.Errorf("write protocol response: %w", err)
+			}
+			continue
+		}
+
+		requestCtx, cancel := context.WithCancel(ctx)
+		if request.TimeoutMS > 0 {
+			requestCtx, cancel = context.WithTimeout(ctx, time.Duration(request.TimeoutMS)*time.Millisecond)
+		}
+		activeMu.Lock()
+		if _, duplicate := active[request.ID]; duplicate {
+			activeMu.Unlock()
+			cancel()
+			if err := writer.Write(Response{ID: request.ID, Error: NewError(CodeInvalidArgument, "duplicate request id")}); err != nil {
+				return fmt.Errorf("write protocol response: %w", err)
+			}
+			continue
+		}
+		active[request.ID] = cancel
+		activeMu.Unlock()
+
+		requests.Add(1)
+		go func(request Request) {
+			defer requests.Done()
+			defer cancel()
+			result, protocolErr := server.Dispatch(requestCtx, request.Method, request.Params)
+			activeMu.Lock()
+			delete(active, request.ID)
+			activeMu.Unlock()
+			_ = writer.Write(Response{ID: request.ID, Result: result, Error: protocolErr})
+		}(request)
+	}
+}

--- a/protocol/stdio.go
+++ b/protocol/stdio.go
@@ -78,7 +78,7 @@ func ServeStdio(ctx context.Context, server *Server, input io.Reader, output io.
 				// not parse has no id to correlate against, so answer with id 0 exactly as the
 				// zero-id case below does - it cannot be routed to a caller, but it puts the bug on
 				// the wire instead of leaving the client to time out against a silent daemon.
-				if writeErr := writer.Write(Response{ID: 0, Error: NewError(CodeInvalidArgument, "malformed request frame: "+malformed.Err.Error())}); writeErr != nil {
+				if writeErr := writeResponse(writer, Response{ID: 0, Error: NewError(CodeInvalidArgument, "malformed request frame: "+malformed.Err.Error())}); writeErr != nil {
 					return fmt.Errorf("write protocol response: %w", writeErr)
 				}
 				continue
@@ -102,21 +102,29 @@ func ServeStdio(ctx context.Context, server *Server, input io.Reader, output io.
 			// serving.  Tearing the daemon down here would take every other session on this worker
 			// with it.  The response is uncorrelatable by definition; it exists so the bug shows up
 			// on the wire instead of as a bare "bilobad closed stdout".
-			if err := writer.Write(Response{ID: 0, Error: NewError(CodeInvalidArgument, "request id must be non-zero")}); err != nil {
+			if err := writeResponse(writer, Response{ID: 0, Error: NewError(CodeInvalidArgument, "request id must be non-zero")}); err != nil {
 				return fmt.Errorf("write protocol response: %w", err)
 			}
 			continue
 		}
 
-		requestCtx, cancel := context.WithCancel(ctx)
+		// Exactly one derived context per request: assigning over a WithCancel context to add a
+		// deadline drops its cancel func on the floor, and the discarded child stays attached to the
+		// daemon-lifetime parent for as long as the daemon lives.  Clients send timeoutMs on nearly
+		// every request, so that leak accumulates for the life of the process.  Every path out of
+		// here calls the one cancel: the duplicate-id branch below, and the handler's defer.
+		var requestCtx context.Context
+		var cancel context.CancelFunc
 		if request.TimeoutMS > 0 {
 			requestCtx, cancel = context.WithTimeout(ctx, time.Duration(request.TimeoutMS)*time.Millisecond)
+		} else {
+			requestCtx, cancel = context.WithCancel(ctx)
 		}
 		activeMu.Lock()
 		if _, duplicate := active[request.ID]; duplicate {
 			activeMu.Unlock()
 			cancel()
-			if err := writer.Write(Response{ID: request.ID, Error: NewError(CodeInvalidArgument, "duplicate request id")}); err != nil {
+			if err := writeResponse(writer, Response{ID: request.ID, Error: NewError(CodeInvalidArgument, "duplicate request id")}); err != nil {
 				return fmt.Errorf("write protocol response: %w", err)
 			}
 			continue
@@ -132,7 +140,7 @@ func ServeStdio(ctx context.Context, server *Server, input io.Reader, output io.
 			activeMu.Lock()
 			delete(active, request.ID)
 			activeMu.Unlock()
-			if err := writer.Write(Response{ID: request.ID, Result: result, Error: protocolErr}); err != nil {
+			if err := writeResponse(writer, Response{ID: request.ID, Result: result, Error: protocolErr}); err != nil {
 				select {
 				case writeErrors <- err:
 				default:
@@ -140,4 +148,50 @@ func ServeStdio(ctx context.Context, server *Server, input io.Reader, output io.
 			}
 		}(request)
 	}
+}
+
+// writeResponse puts response on the wire, degrading a response the writer will not encode into an
+// error response rather than into a dead daemon.  An UnwritableFrameError is the writer saying it
+// rejected the value before writing a single byte, so the stream is still aligned on a frame
+// boundary: the session is intact and only that one request is lost.  The runner's poll trajectory
+// is uncapped, which makes an over-large response genuinely reachable - and one daemon carries every
+// session on the worker, so dying here would take all of them.
+//
+// A non-nil error from here is the other kind of failure: bytes did reach the stream, the frame is
+// half-written, and nothing downstream can resynchronize.  That one stays fatal and must surface to
+// the caller rather than being swallowed.
+func writeResponse(writer *FramedWriter, response Response) error {
+	err := writer.Write(response)
+	if err == nil {
+		return nil
+	}
+	var unwritable *UnwritableFrameError
+	if !errors.As(err, &unwritable) {
+		return err
+	}
+	return writer.Write(substituteForUnwritableResponse(response.ID, unwritable))
+}
+
+// substituteForUnwritableResponse builds the answer to send in place of a response that will not fit
+// in one frame.  DRIVER_ERROR is the code for the daemon failing to deliver on a request whose
+// arguments were fine - the same code normalizeError gives an unclassifiable daemon failure - rather
+// than INVALID_ARGUMENT, which would blame the caller for the daemon's own output.  The substitute
+// carries two integers and a bounded message, so it cannot fail the way the response it replaces
+// did.
+func substituteForUnwritableResponse(id uint64, unwritable *UnwritableFrameError) Response {
+	if unwritable.Size == 0 {
+		return Response{ID: id, Error: NewError(CodeDriver, "response could not be encoded: "+boundedDetail(unwritable.Err.Error()))}
+	}
+	return Response{ID: id, Error: NewError(CodeDriver, fmt.Sprintf("response is %d bytes; the protocol caps a single response at %d bytes", unwritable.Size, MaxFrameSize))}
+}
+
+// boundedDetail keeps detail borrowed from another error from reintroducing the size problem the
+// substitute exists to report.  A cut that lands mid-rune is fine: encoding/json replaces the
+// fragment rather than failing.
+func boundedDetail(message string) string {
+	const limit = 1024
+	if len(message) <= limit {
+		return message
+	}
+	return message[:limit] + "…(truncated)"
 }

--- a/protocol/stdio.go
+++ b/protocol/stdio.go
@@ -17,6 +17,30 @@ func ServeStdio(ctx context.Context, server *Server, input io.Reader, output io.
 	writer := NewFramedWriter(output)
 	ctx, cancelAll := context.WithCancel(ctx)
 	defer cancelAll()
+	type readResult struct {
+		request Request
+		err     error
+	}
+	reads := make(chan readResult, 1)
+	go func() {
+		for {
+			var request Request
+			err := reader.Read(&request)
+			select {
+			case reads <- readResult{request: request, err: err}:
+			case <-ctx.Done():
+				return
+			}
+			if err != nil {
+				var malformed *MalformedFrameError
+				if errors.As(err, &malformed) {
+					continue
+				}
+				return
+			}
+		}
+	}()
+	writeErrors := make(chan error, 1)
 
 	var activeMu sync.Mutex
 	active := map[uint64]context.CancelFunc{}
@@ -32,7 +56,17 @@ func ServeStdio(ctx context.Context, server *Server, input io.Reader, output io.
 
 	for {
 		var request Request
-		if err := reader.Read(&request); err != nil {
+		select {
+		case <-ctx.Done():
+			return nil
+		case err := <-writeErrors:
+			return fmt.Errorf("write protocol response: %w", err)
+		case read := <-reads:
+			request = read.request
+			if read.err == nil {
+				break
+			}
+			err := read.err
 			if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) || ctx.Err() != nil {
 				return nil
 			}
@@ -98,7 +132,12 @@ func ServeStdio(ctx context.Context, server *Server, input io.Reader, output io.
 			activeMu.Lock()
 			delete(active, request.ID)
 			activeMu.Unlock()
-			_ = writer.Write(Response{ID: request.ID, Result: result, Error: protocolErr})
+			if err := writer.Write(Response{ID: request.ID, Result: result, Error: protocolErr}); err != nil {
+				select {
+				case writeErrors <- err:
+				default:
+				}
+			}
 		}(request)
 	}
 }

--- a/protocol/stdio_test.go
+++ b/protocol/stdio_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"time"
@@ -155,7 +156,29 @@ var _ = Describe("serving requests over framed stdio", func() {
 		Expect(blocking.cancelled).To(BeClosed(), "ServeStdio must cancel in-flight work before returning, not orphan it")
 		Expect(serverConnection.Close()).To(Succeed())
 	})
+
+	It("returns an asynchronous response write failure even while input remains open", func() {
+		clientConnection, serverConnection := net.Pipe()
+		server := protocol.NewServer(&fakeBackend{})
+		DeferCleanup(func() { Expect(server.Close()).To(Succeed()) })
+		served := make(chan error, 1)
+		go func() {
+			served <- protocol.ServeStdio(context.Background(), server, serverConnection, failingWriter{})
+		}()
+
+		Expect(protocol.NewFramedWriter(clientConnection).Write(protocol.Request{
+			ID: 1, Method: "handshake", Params: json.RawMessage(`{"protocolVersion":"1"}`),
+		})).To(Succeed())
+
+		Eventually(served, time.Second).Should(Receive(MatchError(ContainSubstring("write protocol response"))))
+		Expect(clientConnection.Close()).To(Succeed())
+		Expect(serverConnection.Close()).To(Succeed())
+	})
 })
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, errors.New("output is closed") }
 
 // beginRaw is begin for a payload that is deliberately not the shape the method expects.
 func (c *testClient) beginRaw(method string, params json.RawMessage, timeoutMS int64) (uint64, <-chan protocol.Response) {

--- a/protocol/stdio_test.go
+++ b/protocol/stdio_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/onsi/biloba/protocol"
@@ -77,6 +78,31 @@ var _ = Describe("serving requests over framed stdio", func() {
 		Eventually(responses).Should(Receive(&response))
 		Expect(response.Error.Code).To(Equal(protocol.CodeInvalidArgument))
 		Expect(response.Error.Message).To(ContainSubstring("malformed request frame"))
+		stillServing()
+	})
+
+	It("answers a response too large to frame instead of tearing the daemon down", func() {
+		// The writer rejects an over-large frame before it writes a byte, so the stream is still
+		// aligned: this costs the one request, not the daemon that carries every other session on
+		// this worker.  Nothing caps a poll trajectory, so a response can genuinely grow past the
+		// frame limit - and the caller has to hear about it rather than wait out its timeout.
+		backend.session = &fakeSession{result: protocol.Result{
+			Matched: true, Attempts: 1, ObservedJSON: strings.Repeat("x", protocol.MaxFrameSize+1),
+		}}
+		var opened protocol.OpenSessionResponse
+		Expect(client.call("openSession", struct{}{}, &opened)).To(Succeed())
+
+		// Eventually rather than a bare receive: a regression here does not answer at all, and that
+		// has to fail this spec rather than hang the suite waiting on a daemon that has gone away.
+		_, responses := client.begin("assert", protocol.AssertRequest{
+			SessionID: opened.SessionID,
+			Assertion: &protocol.WireAssertion{Kind: "TEXT", Locator: &protocol.WireLocator{Kind: "CSS", Value: "#status"}, ExpectedString: "ready"},
+		}, 0)
+
+		var response protocol.Response
+		Eventually(responses, time.Second).Should(Receive(&response))
+		Expect(response.Error.Code).To(Equal(protocol.CodeDriver))
+		Expect(response.Error.Message).To(ContainSubstring("the protocol caps a single response"))
 		stillServing()
 	})
 

--- a/protocol/stdio_test.go
+++ b/protocol/stdio_test.go
@@ -1,0 +1,186 @@
+package protocol_test
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"net"
+	"time"
+
+	"github.com/onsi/biloba/protocol"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// One worker owns one daemon and one daemon owns every session that worker is driving, so a
+// malformed or hostile request has to cost that request rather than the process.  These specs pin
+// the blast radius: after each of them the same connection must still answer.
+var _ = Describe("serving requests over framed stdio", func() {
+	var client *testClient
+	var backend *fakeBackend
+
+	BeforeEach(func() {
+		backend = &fakeBackend{}
+		var cleanup func()
+		client, cleanup = startTestServer(backend)
+		DeferCleanup(cleanup)
+	})
+
+	// stillServing proves the connection survived whatever the previous request did to it.
+	stillServing := func() {
+		GinkgoHelper()
+		var response protocol.HandshakeResponse
+		Expect(client.call("handshake", protocol.HandshakeRequest{ProtocolVersion: protocol.Version}, &response)).To(Succeed())
+		Expect(response.ProtocolVersion).To(Equal(protocol.Version))
+	}
+
+	It("rejects an unknown method and keeps serving", func() {
+		err := client.call("teleport", struct{}{}, nil)
+
+		Expect(err.Code).To(Equal(protocol.CodeInvalidArgument))
+		Expect(err.Message).To(ContainSubstring(`unsupported method "teleport"`))
+		stillServing()
+	})
+
+	It("rejects params that are not the shape the method expects", func() {
+		_, responses := client.beginRaw("navigate", json.RawMessage(`{"sessionId": 17}`), 0)
+		response := <-responses
+
+		Expect(response.Error.Code).To(Equal(protocol.CodeInvalidArgument))
+		Expect(response.Error.Message).To(ContainSubstring("invalid request parameters"))
+		stillServing()
+	})
+
+	It("answers a zero request id instead of tearing the daemon down", func() {
+		// A zero id cannot be correlated, so the answer is the point: the daemon has to survive a
+		// client that sends one, because every other session on this worker rides the same pipe.
+		responses := client.watch(0)
+		Expect(client.writer.Write(protocol.Request{ID: 0, Method: "handshake"})).To(Succeed())
+
+		var response protocol.Response
+		Eventually(responses).Should(Receive(&response))
+		Expect(response.Error.Code).To(Equal(protocol.CodeInvalidArgument))
+		Expect(response.Error.Message).To(ContainSubstring("non-zero"))
+		stillServing()
+	})
+
+	It("answers a malformed frame body instead of tearing the daemon down", func() {
+		// The length prefix was honoured and the payload was consumed in full, so the stream is
+		// still aligned: only that one request is garbage.  Killing the daemon here would take
+		// every other session on this worker with it.
+		responses := client.watch(0)
+		Expect(writeRawFrame(client.connection, []byte(`{"id": 3, "method": `))).To(Succeed())
+
+		var response protocol.Response
+		Eventually(responses).Should(Receive(&response))
+		Expect(response.Error.Code).To(Equal(protocol.CodeInvalidArgument))
+		Expect(response.Error.Message).To(ContainSubstring("malformed request frame"))
+		stillServing()
+	})
+
+	It("ends the loop when the stream itself is desynced", func() {
+		// A truncated frame is the other kind of failure: the reader cannot know where the next
+		// frame starts, so there is nothing left to serve and pretending otherwise would answer
+		// garbage forever.
+		clientConnection, serverConnection := net.Pipe()
+		server := protocol.NewServer(&fakeBackend{})
+		DeferCleanup(func() { Expect(server.Close()).To(Succeed()) })
+		served := make(chan error, 1)
+		go func() { served <- protocol.ServeStdio(context.Background(), server, serverConnection, io.Discard) }()
+
+		var header [4]byte
+		binary.LittleEndian.PutUint32(header[:], 64)
+		_, err := clientConnection.Write(append(header[:], []byte(`{"id":1}`)...))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clientConnection.Close()).To(Succeed())
+
+		Eventually(served, time.Second).Should(Receive(MatchError(ContainSubstring("read protocol request"))))
+		Expect(serverConnection.Close()).To(Succeed())
+	})
+
+	It("rejects a duplicate in-flight id without disturbing the original request", func() {
+		backend.session = &fakeSession{blockNavigate: true, cancelled: make(chan struct{})}
+		var opened protocol.OpenSessionResponse
+		Expect(client.call("openSession", struct{}{}, &opened)).To(Succeed())
+		id, _ := client.begin("navigate", protocol.NavigateRequest{SessionID: opened.SessionID, URL: "https://example.test"}, 0)
+		Eventually(backend.session.started).Should(BeClosed())
+
+		// same id, while the first one is still in flight
+		duplicate := client.watch(id)
+		Expect(client.writer.Write(protocol.Request{ID: id, Method: "handshake"})).To(Succeed())
+		var response protocol.Response
+		Eventually(duplicate).Should(Receive(&response))
+		Expect(response.Error.Code).To(Equal(protocol.CodeInvalidArgument))
+		Expect(response.Error.Message).To(ContainSubstring("duplicate request id"))
+
+		// the original is untouched: it is still running, and still the request that id cancels
+		original := client.watch(id)
+		Consistently(original, 50*time.Millisecond).ShouldNot(Receive())
+		client.cancel(id)
+		Eventually(original).Should(Receive(&response))
+		Expect(response.Error.Code).To(Equal(protocol.CodeCancelled))
+		Eventually(backend.session.cancelled).Should(BeClosed())
+		stillServing()
+	})
+
+	It("ignores a cancellation for a request that is not in flight", func() {
+		client.cancel(4242)
+
+		stillServing()
+	})
+
+	It("cancels in-flight work when the stream ends rather than leaking the request", func() {
+		// A vitest worker that dies takes its end of the pipe with it.  The daemon has to unwind
+		// the request that was running, or Chrome keeps doing work nobody is waiting for.
+		blocking := &fakeSession{blockNavigate: true, cancelled: make(chan struct{}), started: make(chan struct{})}
+		clientConnection, serverConnection := net.Pipe()
+		server := protocol.NewServer(&fakeBackend{session: blocking})
+		DeferCleanup(func() { Expect(server.Close()).To(Succeed()) })
+		served := make(chan error, 1)
+		go func() {
+			served <- protocol.ServeStdio(context.Background(), server, serverConnection, serverConnection)
+		}()
+		peer := &testClient{connection: clientConnection, writer: protocol.NewFramedWriter(clientConnection), pending: map[uint64]chan protocol.Response{}}
+		go peer.readResponses()
+
+		var opened protocol.OpenSessionResponse
+		Expect(peer.call("openSession", struct{}{}, &opened)).To(Succeed())
+		peer.begin("navigate", protocol.NavigateRequest{SessionID: opened.SessionID, URL: "https://example.test"}, 0)
+		Eventually(blocking.started).Should(BeClosed())
+
+		Expect(clientConnection.Close()).To(Succeed())
+
+		Eventually(served, time.Second).Should(Receive(Succeed()))
+		Expect(blocking.cancelled).To(BeClosed(), "ServeStdio must cancel in-flight work before returning, not orphan it")
+		Expect(serverConnection.Close()).To(Succeed())
+	})
+})
+
+// beginRaw is begin for a payload that is deliberately not the shape the method expects.
+func (c *testClient) beginRaw(method string, params json.RawMessage, timeoutMS int64) (uint64, <-chan protocol.Response) {
+	GinkgoHelper()
+	id := c.nextID.Add(1)
+	response := c.watch(id)
+	Expect(c.writer.Write(protocol.Request{ID: id, Method: method, Params: params, TimeoutMS: timeoutMS})).To(Succeed())
+	return id, response
+}
+
+// watch registers interest in an id the test is about to write by hand, so a response the client
+// would otherwise drop on the floor can be asserted on.
+func (c *testClient) watch(id uint64) <-chan protocol.Response {
+	response := make(chan protocol.Response, 1)
+	c.mu.Lock()
+	c.pending[id] = response
+	c.mu.Unlock()
+	return response
+}
+
+// writeRawFrame writes a payload the FramedWriter would refuse to produce: a well-framed body that
+// is not valid JSON.
+func writeRawFrame(writer io.Writer, payload []byte) error {
+	var header [4]byte
+	binary.LittleEndian.PutUint32(header[:], uint32(len(payload)))
+	_, err := writer.Write(append(header[:], payload...))
+	return err
+}

--- a/protocol/stdio_test.go
+++ b/protocol/stdio_test.go
@@ -100,7 +100,7 @@ var _ = Describe("serving requests over framed stdio", func() {
 		}, 0)
 
 		var response protocol.Response
-		Eventually(responses, time.Second).Should(Receive(&response))
+		Eventually(responses, 5*time.Second).Should(Receive(&response))
 		Expect(response.Error.Code).To(Equal(protocol.CodeDriver))
 		Expect(response.Error.Message).To(ContainSubstring("the protocol caps a single response"))
 		stillServing()

--- a/protocol/testdata/golden/handshake-request.json
+++ b/protocol/testdata/golden/handshake-request.json
@@ -1,0 +1,7 @@
+{
+  "id": 1,
+  "method": "handshake",
+  "params": {
+    "protocolVersion": "1"
+  }
+}

--- a/protocol/testdata/golden/operation-response.json
+++ b/protocol/testdata/golden/operation-response.json
@@ -1,0 +1,26 @@
+{
+  "id": 9,
+  "result": {
+    "matched": true,
+    "observedJson": "\"Saved\"",
+    "attemptCount": 2,
+    "trajectory": [
+      {
+        "attempt": 1,
+        "elapsedMs": 0,
+        "observedJson": "\"Saving\""
+      },
+      {
+        "attempt": 2,
+        "elapsedMs": 10,
+        "observedJson": "\"Saved\""
+      }
+    ],
+    "timings": {
+      "startedUnixMs": 1700000000000,
+      "elapsedMs": 10
+    },
+    "rpcRequestCount": 1,
+    "rpcResponseCount": 1
+  }
+}

--- a/protocol/testdata/golden/protocol-error-response.json
+++ b/protocol/testdata/golden/protocol-error-response.json
@@ -1,0 +1,7 @@
+{
+  "id": 7,
+  "error": {
+    "code": "PROTOCOL_MISMATCH",
+    "message": "protocol version mismatch"
+  }
+}

--- a/typescript/src/generated/protocol.ts
+++ b/typescript/src/generated/protocol.ts
@@ -1,0 +1,156 @@
+// Code generated from the Go protocol definition; DO NOT EDIT.
+
+export type ErrorCode =
+  | "INVALID_ARGUMENT"
+  | "TIMEOUT"
+  | "TARGET_NOT_FOUND"
+  | "TARGET_NOT_READY"
+  | "JAVASCRIPT_ERROR"
+  | "PROTOCOL_MISMATCH"
+  | "DRIVER_CLOSED"
+  | "DRIVER_ERROR"
+  | "CANCELLED"
+  | "BROWSER_GONE"
+  | "PAGE_CRASHED"
+;
+
+export interface Diagnostics {
+  locator?: string;
+  expected?: string;
+  domOutline?: string;
+  screenshotPath?: string;
+  daemonDetail?: string;
+}
+
+export interface ProtocolError {
+  code: ErrorCode;
+  message: string;
+  diagnostics?: Diagnostics;
+}
+
+export interface Request {
+  id: number;
+  method: string;
+  params?: unknown;
+  timeoutMs?: number;
+}
+
+export interface HandshakeRequest {
+  protocolVersion: string;
+}
+
+export interface HandshakeResponse {
+  protocolVersion: string;
+  capabilities: string[];
+}
+
+export interface OpenSessionResponse {
+  sessionId: string;
+}
+
+export interface SessionRequest {
+  sessionId: string;
+}
+
+export interface NavigateRequest {
+  sessionId: string;
+  url: string;
+}
+
+export interface PollOptions {
+  timeoutMs?: number;
+  intervalMs?: number;
+}
+
+export interface Locator {
+  kind: "CSS" | "TEST_ID" | "TEXT" | "ROLE";
+  value?: string;
+  role?: string;
+  name?: string;
+  match?: "EXACT" | "CONTAINS";
+  first: boolean;
+}
+
+export interface Cookie {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+  expiresUnix?: number;
+  secure?: boolean;
+  httpOnly?: boolean;
+  sameSite?: string;
+}
+
+export interface SetCookiesRequest {
+  sessionId: string;
+  cookies: Cookie[];
+}
+
+export interface LocatorRequest {
+  sessionId: string;
+  locator?: Locator;
+  poll?: PollOptions;
+}
+
+export interface SetValueRequest {
+  sessionId: string;
+  locator?: Locator;
+  valueJson: string;
+  poll?: PollOptions;
+}
+
+export interface EvaluateRequest {
+  sessionId: string;
+  expression: string;
+  argumentsJson?: string;
+  invoke?: boolean;
+}
+
+export interface Assertion {
+  kind: "VISIBLE" | "TEXT" | "COUNT" | "ATTRIBUTE" | "VALUE" | "URL" | "EVALUATE";
+  locator?: Locator;
+  attribute?: string;
+  expression?: string;
+  expectedString?: string;
+  expectedCount?: number;
+  expectedJson?: string;
+  match?: "EXACT" | "CONTAINS";
+}
+
+export interface AssertRequest {
+  sessionId: string;
+  assertion?: Assertion;
+  poll?: PollOptions;
+}
+
+export interface PollObservation {
+  attempt: number;
+  elapsedMs: number;
+  observedJson?: string;
+  retryReason?: string;
+}
+
+export interface Timings {
+  startedUnixMs: number;
+  elapsedMs: number;
+}
+
+export interface OperationResult {
+  matched: boolean;
+  observedJson?: string;
+  attemptCount: number;
+  trajectory?: PollObservation[];
+  timings: Timings;
+  diagnostics?: Diagnostics;
+  rpcRequestCount: number;
+  rpcResponseCount: number;
+}
+
+export interface Response<Result = unknown> {
+  id: number;
+  result?: Result;
+  error?: ProtocolError;
+}
+
+export type OpenSessionRequest = Record<string, never>;


### PR DESCRIPTION
**Stack 3 of 17** · base [#18](https://github.com/onsi/biloba/pull/18) · next: [#20](https://github.com/onsi/biloba/pull/20)

`protocol` is the boundary between Go and TypeScript: 4-byte little-endian length-prefixed JSON over stdin and stdout. The Go wire structs are the single definition, and `go generate ./protocol` produces the TypeScript declarations and golden frames from them.

`bilobad` is the daemon that serves the protocol on top of `engine`. Each test-runner worker gets one, and they all attach to a shared Chrome.

Everything here is additive. Nothing outside `protocol/` and `cmd/bilobad/` changes, except the generated `typescript/src/generated/protocol.ts`, which `protocol`'s own specs check.

## Design decisions worth challenging

**The daemon does the polling.** One request covers as many attempts as it takes, and the response carries the whole attempt history. A client never loops over RPCs, and a timeout can report what it saw on each attempt. The result includes `RPCRequestCount` and `RPCResponseCount` so that a client-side retry loop would be visible if one ever crept in.

**A bad request costs you the request, not the daemon.** One worker's daemon owns every session that worker drives, so shutting it down over a single malformed message also kills unrelated work. An unknown method, mis-shaped params, a duplicate in-flight ID, a zero ID, or a frame whose body doesn't parse all get error responses while the loop keeps serving.

Only a genuinely desynchronized stream ends the loop. That's what `MalformedFrameError` distinguishes: the header and payload were read in full and the stream is still frame-aligned, so one message was bad, rather than the bytes being untrustworthy.

**Failures get names instead of timing out.** `BROWSER_GONE`, `PAGE_CRASHED`, and `DRIVER_CLOSED` are three different problems, and a client can act on each. Reporting any of them as an assertion timeout tells the reader their page never reached the expected state, and sends them off to debug a test that was fine.

**Diagnostics come out of the request deadline** rather than a fixed two seconds, so a timed-out assertion's attempt history, DOM outline, and screenshot reach the client instead of losing a race against the client's own timer.

## Two failures found while reviewing this stack

The last commit fixes both.

**An unwritable response killed the daemon.** `FramedWriter` validates a frame before writing any bytes, so a response that won't encode, or that exceeds `MaxFrameSize`, leaves the stream on a frame boundary. `ServeStdio` treated that as fatal and returned, taking every other session on the worker with it. The runner's attempt history has no size limit, so an over-large response is reachable in practice.

`Write` now returns a typed `UnwritableFrameError`, which mirrors `MalformedFrameError` on the read side. `ServeStdio` uses it to tell "no bytes reached the stream, so recover and keep serving" from "the frame is half-written, so stop."

**Every request leaked a context.** When `TimeoutMS` was set, the code built a `WithCancel` context, then assigned a `WithTimeout` context over it and dropped the first cancel function. Each request left a `cancelCtx` attached to the daemon-lifetime parent. Clients send `timeoutMs` on nearly every request, so this accumulated for the life of the process.

## Two guards on the generated files

`encoding_test.go` marshals every response type and compares the emitted keys against what the generated TypeScript declares as required. This catches `omitempty` on a struct, which does nothing in Go: a field can be declared optional in TypeScript and still be present in every response. That's exactly how an empty `"diagnostics":{}` was riding along on every successful operation.

`generated_test.go` checks the files against the generator, not against git. "Does the tree match the last commit?" is the wrong question, and it gets the answer wrong in both directions: it passes a staged file that has diverged, and it fails a working tree you just regenerated correctly.

## Verification

At this commit: Biloba 1037/1037, Engine 23/23, Protocol 35/35, Bilobad 15/15. The protocol suite is also green under `--race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)