### PR TITLE
4/17 typescript: the client, and the harness that proves it

### DIFF
--- a/.claude/skills/biloba-testing/SKILL.md
+++ b/.claude/skills/biloba-testing/SKILL.md
@@ -16,6 +16,9 @@ The `Makefile` wraps the canonical invocations — prefer these:
 | `make test` | headless (chrome-headless-shell), parallel + randomized | your default, every change |
 | `make test-all` | `make test`, then the same suite in full ("new") headless google-chrome (`BILOBA_TEST_HIGH_FIDELITY=true`) | before changes touching tab/Chrome lifecycle — both lanes are what CI runs |
 | `make stress-test` | 6 procs under moderate CPU/IO load (`stress`), 41 repeats, generous total budget | **only periodically, or when you suspect a change might be flaky** — it's slow and needs `stress` (`brew install stress`) |
+| `make driver-test` | the Go driver packages (`./engine ./protocol ./cmd/bilobad`, including the generated-protocol and biloba.js drift specs) and the TypeScript unit suites | when touching `engine/`, `protocol/`, `cmd/bilobad/`, or `typescript/` |
+| `make driver-parity` | the Go/TypeScript parity contract: a real `bilobad` driving a real shared Chrome, asserted against the same fixture from both languages | same, plus before trusting a new vertical slice |
+| `make driver-e2e` | the shipping topology: three vitest worker *processes*, one `bilobad` each, one shared Chrome | before anything touching session isolation, daemon lifecycle, or shared-browser attach/detach |
 
 Under the hood `make test` is just `ginkgo -r -p --randomize-all`. `-p` (parallel) is the realistic mode — Biloba is built for it (one shared Chrome, one isolated root tab per process); `--randomize-all` enforces spec independence.
 
@@ -27,6 +30,109 @@ To focus while debugging, run in serial and optionally non-headless/interactive:
 ginkgo --focus="..."                 # serial, easier to read
 BILOBA_INTERACTIVE=true ginkgo       # headed; pauses on failure until ^C (serial, few specs)
 ```
+
+### The driver lanes, and why they refuse to skip
+
+CI runs every one of these (`.github/workflows/test.yml`). Two rules keep them honest:
+
+- **The engine suite fails rather than skips when it cannot find Chrome.** It resolves the binary
+  through `engine.LocateChrome("")` — the same search the Go suite and `bilobad` use (explicit path
+  → `BILOBA_CHROME_HEADLESS_SHELL` → `$PATH` → the puppeteer/Biloba caches). It is the only guard
+  that `engine/biloba.js` still matches the canonical `biloba.js`, so a quiet skip there means the
+  copy can drift unnoticed. If it fails, run `make update-chrome`.
+- **`typescript/test/parity.test.ts` fails rather than skips when `BILOBA_DAEMON_EXECUTABLE` is
+  unset.** It is the only test that exercises the real daemon end to end; "4 skipped, exit 0" is
+  indistinguishable from "4 passed" at a glance. Run it via `make driver-parity` (which builds the
+  daemon first). To opt out on purpose, set `BILOBA_SKIP_PARITY=true`.
+
+`bilobad` resolves Chrome itself, so neither lane needs a browser environment variable.
+
+`make driver-test` deliberately does *not* run `go generate ./engine` — regenerating
+`engine/biloba.js` there would silently repair the drift the engine suite exists to catch. Run
+`go generate ./engine` yourself after editing `biloba.js`.
+
+### The e2e suite tests the topology, not an approximation of it
+
+`typescript/test/e2e/` is the only place the shipping arrangement — N worker processes, one daemon
+each, one shared Chrome — exists as such. `globalSetup` starts the single Chrome in the main process
+and provides its websocket URL; each test *file* becomes its own forked worker with its own daemon.
+
+The `rendezvous()` barriers in `test/e2e/harness.ts` are load-bearing twice over. They order the
+workers so an assertion happens while the others are demonstrably live, **and** they are the proof
+that the workers are concurrent processes at all: run the files serially and the first one blocks
+until it times out. A green run is therefore evidence of the topology. If you add a worker file,
+update the expected count in every `rendezvous()` call — a stale count makes the barrier release
+early and quietly stops proving anything.
+
+`crash.e2e.test.ts` runs in a second vitest invocation with a Chrome of its own, because it kills
+things on purpose. Its specs run in a deliberate order — the recoverable crashes first, the terminal
+one (killing Chrome) last — and vitest runs `it`s in source order, so that ordering is local and
+explicit rather than a property of how files happen to get scheduled.
+
+Every case in it pins a *diagnosis*. A crash reported as an assertion timeout is worse than useless:
+it says the page never reached the expected state, sending the reader to debug a test that was fine.
+The four covered: a crashed renderer (`PAGE_CRASHED`, recoverable by navigating), a dead browser
+(`BROWSER_GONE`), a worker killed without teardown (its daemon reaps itself, Chrome and the other
+workers are untouched), and Chrome unreachable at daemon startup (`DRIVER_CLOSED` with the daemon's
+stderr attached).
+
+Two of those carry timing bounds, and the bounds are the point rather than decoration: CDP does not
+*fail* calls against a dead renderer or a dead browser, it stops answering them, so both used to sit
+until their deadline and then report a timeout. Loosening those bounds would let the old behaviour
+back in silently.
+
+The isolation assertion is self-evidencing for the same reason: all three workers set
+`owner=<name>` on the *same* origin, so three different values coexisting is exactly what browser-
+context isolation means. If it broke, they would see each other's.
+
+### Two guards on the wire protocol
+
+`protocol/` is the Go↔TypeScript boundary, and it has a guard on each side that you should extend
+rather than work around:
+
+- `protocol/encoding_test.go` marshals every response type and compares the keys that actually
+  appear against the keys the **generated** TypeScript declares required. This is what catches
+  `omitempty` on a struct (a no-op in Go: the field ships on every response while TypeScript calls
+  it optional — make the Go field a pointer). When you add a wire field, add its type to the table.
+- `typescript/test/protocol-golden.test.ts` asserts the goldens with `toEqual`, not
+  `toMatchObject`, so a field the daemon starts or stops emitting is a failure rather than a
+  silently-ignored extra key.
+
+`protocol/generated_test.go` is the drift guard for the generated TypeScript and golden frames: it
+renders them from the Go wire structs and compares against what is on disk. It deliberately does not
+shell out to git — "does the tree match the last commit?" is the wrong question (it passes a staged
+divergent file and fails a working tree you just regenerated correctly), so nothing here needs you to
+commit before the check goes green. After editing the wire structs, run `go generate ./protocol` and
+commit the generated files alongside the change.
+
+Two conventions the wire specs enforce, worth knowing before you add a method:
+
+- **A bad request costs the request, not the daemon.** One worker's daemon owns every session that
+  worker is driving, so an unknown method, mis-shaped params, a duplicate in-flight id, a zero id, or
+  an unparseable frame body are all answered as errors while the loop keeps going. Only a genuinely
+  desynced stream (short read, bad length prefix) ends it. `protocol/stdio_test.go` pins each case
+  with a `stillServing()` call afterwards — follow that shape.
+- **A stub daemon and the real one answer to one contract.** `typescript/test/support/assertions.ts`
+  holds the invariants a timed-out operation owes; both `client.test.ts` (fast, stub) and
+  `parity.test.ts` (slow, real `bilobad`) assert through it. Generated types constrain the *shape* a
+  stub can send, but nothing constrains its *behaviour* — a stub is free to claim a failed click
+  succeeded. Sharing the assertion is what stops that: it caught the stub reporting a timed-out
+  click with an empty trajectory, which the real daemon cannot produce. Put invariants there and
+  payload specifics at the call site.
+- **Some failures are not worth retrying.** `engine.Poll` stops immediately on a fatal attempt
+  error — the engine's runner-neutral answer to `gomega.StopTrying`, which the Go API already uses
+  for the same reason (`capture.go`, `visual.go`, `cookie_matchers.go`: a decode into the wrong
+  pointer type, a missing baseline, a selector that will never parse). Mark one with
+  `engine.Fatal(err)`, or give an `engine.Error` a code whose `Fatal()` is true. Getting this wrong
+  is expensive in a specific way: the poll burns its whole budget and then reports a *timeout*,
+  attributing to the page a failure that was never about the page. The line to walk: a
+  `ReferenceError` or `TypeError` is the ordinary shape of "not there yet" (biloba.js not installed,
+  an element not rendered) and must stay retryable; a `SyntaxError` cannot start parsing later, so it
+  is fatal. Same for a malformed *expectation* — invalid `expectedJson` is the caller's bug, not a
+  page that has not settled.
+- **Meaning goes on the wire, not into inference.** `evaluate` carries an explicit `invoke` flag
+  rather than guessing from whether the argument array is empty. If you find yourself deriving one
+  field's meaning from another's emptiness, add the field instead.
 
 ## Suite setup (`biloba_suite_test.go`)
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,3 +59,35 @@ jobs:
     # ConnectToChrome's retry/backoff; the one-time full google-chrome launch gets a roomier
     # WSURLReadTimeout (see SpinUpChrome) since a cold runner can take >20s to expose DevTools.
     - run: go run github.com/onsi/ginkgo/v2/ginkgo -r --randomize-all --fail-on-pending --keep-going --race -procs=2 --poll-progress-after=30s --timeout=8m
+
+  driver:
+    runs-on: ubuntu-latest
+    name: Test (TypeScript driver + daemon)
+    steps:
+    - uses: actions/checkout@v5
+    - uses: actions/setup-go@v6
+      with:
+        go-version-file: 'go.mod'
+    - uses: pnpm/action-setup@v4
+      with:
+        package_json_file: typescript/package.json
+    - uses: actions/setup-node@v5
+      with:
+        node-version: 22
+        cache: pnpm
+        cache-dependency-path: typescript/pnpm-lock.yaml
+    # See the note in the build job: Chrome's sandbox needs unprivileged user namespaces.
+    - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+    # bilobad and the engine suite resolve Chrome through engine.LocateChrome, which searches the
+    # puppeteer cache this populates.  Installing it explicitly (rather than relying on the Go
+    # suite's auto-install side effect) keeps this job independent of job ordering.
+    - run: npx -y @puppeteer/browsers install chrome-headless-shell@stable --path "$HOME/.cache/puppeteer"
+    # Regenerated protocol types/goldens must match what is committed, TypeScript must typecheck
+    # and build, and the Go driver packages must pass - including the engine suite's guard that
+    # engine/biloba.js has not drifted from the canonical biloba.js.
+    - run: make driver-test
+    # The real daemon, driving a real shared Chrome, reaching the same observable outcome as the
+    # Go API.  Fails (not skips) if it is not configured.
+    - run: make driver-parity
+    # The shipping topology: three worker processes, one daemon each, one shared Chrome.
+    - run: make driver-e2e

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 GINKGO := go run github.com/onsi/ginkgo/v2/ginkgo
 
-.PHONY: test test-all stress-test update-chrome
+.PHONY: test test-all stress-test update-chrome driver-test driver-parity driver-e2e
 
 ## test: standard headless (chrome-headless-shell) suite - parallel + randomized. Your default.
 test:
@@ -16,6 +16,35 @@ test:
 test-all:
 	$(GINKGO) -r -p --randomize-all
 	BILOBA_TEST_HIGH_FIDELITY=true $(GINKGO) -r -p --randomize-all
+
+## driver-test: Go driver packages and TypeScript unit coverage.
+## Deliberately does NOT regenerate anything: `go generate ./engine` here would silently repair the
+## engine/biloba.js drift the engine suite exists to catch, and `go generate ./protocol` would do the
+## same for the generated types.  Both are guarded by specs instead (engine_test.go's drift spec and
+## protocol/generated_test.go), which compare what is on disk against what the generator renders -
+## so they are right on a dirty working tree too.  Run the generators yourself after editing
+## biloba.js or the protocol wire structs.
+driver-test:
+	cd typescript && pnpm install --frozen-lockfile && pnpm test && pnpm typecheck && pnpm build
+	$(GINKGO) --randomize-all ./engine ./protocol ./cmd/bilobad
+
+## driver-parity: run the shared Go/TypeScript behavior contract against the same fixture.
+## bilobad resolves Chrome itself (same search as the Go suite), so this needs no browser env var.
+## The TypeScript half fails rather than skips when it is misconfigured - see parity.test.ts.
+driver-parity:
+	mkdir -p .bin
+	go build -o .bin/bilobad ./cmd/bilobad
+	$(GINKGO) --randomize-all --focus="TypeScript driver parity contract" .
+	cd typescript && pnpm install --frozen-lockfile && BILOBA_DAEMON_EXECUTABLE="$(CURDIR)/.bin/bilobad" pnpm test:parity
+
+## driver-e2e: the topology itself - three vitest worker processes, one bilobad each, all sharing a
+## single Chrome.  Every other suite approximates this from inside one process; this one does not.
+## The suite's rendezvous barriers double as the proof that the workers really are concurrent: run
+## the files serially and they time out rather than passing vacuously.
+driver-e2e:
+	mkdir -p .bin
+	go build -o .bin/bilobad ./cmd/bilobad
+	cd typescript && pnpm install --frozen-lockfile && BILOBA_DAEMON_EXECUTABLE="$(CURDIR)/.bin/bilobad" pnpm test:e2e
 
 ## update-chrome: pull the latest stable chrome-headless-shell into the puppeteer cache Biloba
 ## searches first (~/.cache/puppeteer), so `make test` exercises the same Chrome CI auto-installs.

--- a/fixtures/graft-parity-expected.json
+++ b/fixtures/graft-parity-expected.json
@@ -1,0 +1,7 @@
+{
+  "count": "1",
+  "delayed": "ready",
+  "echo": "Ada",
+  "heading": "Biloba parity",
+  "value": "Ada"
+}

--- a/fixtures/graft-parity.html
+++ b/fixtures/graft-parity.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <body>
+    <h1>Biloba parity</h1>
+    <label>Name <input data-testid="name"></label>
+    <output id="echo"></output>
+    <button aria-label="Increment">Increment</button>
+    <div id="count">0</div>
+    <div id="delayed">loading</div>
+    <script>
+      const input = document.querySelector('[data-testid="name"]')
+      input.addEventListener('input', () => document.querySelector('#echo').textContent = input.value)
+      document.querySelector('button').addEventListener('click', () => {
+        const count = document.querySelector('#count')
+        count.textContent = String(Number(count.textContent) + 1)
+      })
+      setTimeout(() => document.querySelector('#delayed').textContent = 'ready', 80)
+    </script>
+  </body>
+</html>

--- a/graft_parity_test.go
+++ b/graft_parity_test.go
@@ -1,0 +1,45 @@
+package biloba_test
+
+import (
+	"encoding/json"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TypeScript driver parity contract", func() {
+	It("reaches the shared observable outcome through Biloba's Go API", func() {
+		b.Navigate(fixtureServer + "/graft-parity.html")
+		Eventually(b.ByRole("heading").WithName("Biloba parity")).Should(b.BeVisible())
+		Eventually("#delayed").Should(b.HaveInnerText("ready"))
+
+		b.SetValue(b.ByTestID("name"), "Ada")
+		b.Click(b.ByRole("button").WithName("Increment"))
+
+		actual := b.Run(`({
+			count: document.querySelector('#count').innerText,
+			delayed: document.querySelector('#delayed').innerText,
+			echo: document.querySelector('#echo').innerText,
+			heading: document.querySelector('h1').innerText,
+			value: document.querySelector('[data-testid="name"]').value,
+		})`)
+		expectedJSON, err := os.ReadFile("fixtures/graft-parity-expected.json")
+		Expect(err).NotTo(HaveOccurred())
+		var expected any
+		Expect(json.Unmarshal(expectedJSON, &expected)).To(Succeed())
+		Expect(actual).To(Equal(expected))
+	})
+
+	It("preserves Biloba's failure semantics for a missing element", func() {
+		b.Navigate(fixtureServer + "/graft-parity.html")
+
+		b.WithTimeout(40 * time.Millisecond).GetInnerText("#never")
+
+		ExpectFailures(SatisfyAll(
+			ContainSubstring("Timed out after"),
+			ContainSubstring(`to have property "innerText"`),
+		))
+	})
+})

--- a/typescript/.gitignore
+++ b/typescript/.gitignore
@@ -1,0 +1,3 @@
+/.tmp/
+/dist/
+/node_modules/

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@onsi/biloba-vitest-prototype",
+  "version": "0.0.0-private",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@11.20.0",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "generate:protocol": "cd .. && go generate ./protocol",
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "test:parity": "vitest run -c vitest.parity.config.ts",
+    "test:e2e": "vitest run -c vitest.e2e.config.ts && vitest run -c vitest.e2e-crash.config.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "22.15.30",
+    "typescript": "5.8.3",
+    "vitest": "3.2.4"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/typescript/pnpm-lock.yaml
+++ b/typescript/pnpm-lock.yaml
@@ -1,0 +1,1042 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: 22.15.30
+        version: 22.15.30
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/node@22.15.30)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-android-arm-eabi@4.63.0':
+    resolution: {integrity: sha512-70TeIFezKKy65LgAVyQh+w94/gjWhvPWaLaGGeMEgVrPkQhuj/M5bAYYZzIFUj9Y69oHyTm5Um/R6gcLh4A8JA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.63.0':
+    resolution: {integrity: sha512-YC86tYIHK6M1IV+wbzO+Bxk8RCBr6ZyWYgWxUCzaZD8mc8rrFoIJDNzDrkHBYRc/wKdrsIXmm6/F7NzrAO+OrA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.63.0':
+    resolution: {integrity: sha512-oI+ECtUcli0y0fi4xpW82GdPIXdTkI8G8DSjG2LRuw09fPAGykaWYH/hXxiKuTxiAjiPSTIIuYUqof5Z2hShWw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.63.0':
+    resolution: {integrity: sha512-NwV+1s7TiKrMe4owHyKB/dTLD7ZJD0YEBEhIz+hvav1Cu1GReJjF+rsdNwjzENQeIAbE/CoNiaAc5Vz2h5DPAA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.63.0':
+    resolution: {integrity: sha512-tWtHBTu5gOPK4u4Urtk4qAHW3zZ9rQAmbssO8gp7ELvGTGI3aCiq6NqyTQ0PCIg7KbHJF2UkGDDs77YZGxfjCA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.63.0':
+    resolution: {integrity: sha512-2qPoJiwTvtHQ27NnYvTnsgk8laXWYuVmNESG8WFZBcEPKLfZ3I27qBJarjVRQtwGeYyRfq5ZowHXih9lm2BItw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.0':
+    resolution: {integrity: sha512-FQwsTRvLNuHoTdICABJQfbPUSEueISGmnpT06tXTMpfprf5NiKLSXKA0A+w45wJnCmZAnzgqBwbt6ARFuyOi5w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.0':
+    resolution: {integrity: sha512-BBVTXziw8mY1a4ZbWME9tZyfzqXCDPqaC7Z3heQ29p5dkvXzwL0NwelO8zLa8c3RBKvl3YTuSnBgsBhYBtwjIw==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.0':
+    resolution: {integrity: sha512-w2Iyy9+RqKwx3d9qWMKsJg0FfRBsY0/pXNv0mCQ3ueRvJI6+QAScfD4nrMlzFLs2HNVW6Ew+mtZfDl9b7Ew5/Q==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.63.0':
+    resolution: {integrity: sha512-YK++KtrFRHYE0P6/RtYEAy9t8F37znP+K03RrIuLPYOL6SVlObRumf/0OE4V/h63xL9DwkWbNssZfmA9hawuDA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.0':
+    resolution: {integrity: sha512-aBfOG6fP7YkkPmTqPwufRJeFyz7WPpECv9XNbnsk9+vg7rxdih0lbtEel7jcRng4LZrrmU3FfitCFyEj4BWDWg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.63.0':
+    resolution: {integrity: sha512-LGaHEOeHNAag9VuS1Crs5DFg4RrU9MPi2nVnNJk9DTePx/B6RRYKVmrIXt2h7YOJlwjaFJ6lwtFDliZxScTLrQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.0':
+    resolution: {integrity: sha512-jClvk+J0FC3b7Udvegiw5/4hErbHtmsNsQgENnKXDWtNCJXsJYZH5WURvu7imDOO38xYml24eeh5x3A04ppwCw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.0':
+    resolution: {integrity: sha512-0OJlaGK+8+B777Ql5okIpD7ua5Ro9+VB9Ve0OKa28OQJZ1RbuUBVNHK/e3pr4BROqsyPl1JrPO1ZxJseCNffcA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.0':
+    resolution: {integrity: sha512-Ygsx+HoNH7afwi1bTIXbnTvVnsO+zurPLSYxybV1hHFVU72OWOCl6v05ql/z0hkpAPx+DK7Kn9Bi7MayCcjLTA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.0':
+    resolution: {integrity: sha512-pDQxtMGb+OvG3fLwR2OkZlSd47hW+kWg4BYMG/++sR6RqorQccwPTDsxda5hPwiIeIErAnCF9ma3SAU06bdQtQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.0':
+    resolution: {integrity: sha512-0BnUG9mS8I4SSHr3XsxVhuCMEiu+rX61xxZF5vujso4LaiAGFZFxvDjg6Xn6tLPNTUAfuCvQYas4LMQMVsKRSQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.63.0':
+    resolution: {integrity: sha512-Adu/VttB1dpPNW+FEacrZ+xVm9tFty84+RrFzsqlFaPxoJB+9XXyDGtp5dCOoBwGBIEVH0To7lExFXEx0BIF4A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.63.0':
+    resolution: {integrity: sha512-NQ3bDvjUbFKmP23671xUlXtKmqVsUBd6M4PQCvbmNtOy06hnQIdKHy8oG/6S3R/S6He1JgPk6A5VT+prAJMYEw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.63.0':
+    resolution: {integrity: sha512-u2eDAl4+0aFvA13GxlGBtTI3SS3sdgwgtV0HyjZ0QaQVCgNE+jqNGey+GtxWiq+wxr/UycAx/OnfJzApCFamvA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.63.0':
+    resolution: {integrity: sha512-XvRb5vfW3wAZQ+ZUG21AnHHDKtNcw99eigzEhjr//NZ3u7SoBaPP0seSc7FgP7p1epAEdAoZckMW9WY/+4w70w==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.0':
+    resolution: {integrity: sha512-iZPmniy4kNBf5yo2RezbkYNNK5HPbXE9+g+twnbqSng7dtLEJy1SKoxiE/ni4FDacjyuZpEeb9U054N4EoKHYw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.0':
+    resolution: {integrity: sha512-mFBBd+LF37fnE8JnYUOH+imj0aPFPK30vpar4ehJkgnLj9sZn8ZxiRENmLtgIwxK7TC8klF6N57fxdNBwQoqOA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.63.0':
+    resolution: {integrity: sha512-ujeqEY3B+zbGn3Z4Q03cUBG/LGWnBJncVT36WER31LcOsQk9+1dmINKKtvmmfChUvRbK1G0R8OhMWFgHgaZtAw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.63.0':
+    resolution: {integrity: sha512-hncn90N4sOky0L2LKE5oESKLbxCPeVo4eLA2LSMoDzM+879ml4WSr+Rr4DWknNIVVvS1Hirkc9hx02W6YxS8rQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@22.15.30':
+    resolution: {integrity: sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.7:
+    resolution: {integrity: sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.63.0:
+    resolution: {integrity: sha512-T5vnZ2y4QqC3/4P+w2+JO+Q/OVdnPsv4XcSYJYMEn0R9/jjl5AgLwO9LAZMzP2lN71O6pypn91rB7lDstUkfrQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.63.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.63.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.63.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.63.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.63.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.63.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.63.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.63.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.63.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.63.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.63.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.63.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.63.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.63.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.63.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.63.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.63.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.63.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.63.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.63.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.63.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.63.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.63.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.63.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.63.0':
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@22.15.30':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.6(@types/node@22.15.30))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@22.15.30)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fdir@6.5.0(picomatch@4.0.7):
+    optionalDependencies:
+      picomatch: 4.0.7
+
+  fsevents@2.3.3:
+    optional: true
+
+  js-tokens@9.0.1: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.18: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.7: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.63.0:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.63.0
+      '@rollup/rollup-android-arm64': 4.63.0
+      '@rollup/rollup-darwin-arm64': 4.63.0
+      '@rollup/rollup-darwin-x64': 4.63.0
+      '@rollup/rollup-freebsd-arm64': 4.63.0
+      '@rollup/rollup-freebsd-x64': 4.63.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.63.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.63.0
+      '@rollup/rollup-linux-arm64-gnu': 4.63.0
+      '@rollup/rollup-linux-arm64-musl': 4.63.0
+      '@rollup/rollup-linux-loong64-gnu': 4.63.0
+      '@rollup/rollup-linux-loong64-musl': 4.63.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.63.0
+      '@rollup/rollup-linux-ppc64-musl': 4.63.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.63.0
+      '@rollup/rollup-linux-riscv64-musl': 4.63.0
+      '@rollup/rollup-linux-s390x-gnu': 4.63.0
+      '@rollup/rollup-linux-x64-gnu': 4.63.0
+      '@rollup/rollup-linux-x64-musl': 4.63.0
+      '@rollup/rollup-openbsd-x64': 4.63.0
+      '@rollup/rollup-openharmony-arm64': 4.63.0
+      '@rollup/rollup-win32-arm64-msvc': 4.63.0
+      '@rollup/rollup-win32-ia32-msvc': 4.63.0
+      '@rollup/rollup-win32-x64-gnu': 4.63.0
+      '@rollup/rollup-win32-x64-msvc': 4.63.0
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  typescript@5.8.3: {}
+
+  undici-types@6.21.0: {}
+
+  vite-node@3.2.4(@types/node@22.15.30):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@22.15.30)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(@types/node@22.15.30):
+    dependencies:
+      esbuild: 0.28.2
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
+      postcss: 8.5.26
+      rollup: 4.63.0
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.15.30
+      fsevents: 2.3.3
+
+  vitest@3.2.4(@types/node@22.15.30):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.6(@types/node@22.15.30))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@22.15.30)
+      vite-node: 3.2.4(@types/node@22.15.30)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.15.30
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/typescript/pnpm-workspace.yaml
+++ b/typescript/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# vitest pulls in esbuild, whose postinstall fetches the platform binary.  pnpm 10+ refuses to run
+# a dependency's build scripts unless they are allowed here, and `pnpm install` exits non-zero when
+# it has to ignore one - which would fail CI at the install step.
+allowBuilds:
+  esbuild: true

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,0 +1,182 @@
+import {connectWithTransport, stripStackHeader} from "./internal/client.js";
+import {
+  startSharedBrowser as spawnSharedBrowser,
+  type SharedBrowserProcess,
+  type StartSharedBrowserOptions,
+} from "./internal/browser-manager.js";
+import {
+  startDaemon as spawnDaemon,
+  type DaemonProcess,
+  type StartDaemonOptions,
+} from "./internal/daemon-manager.js";
+
+export type {DaemonProcess, StartDaemonOptions};
+export type {SharedBrowserProcess, StartSharedBrowserOptions};
+
+export type SerializableValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly SerializableValue[]
+  | {readonly [key: string]: SerializableValue};
+
+export interface WaitOptions {
+  timeoutMs?: number;
+  intervalMs?: number;
+  signal?: AbortSignal;
+}
+
+export interface Cookie {
+  name: string;
+  value: string;
+  domain?: string;
+  path?: string;
+  expires?: Date | number;
+  secure?: boolean;
+  httpOnly?: boolean;
+  sameSite?: string;
+}
+
+export interface PollObservation {
+  readonly attempt: number;
+  readonly elapsedMs: number;
+  readonly observed: unknown;
+  readonly retryReason?: string;
+}
+
+export interface AssertionResult {
+  readonly observed: unknown;
+  readonly attemptCount: number;
+  readonly trajectory: readonly PollObservation[];
+  readonly rpcRequestCount: number;
+  readonly rpcResponseCount: number;
+  readonly elapsedMs?: number;
+}
+
+export type BilobaErrorCode =
+  | "INVALID_ARGUMENT"
+  | "TIMEOUT"
+  | "TARGET_NOT_FOUND"
+  | "TARGET_NOT_READY"
+  | "JAVASCRIPT_ERROR"
+  | "PROTOCOL_MISMATCH"
+  | "DRIVER_CLOSED"
+  | "DRIVER_ERROR"
+  | "CANCELLED"
+  /** The shared Chrome exited or crashed underneath this worker. */
+  | "BROWSER_GONE"
+  /** This session's page crashed; the browser is fine. Navigate again to recover. */
+  | "PAGE_CRASHED";
+
+interface BilobaErrorOptions {
+  code: BilobaErrorCode;
+  message: string;
+  locator?: string;
+  expected?: unknown;
+  observed?: unknown;
+  trajectory?: readonly PollObservation[];
+  domOutline?: string;
+  screenshotPath?: string;
+  daemonDetail?: string;
+  rpcRequestCount?: number;
+  rpcResponseCount?: number;
+  callsiteStack?: string;
+}
+
+export class BilobaError extends Error {
+  readonly code: BilobaErrorCode;
+  readonly locator?: string;
+  readonly expected?: unknown;
+  readonly observed?: unknown;
+  readonly trajectory: readonly PollObservation[];
+  readonly domOutline?: string;
+  readonly screenshotPath?: string;
+  readonly daemonDetail?: string;
+  readonly rpcRequestCount?: number;
+  readonly rpcResponseCount?: number;
+
+  constructor(options: BilobaErrorOptions) {
+    super(options.message);
+    this.name = "BilobaError";
+    this.code = options.code;
+    if (options.locator !== undefined) this.locator = options.locator;
+    if (options.expected !== undefined) this.expected = options.expected;
+    if (options.observed !== undefined) this.observed = options.observed;
+    this.trajectory = options.trajectory ?? [];
+    if (options.domOutline !== undefined) this.domOutline = options.domOutline;
+    if (options.screenshotPath !== undefined) this.screenshotPath = options.screenshotPath;
+    if (options.daemonDetail !== undefined) this.daemonDetail = options.daemonDetail;
+    if (options.rpcRequestCount !== undefined) this.rpcRequestCount = options.rpcRequestCount;
+    if (options.rpcResponseCount !== undefined) this.rpcResponseCount = options.rpcResponseCount;
+    if (options.callsiteStack) {
+      this.stack = `${this.name}: ${this.message}\n${stripStackHeader(options.callsiteStack)}`;
+    }
+  }
+}
+
+export interface Locator {
+  first(): Locator;
+  click(options?: WaitOptions): Promise<void>;
+  setValue(value: SerializableValue, options?: WaitOptions): Promise<void>;
+  expectVisible(options?: WaitOptions): Promise<AssertionResult>;
+  expectText(expected: string, options?: WaitOptions & {exact?: boolean}): Promise<AssertionResult>;
+  expectCount(expected: number, options?: WaitOptions): Promise<AssertionResult>;
+  expectAttribute(name: string, expected: string, options?: WaitOptions & {exact?: boolean}): Promise<AssertionResult>;
+  expectValue(expected: SerializableValue, options?: WaitOptions): Promise<AssertionResult>;
+}
+
+export interface Session {
+  readonly id: string;
+  prepare(): Promise<void>;
+  navigate(url: string, options?: WaitOptions): Promise<void>;
+  setCookies(cookies: readonly Cookie[]): Promise<void>;
+  evaluate<T = unknown>(expression: string, args?: readonly SerializableValue[], options?: WaitOptions): Promise<T>;
+  close(): Promise<void>;
+  locator(css: string): Locator;
+  getByTestId(value: string): Locator;
+  getByText(value: string, options?: {exact?: boolean}): Locator;
+  getByRole(role: string, options?: {name?: string; exact?: boolean}): Locator;
+  expectUrl(expected: string, options?: WaitOptions & {exact?: boolean; pathname?: boolean}): Promise<AssertionResult>;
+  expectEvaluation(expression: string, expected: SerializableValue, options?: WaitOptions): Promise<AssertionResult>;
+}
+
+export interface Browser {
+  readonly protocolVersion: string;
+  readonly capabilities: ReadonlySet<string>;
+  openSession(): Promise<Session>;
+  close(): Promise<void>;
+}
+
+export interface ConnectOptions {
+  daemonExecutable?: string;
+  chromePath?: string;
+  chromeWsUrl?: string;
+  artifactDir?: string;
+  signal?: AbortSignal;
+}
+
+export async function connect(options: ConnectOptions = {}): Promise<Browser> {
+  const executable = options.daemonExecutable ?? process.env.BILOBA_DAEMON_EXECUTABLE;
+  if (!executable) {
+    throw new BilobaError({
+      code: "INVALID_ARGUMENT",
+      message: "connect requires daemonExecutable",
+    });
+  }
+  const daemon = await spawnDaemon({
+    executable,
+    ...(options.chromePath && {chromePath: options.chromePath}),
+    ...(options.chromeWsUrl && {chromeWsUrl: options.chromeWsUrl}),
+    ...(options.artifactDir && {artifactDir: options.artifactDir}),
+  });
+  return await connectWithTransport(daemon.transport, options, () => daemon.stop());
+}
+
+export async function startDaemon(options: StartDaemonOptions): Promise<DaemonProcess> {
+  return await spawnDaemon(options);
+}
+
+export async function startSharedBrowser(options: StartSharedBrowserOptions): Promise<SharedBrowserProcess> {
+  return await spawnSharedBrowser(options);
+}

--- a/typescript/src/internal/browser-manager.ts
+++ b/typescript/src/internal/browser-manager.ts
@@ -1,0 +1,118 @@
+import {spawn, type ChildProcessByStdio} from "node:child_process";
+import {platform} from "node:os";
+import type {Readable, Writable} from "node:stream";
+
+import {BilobaError} from "../index.js";
+
+export interface StartSharedBrowserOptions {
+  executable: string;
+  chromePath?: string;
+  readyTimeoutMs?: number;
+}
+
+export interface SharedBrowserProcess {
+  readonly wsURL: string;
+  readonly pid: number;
+  stop(): Promise<void>;
+}
+
+type BrowserChild = ChildProcessByStdio<Writable, Readable, Readable>;
+
+export async function startSharedBrowser(options: StartSharedBrowserOptions): Promise<SharedBrowserProcess> {
+  const child = spawn(options.executable, [
+    "serve-browser",
+    ...(options.chromePath ? [`--chrome-path=${options.chromePath}`] : []),
+  ], {stdio: ["pipe", "pipe", "pipe"], detached: platform() !== "win32"});
+  const stop = createStop(child);
+  const killOnExit = () => killProcessGroup(child, "SIGTERM");
+  process.once("exit", killOnExit);
+  try {
+    const wsURL = await waitForReady(child, options.readyTimeoutMs ?? 60_000);
+    if (child.pid === undefined) throw new BilobaError({code: "DRIVER_CLOSED", message: "browser host did not expose a process id"});
+    return {
+      wsURL,
+      pid: child.pid,
+      async stop() {
+        process.removeListener("exit", killOnExit);
+        await stop();
+      },
+    };
+  } catch (error) {
+    process.removeListener("exit", killOnExit);
+    await stop();
+    throw error;
+  }
+}
+
+function waitForReady(child: BrowserChild, timeoutMs: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let stdout = "";
+    let stderr = "";
+    const timeout = setTimeout(() => fail(new BilobaError({
+      code: "DRIVER_CLOSED",
+      message: `shared Chrome did not become ready within ${timeoutMs}ms`,
+      ...(stderr && {daemonDetail: stderr}),
+    })), timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.stdout.removeListener("data", onStdout);
+      child.removeListener("error", onError);
+      child.removeListener("exit", onExit);
+    };
+    const fail = (error: Error) => { cleanup(); reject(error); };
+    const onStderr = (chunk: Buffer | string) => { stderr = (stderr + chunk.toString()).slice(-64 * 1024); };
+    const onStdout = (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+      const lines = stdout.split(/\r?\n/);
+      stdout = lines.pop() ?? "";
+      for (const line of lines) {
+        try {
+          const ready = JSON.parse(line) as {wsURL?: unknown};
+          if (typeof ready.wsURL === "string" && ready.wsURL.startsWith("ws://")) {
+            cleanup();
+            resolve(ready.wsURL);
+            return;
+          }
+        } catch {
+          fail(new BilobaError({code: "DRIVER_ERROR", message: "browser host wrote invalid startup JSON"}));
+          return;
+        }
+      }
+    };
+    const onError = (error: Error) => fail(new BilobaError({code: "DRIVER_CLOSED", message: `Could not start browser host: ${error.message}`}));
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => fail(new BilobaError({
+      code: "DRIVER_CLOSED",
+      message: `browser host exited before ready (code=${String(code)}, signal=${String(signal)})`,
+      ...(stderr && {daemonDetail: stderr}),
+    }));
+    child.stdout.on("data", onStdout);
+    child.stderr.on("data", onStderr);
+    child.once("error", onError);
+    child.once("exit", onExit);
+  });
+}
+
+function createStop(child: BrowserChild): () => Promise<void> {
+  let stopping: Promise<void> | undefined;
+  return () => stopping ??= new Promise<void>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) { resolve(); return; }
+    const forceTimer = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) killProcessGroup(child, "SIGKILL");
+    }, 2_000);
+    child.once("exit", () => { clearTimeout(forceTimer); resolve(); });
+    // Same ordering as the daemon's stop (daemon-manager.ts): end stdin, then signal the group in
+    // the same turn, while the leader is still alive and the pgid cannot have been recycled.
+    child.stdin.end();
+    killProcessGroup(child, "SIGTERM");
+  });
+}
+
+function killProcessGroup(child: BrowserChild, signal: NodeJS.Signals): void {
+  if (child.pid === undefined) return;
+  try {
+    if (platform() === "win32") child.kill(signal);
+    else process.kill(-child.pid, signal);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+  }
+}

--- a/typescript/src/internal/client.ts
+++ b/typescript/src/internal/client.ts
@@ -1,0 +1,450 @@
+import type {
+  Assertion as WireAssertion,
+  Locator as WireLocator,
+  LocatorRequest,
+  OperationResult as StdioOperationResult,
+  SetValueRequest,
+} from "../generated/protocol.js";
+import {
+  BilobaError,
+  type AssertionResult,
+  type Browser,
+  type ConnectOptions,
+  type Cookie,
+  type Locator,
+  type SerializableValue,
+  type Session,
+  type WaitOptions,
+} from "../index.js";
+import {StdioTransport} from "./stdio-transport.js";
+
+type DriverTransport = StdioTransport;
+type DriverOperationResult = StdioOperationResult;
+
+class ClientBrowser implements Browser {
+  readonly #transport: DriverTransport;
+  readonly #sessions = new Set<ClientSession>();
+  readonly #stopDaemon?: () => Promise<void>;
+  readonly protocolVersion: string;
+  readonly capabilities: ReadonlySet<string>;
+  #closed = false;
+
+  constructor(
+    transport: DriverTransport,
+    protocolVersion: string,
+    capabilities: readonly string[],
+    stopDaemon?: () => Promise<void>,
+  ) {
+    this.#transport = transport;
+    this.protocolVersion = protocolVersion;
+    this.capabilities = new Set(capabilities);
+    if (stopDaemon) this.#stopDaemon = stopDaemon;
+  }
+
+  // Every call opens a genuinely new daemon session with its own browser context.  Sessions are
+  // tracked only so close() can reap the ones a suite forgot - reusing one per worker would make
+  // any spec that opens two sessions to prove isolation pass vacuously, and a client that Ginkgo,
+  // vitest or anything else can drive has no business reading VITEST_POOL_ID.
+  async openSession(): Promise<Session> {
+    this.#assertOpen();
+    const response = await this.#transport.openSession({});
+    const session: ClientSession = new ClientSession(
+      response.sessionId ?? "",
+      this.#transport,
+      () => this.#sessions.delete(session),
+    );
+    this.#sessions.add(session);
+    return session;
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    await Promise.allSettled([...this.#sessions].map(async (session) => session.close()));
+    this.#sessions.clear();
+    this.#transport.close();
+    await this.#stopDaemon?.();
+  }
+
+  #assertOpen(): void {
+    if (this.#closed) throw new BilobaError({code: "DRIVER_CLOSED", message: "Biloba browser is closed"});
+  }
+}
+
+class ClientSession implements Session {
+  readonly id: string;
+  readonly #transport: DriverTransport;
+  readonly #onClose: () => void;
+  closed = false;
+
+  constructor(id: string, transport: DriverTransport, onClose: () => void) {
+    this.id = id;
+    this.#transport = transport;
+    this.#onClose = onClose;
+  }
+
+  async prepare(): Promise<void> {
+    this.#assertOpen();
+    await this.#transport.prepareSession({sessionId: this.id});
+  }
+
+  async navigate(url: string, options: WaitOptions = {}): Promise<void> {
+    this.#assertOpen();
+    await this.#transport.navigate({sessionId: this.id, url}, options);
+  }
+
+  async setCookies(cookies: readonly Cookie[]): Promise<void> {
+    this.#assertOpen();
+    await this.#transport.setCookies({
+      sessionId: this.id,
+      cookies: cookies.map(({expires, ...cookie}) => ({
+        ...cookie,
+        ...(expires !== undefined && {
+          expiresUnix: typeof expires === "number" ? expires : expires.getTime() / 1_000,
+        }),
+      })),
+    });
+  }
+
+  // invoke tells the daemon what expression means instead of letting it infer that from the
+  // argument count: passing an args array - even an empty one - is the caller saying "call this",
+  // so evaluate("(a) => a + 1", []) runs the function while evaluate("window.appState") reads the
+  // expression.  Without it the daemon falls back to the pre-invoke inference, where an empty array
+  // silently turned a function call back into a function-source read.
+  async evaluate<T = unknown>(
+    expression: string,
+    args?: readonly SerializableValue[],
+    options: WaitOptions = {},
+  ): Promise<T> {
+    this.#assertOpen();
+    const response = await this.#transport.evaluate({
+      sessionId: this.id,
+      expression,
+      argumentsJson: JSON.stringify(args ?? []),
+      invoke: args !== undefined,
+    }, options);
+    return parseJson(response.observedJson) as T;
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      await this.#transport.closeSession({sessionId: this.id});
+    } finally {
+      this.#onClose();
+    }
+  }
+
+  locator(css: string): Locator {
+    return new ClientLocator(this, {kind: "CSS", value: css, match: "EXACT", first: false});
+  }
+
+  getByTestId(value: string): Locator {
+    return new ClientLocator(this, {kind: "TEST_ID", value, match: "EXACT", first: false});
+  }
+
+  getByText(value: string, options: {exact?: boolean} = {}): Locator {
+    return new ClientLocator(this, {
+      kind: "TEXT",
+      value,
+      match: options.exact === true ? "EXACT" : "CONTAINS",
+      first: false,
+    });
+  }
+
+  getByRole(role: string, options: {name?: string; exact?: boolean} = {}): Locator {
+    return new ClientLocator(this, {
+      kind: "ROLE",
+      role,
+      ...(options.name !== undefined && {name: options.name}),
+      match: options.exact === false ? "CONTAINS" : "EXACT",
+      first: false,
+    });
+  }
+
+  async expectUrl(
+    expected: string,
+    options: WaitOptions & {exact?: boolean; pathname?: boolean} = {},
+  ): Promise<AssertionResult> {
+    const callsiteStack = new Error().stack;
+    if (options.pathname) {
+      return await this.assert({
+        kind: "EVALUATE",
+        expression: "window.location.pathname",
+        expectedJson: JSON.stringify(expected),
+      }, options, callsiteStack);
+    }
+    return await this.assert({
+      kind: "URL",
+      expectedString: expected,
+      match: matchMode(options.exact),
+    }, options, callsiteStack);
+  }
+
+  async expectEvaluation(
+    expression: string,
+    expected: SerializableValue,
+    options: WaitOptions = {},
+  ): Promise<AssertionResult> {
+    const callsiteStack = new Error().stack;
+    return await this.assert({
+      kind: "EVALUATE",
+      expression,
+      expectedJson: JSON.stringify(expected),
+    }, options, callsiteStack);
+  }
+
+  async assert(
+    assertion: WireAssertion,
+    options: WaitOptions,
+    callsiteStack: string | undefined,
+  ): Promise<AssertionResult> {
+    this.#assertOpen();
+    try {
+      const response = await this.#transport.assert({
+        sessionId: this.id,
+        assertion,
+        poll: pollPolicy(options),
+      }, {
+        ...options,
+        ...(options.timeoutMs !== undefined && {deadlineMs: options.timeoutMs + 2_100}),
+      });
+      return assertionResult(response, callsiteStack);
+    } catch (error) {
+      if (error instanceof BilobaError && callsiteStack && !error.stack?.includes(stripStackHeader(callsiteStack))) {
+        error.stack = `${error.name}: ${error.message}\n${stripStackHeader(callsiteStack)}`;
+      }
+      throw error;
+    }
+  }
+
+  async action(
+    method: "click" | "setValue",
+    locator: WireLocator,
+    payload: Record<string, unknown>,
+    options: WaitOptions,
+  ): Promise<void> {
+    this.#assertOpen();
+    const callsiteStack = new Error().stack;
+    const request = {
+      sessionId: this.id,
+      locator,
+      ...payload,
+      poll: pollPolicy(options),
+    };
+    const transportOptions = {
+      ...options,
+      ...(options.timeoutMs !== undefined && {deadlineMs: options.timeoutMs + 2_100}),
+    };
+    const response = method === "click"
+      ? await this.#transport.click(request as LocatorRequest, transportOptions)
+      : await this.#transport.setValue(request as unknown as SetValueRequest, transportOptions);
+    operationResult(response, `${method} operation`, callsiteStack);
+  }
+
+  #assertOpen(): void {
+    if (this.closed) throw new BilobaError({code: "DRIVER_CLOSED", message: `Biloba session ${this.id} is closed`});
+  }
+}
+
+class ClientLocator implements Locator {
+  readonly #session: ClientSession;
+  readonly #locator: WireLocator;
+
+  constructor(session: ClientSession, locator: WireLocator) {
+    this.#session = session;
+    this.#locator = locator;
+  }
+
+  first(): Locator {
+    return new ClientLocator(this.#session, {...this.#locator, first: true});
+  }
+
+  async click(options: WaitOptions = {}): Promise<void> {
+    await this.#session.action("click", this.#locator, {}, options);
+  }
+
+  async setValue(value: SerializableValue, options: WaitOptions = {}): Promise<void> {
+    await this.#session.action("setValue", this.#locator, {valueJson: JSON.stringify(value)}, options);
+  }
+
+  async expectVisible(options: WaitOptions = {}): Promise<AssertionResult> {
+    return await this.#assert({kind: "VISIBLE", locator: this.#locator}, options);
+  }
+
+  async expectText(
+    expected: string,
+    options: WaitOptions & {exact?: boolean} = {},
+  ): Promise<AssertionResult> {
+    return await this.#assert({
+      kind: "TEXT",
+      locator: this.#locator,
+      expectedString: expected,
+      match: matchMode(options.exact),
+    }, options);
+  }
+
+  async expectCount(expected: number, options: WaitOptions = {}): Promise<AssertionResult> {
+    return await this.#assert({kind: "COUNT", locator: this.#locator, expectedCount: expected}, options);
+  }
+
+  async expectAttribute(
+    name: string,
+    expected: string,
+    options: WaitOptions & {exact?: boolean} = {},
+  ): Promise<AssertionResult> {
+    return await this.#assert({
+      kind: "ATTRIBUTE",
+      locator: this.#locator,
+      attribute: name,
+      expectedString: expected,
+      match: matchMode(options.exact),
+    }, options);
+  }
+
+  async expectValue(expected: SerializableValue, options: WaitOptions = {}): Promise<AssertionResult> {
+    return await this.#assert({kind: "VALUE", locator: this.#locator, expectedJson: JSON.stringify(expected)}, options);
+  }
+
+  async #assert(assertion: WireAssertion, options: WaitOptions): Promise<AssertionResult> {
+    const callsiteStack = new Error().stack;
+    return await this.#session.assert(assertion, options, callsiteStack);
+  }
+}
+
+// The seam test/client.test.ts uses to drive the client against an in-memory framed peer.  It lives
+// here rather than on the public entry point: exporting it there and marking it internal only makes
+// stripInternal delete it from dist/index.d.ts, while dist/index.js goes on exposing it - an untyped
+// escape hatch in the published surface.  Internal modules are outside the package's "exports" map,
+// so this stays reachable from the repo's own tests and from nowhere else.
+export async function connectWithTransport(
+  transport: StdioTransport,
+  options: Pick<ConnectOptions, "signal"> = {},
+  stopDaemon?: () => Promise<void>,
+): Promise<Browser> {
+  try {
+    const handshake = await transport.handshake(
+      {protocolVersion: "1"},
+      options.signal ? {signal: options.signal} : {},
+    );
+    if (handshake.protocolVersion !== "1") {
+      throw new BilobaError({
+        code: "PROTOCOL_MISMATCH",
+        message: `Biloba protocol mismatch: client 1, daemon ${handshake.protocolVersion}`,
+      });
+    }
+    return new ClientBrowser(
+      transport,
+      handshake.protocolVersion ?? "",
+      handshake.capabilities ?? [],
+      stopDaemon,
+    );
+  } catch (error) {
+    transport.close();
+    await stopDaemon?.();
+    throw error;
+  }
+}
+
+function assertionResult(response: DriverOperationResult, callsiteStack: string | undefined): AssertionResult {
+  const observed = parseJson(response.observedJson);
+  const trajectory = (response.trajectory ?? []).map((entry) => ({
+    attempt: entry.attempt ?? 0,
+    elapsedMs: Number(entry.elapsedMs ?? 0),
+    observed: parseJson(entry.observedJson),
+    ...(entry.retryReason && {retryReason: entry.retryReason}),
+  }));
+  if (!response.matched) {
+    const diagnostics = response.diagnostics ?? {};
+    const message = [
+      "Biloba assertion timed out",
+      diagnostics.locator ? `locator: ${diagnostics.locator}` : undefined,
+      diagnostics.expected ? `expected: ${diagnostics.expected}` : undefined,
+      `last observed: ${JSON.stringify(observed)}`,
+      `attempts: ${response.attemptCount ?? trajectory.length}`,
+    ].filter((line): line is string => line !== undefined).join("\n");
+    throw new BilobaError({
+      code: "TIMEOUT",
+      message,
+      ...(diagnostics.locator && {locator: diagnostics.locator}),
+      ...(diagnostics.expected && {expected: diagnostics.expected}),
+      observed,
+      trajectory,
+      ...(diagnostics.domOutline && {domOutline: diagnostics.domOutline}),
+      ...(diagnostics.screenshotPath && {screenshotPath: diagnostics.screenshotPath}),
+      ...(diagnostics.daemonDetail && {daemonDetail: diagnostics.daemonDetail}),
+      rpcRequestCount: response.rpcRequestCount ?? 0,
+      rpcResponseCount: response.rpcResponseCount ?? 0,
+      ...(callsiteStack && {callsiteStack}),
+    });
+  }
+  return {
+    observed,
+    attemptCount: response.attemptCount || trajectory.length,
+    trajectory,
+    rpcRequestCount: response.rpcRequestCount ?? 0,
+    rpcResponseCount: response.rpcResponseCount ?? 0,
+    ...(response.timings && {elapsedMs: Number(response.timings.elapsedMs ?? 0)}),
+  };
+}
+
+function operationResult(
+  response: DriverOperationResult,
+  operation: string,
+  callsiteStack: string | undefined,
+): void {
+  if (response.matched) return;
+  const diagnostics = response.diagnostics ?? {};
+  const observed = parseJson(response.observedJson);
+  const trajectory = (response.trajectory ?? []).map((entry) => ({
+    attempt: entry.attempt ?? 0,
+    elapsedMs: Number(entry.elapsedMs ?? 0),
+    observed: parseJson(entry.observedJson),
+    ...(entry.retryReason && {retryReason: entry.retryReason}),
+  }));
+  throw new BilobaError({
+    code: "TIMEOUT",
+    message: [
+      `Biloba ${operation} timed out`,
+      diagnostics.locator ? `locator: ${diagnostics.locator}` : undefined,
+      `attempts: ${response.attemptCount ?? trajectory.length}`,
+    ].filter((line): line is string => line !== undefined).join("\n"),
+    ...(diagnostics.locator && {locator: diagnostics.locator}),
+    ...(diagnostics.expected && {expected: diagnostics.expected}),
+    observed,
+    trajectory,
+    ...(diagnostics.domOutline && {domOutline: diagnostics.domOutline}),
+    ...(diagnostics.screenshotPath && {screenshotPath: diagnostics.screenshotPath}),
+    ...(diagnostics.daemonDetail && {daemonDetail: diagnostics.daemonDetail}),
+    rpcRequestCount: response.rpcRequestCount ?? 0,
+    rpcResponseCount: response.rpcResponseCount ?? 0,
+    ...(callsiteStack && {callsiteStack}),
+  });
+}
+
+function pollPolicy(options: WaitOptions): Record<string, number> {
+  return {
+    ...(options.timeoutMs !== undefined && {timeoutMs: options.timeoutMs}),
+    ...(options.intervalMs !== undefined && {intervalMs: options.intervalMs}),
+  };
+}
+
+function matchMode(exact: boolean | undefined): "EXACT" | "CONTAINS" {
+  return exact === false ? "CONTAINS" : "EXACT";
+}
+
+function parseJson(value: string | undefined): unknown {
+  if (!value) return undefined;
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+}
+
+// index.ts's BilobaError re-homes a failure onto the caller's stack with this too.
+export function stripStackHeader(stack: string): string {
+  const newline = stack.indexOf("\n");
+  return newline === -1 ? stack : stack.slice(newline + 1);
+}

--- a/typescript/src/internal/daemon-manager.ts
+++ b/typescript/src/internal/daemon-manager.ts
@@ -1,0 +1,149 @@
+import {spawn, type ChildProcessByStdio} from "node:child_process";
+import {platform} from "node:os";
+import type {Readable, Writable} from "node:stream";
+
+import {BilobaError} from "../index.js";
+import {StdioTransport} from "./stdio-transport.js";
+
+export interface StartDaemonOptions {
+  executable: string;
+  chromePath?: string;
+  chromeWsUrl?: string;
+  artifactDir?: string;
+  readyTimeoutMs?: number;
+}
+
+export interface DaemonProcess {
+  readonly pid: number;
+  stop(): Promise<void>;
+}
+
+export interface ManagedDaemon extends DaemonProcess {
+  readonly transport: StdioTransport;
+}
+
+type DaemonChild = ChildProcessByStdio<Writable, Readable, Readable>;
+
+export async function startDaemon(options: StartDaemonOptions): Promise<ManagedDaemon> {
+  const args = [
+    ...(options.chromePath ? [`--chrome-path=${options.chromePath}`] : []),
+    ...(options.chromeWsUrl ? [`--chrome-ws-url=${options.chromeWsUrl}`] : []),
+    ...(options.artifactDir ? [`--artifact-dir=${options.artifactDir}`] : []),
+  ];
+  const child = spawn(options.executable, args, {
+    stdio: ["pipe", "pipe", "pipe"],
+    detached: platform() !== "win32",
+  });
+  const stop = createStop(child);
+  const killOnExit = () => killProcessGroup(child, "SIGTERM");
+  process.once("exit", killOnExit);
+  const stderr = new StderrBuffer();
+  child.stderr.on("data", (chunk: Buffer | string) => stderr.append(chunk.toString()));
+
+  try {
+    await waitForSpawn(child, options.readyTimeoutMs ?? 10_000, stderr);
+    if (child.pid === undefined) {
+      throw new BilobaError({code: "DRIVER_CLOSED", message: "bilobad did not expose a process id"});
+    }
+    const transport = new StdioTransport(child.stdout, child.stdin, {failOnEnd: false});
+    child.once("exit", (code, signal) => transport.fail(new Error(
+      `bilobad exited (code=${String(code)}, signal=${String(signal)})`,
+    ), stderr.value));
+    return {
+      pid: child.pid,
+      transport,
+      async stop() {
+        process.removeListener("exit", killOnExit);
+        transport.close();
+        await stop();
+      },
+    };
+  } catch (error) {
+    process.removeListener("exit", killOnExit);
+    await stop();
+    throw error;
+  }
+}
+
+function waitForSpawn(child: DaemonChild, timeoutMs: number, stderr: StderrBuffer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new BilobaError({
+        code: "DRIVER_CLOSED",
+        message: `bilobad did not start within ${timeoutMs}ms`,
+        ...(stderr.value && {daemonDetail: stderr.value}),
+      }));
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.removeListener("spawn", onSpawn);
+      child.removeListener("error", onError);
+      child.removeListener("exit", onExit);
+    };
+    const onSpawn = () => { cleanup(); resolve(); };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(new BilobaError({code: "DRIVER_CLOSED", message: `Could not start bilobad: ${error.message}`}));
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(new BilobaError({
+        code: "DRIVER_CLOSED",
+        message: `bilobad exited during startup (code=${String(code)}, signal=${String(signal)})`,
+        ...(stderr.value && {daemonDetail: stderr.value}),
+      }));
+    };
+    child.once("spawn", onSpawn);
+    child.once("error", onError);
+    child.once("exit", onExit);
+  });
+}
+
+class StderrBuffer {
+  #value = "";
+  append(value: string): void {
+    this.#value = (this.#value + value).slice(-64 * 1024);
+  }
+  get value(): string { return this.#value; }
+}
+
+function createStop(child: DaemonChild): () => Promise<void> {
+  let stopping: Promise<void> | undefined;
+  return () => {
+    stopping ??= new Promise<void>((resolve) => {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        resolve();
+        return;
+      }
+      const forceTimer = setTimeout(() => {
+        // Escalation is only safe while the leader is still ours to signal (see below).
+        if (child.exitCode === null && child.signalCode === null) killProcessGroup(child, "SIGKILL");
+      }, 2_000);
+      child.once("exit", () => {
+        clearTimeout(forceTimer);
+        resolve();
+      });
+      // Close stdin so bilobad can shut down over the protocol, then sweep the group in the same
+      // turn - while the leader is still alive (or at worst an unreaped zombie, which keeps the
+      // group id ours).  Signalling -pid from the exit handler instead would race pgid recycling
+      // and could hit an unrelated process group.  bilobad treats SIGTERM as a clean shutdown
+      // (cmd/bilobad/main.go's signal.NotifyContext), and any Chrome it spawned shares the group,
+      // so the one signal both stops the daemon and reaps its descendants.
+      child.stdin.end();
+      killProcessGroup(child, "SIGTERM");
+    });
+    return stopping;
+  };
+}
+
+function killProcessGroup(child: DaemonChild, signal: NodeJS.Signals): void {
+  if (child.pid === undefined) return;
+  try {
+    if (platform() === "win32") child.kill(signal);
+    else process.kill(-child.pid, signal);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ESRCH") throw error;
+  }
+}

--- a/typescript/src/internal/framing.ts
+++ b/typescript/src/internal/framing.ts
@@ -1,0 +1,58 @@
+import {Transform, type TransformCallback} from "node:stream";
+
+export const MAX_FRAME_SIZE = 16 * 1024 * 1024;
+
+export function encodeFrame(value: unknown): Buffer {
+  const payload = Buffer.from(JSON.stringify(value), "utf8");
+  if (payload.length === 0) throw new Error("Protocol frame is empty");
+  if (payload.length > MAX_FRAME_SIZE) {
+    throw new Error(`Protocol frame is ${payload.length} bytes; maximum is ${MAX_FRAME_SIZE}`);
+  }
+  const frame = Buffer.allocUnsafe(4 + payload.length);
+  frame.writeUInt32LE(payload.length, 0);
+  payload.copy(frame, 4);
+  return frame;
+}
+
+export class FrameDecoder extends Transform {
+  #pending = Buffer.alloc(0);
+
+  constructor() {
+    super({readableObjectMode: true});
+  }
+
+  override _transform(chunk: Buffer | string, encoding: BufferEncoding, callback: TransformCallback): void {
+    try {
+      const incoming = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding);
+      this.#pending = this.#pending.length === 0
+        ? incoming
+        : Buffer.concat([this.#pending, incoming]);
+      this.#decodeAvailable();
+      callback();
+    } catch (error) {
+      callback(error as Error);
+    }
+  }
+
+  override _flush(callback: TransformCallback): void {
+    if (this.#pending.length === 0) {
+      callback();
+      return;
+    }
+    callback(new Error(`Protocol stream ended with ${this.#pending.length} incomplete frame bytes`));
+  }
+
+  #decodeAvailable(): void {
+    while (this.#pending.length >= 4) {
+      const length = this.#pending.readUInt32LE(0);
+      if (length === 0) throw new Error("Protocol frame is empty");
+      if (length > MAX_FRAME_SIZE) {
+        throw new Error(`Protocol frame is ${length} bytes; maximum is ${MAX_FRAME_SIZE}`);
+      }
+      if (this.#pending.length < 4 + length) return;
+      const payload = this.#pending.subarray(4, 4 + length);
+      this.push(JSON.parse(payload.toString("utf8")) as unknown);
+      this.#pending = this.#pending.subarray(4 + length);
+    }
+  }
+}

--- a/typescript/src/internal/stdio-transport.ts
+++ b/typescript/src/internal/stdio-transport.ts
@@ -1,0 +1,214 @@
+import type {Readable, Writable} from "node:stream";
+
+import {BilobaError, type WaitOptions} from "../index.js";
+import type {
+  AssertRequest,
+  EvaluateRequest,
+  HandshakeRequest,
+  HandshakeResponse,
+  LocatorRequest,
+  NavigateRequest,
+  OpenSessionRequest,
+  OpenSessionResponse,
+  OperationResult,
+  ProtocolError,
+  Response,
+  SessionRequest,
+  SetCookiesRequest,
+  SetValueRequest,
+} from "../generated/protocol.js";
+import {encodeFrame, FrameDecoder} from "./framing.js";
+
+interface TransportOptions extends WaitOptions { deadlineMs?: number }
+
+// The non-polling operations carry no poll budget for the transport to inherit, so without a
+// deadline of their own a wedged Chrome - or a daemon stuck mid-request - hangs the worker until
+// the test runner's own timeout fires, with none of Biloba's diagnostics attached.  30s mirrors
+// Go's navigationTimeout (navigation.go): generous enough for a real page load, a fresh browser
+// context, or a slow evaluate, short enough to surface as a Biloba TIMEOUT.  A caller that knows
+// better passes timeoutMs.  The polling operations (click/setValue/assert) deliberately get no
+// default: their deadline is derived from the poll timeout so the client never gives up before the
+// daemon's own poll does.
+const defaultDeadlineMs = 30_000;
+
+function withDefaultDeadline(options: TransportOptions): TransportOptions {
+  return {...options, deadlineMs: options.deadlineMs ?? options.timeoutMs ?? defaultDeadlineMs};
+}
+
+interface PendingRequest {
+  resolve(value: unknown): void;
+  reject(reason: unknown): void;
+  cleanup(): void;
+}
+
+export class StdioTransport {
+  readonly #input: Readable;
+  readonly #output: Writable;
+  readonly #decoder = new FrameDecoder();
+  readonly #pending = new Map<number, PendingRequest>();
+  #nextID = 1;
+  #closed = false;
+  #writeChain = Promise.resolve();
+
+  constructor(input: Readable, output: Writable, options: {failOnEnd?: boolean} = {}) {
+    this.#input = input;
+    this.#output = output;
+    input.pipe(this.#decoder);
+    this.#decoder.on("data", (response: Response) => this.#receive(response));
+    this.#decoder.on("error", (error: Error) => this.fail(error));
+    input.on("error", (error: Error) => this.fail(error));
+    output.on("error", (error: Error) => this.fail(error));
+    if (options.failOnEnd !== false) {
+      input.on("end", () => this.fail(new Error("bilobad closed stdout")));
+    }
+  }
+
+  close(): void {
+    this.fail(new Error("Biloba transport closed"));
+  }
+
+  fail(error: Error, daemonDetail?: string): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#input.unpipe(this.#decoder);
+    const failure = new BilobaError({
+      code: "DRIVER_CLOSED",
+      message: error.message,
+      ...(daemonDetail && {daemonDetail}),
+    });
+    for (const request of this.#pending.values()) {
+      request.cleanup();
+      request.reject(failure);
+    }
+    this.#pending.clear();
+  }
+
+  handshake(request: HandshakeRequest, options: TransportOptions = {}): Promise<HandshakeResponse> {
+    return this.#request("handshake", request, withDefaultDeadline(options));
+  }
+  openSession(request: OpenSessionRequest, options: TransportOptions = {}): Promise<OpenSessionResponse> {
+    return this.#request("openSession", request, withDefaultDeadline(options));
+  }
+  prepareSession(request: SessionRequest, options: TransportOptions = {}): Promise<Record<string, never>> {
+    return this.#request("prepareSession", request, withDefaultDeadline(options));
+  }
+  closeSession(request: SessionRequest, options: TransportOptions = {}): Promise<Record<string, never>> {
+    return this.#request("closeSession", request, withDefaultDeadline(options));
+  }
+  navigate(request: NavigateRequest, options: TransportOptions = {}): Promise<OperationResult> {
+    return this.#request("navigate", request, withDefaultDeadline(options));
+  }
+  setCookies(request: SetCookiesRequest, options: TransportOptions = {}): Promise<OperationResult> {
+    return this.#request("setCookies", request, withDefaultDeadline(options));
+  }
+  click(request: LocatorRequest, options: TransportOptions = {}): Promise<OperationResult> {
+    return this.#request("click", request, options);
+  }
+  setValue(request: SetValueRequest, options: TransportOptions = {}): Promise<OperationResult> {
+    return this.#request("setValue", request, options);
+  }
+  evaluate(request: EvaluateRequest, options: TransportOptions = {}): Promise<OperationResult> {
+    return this.#request("evaluate", request, withDefaultDeadline(options));
+  }
+  assert(request: AssertRequest, options: TransportOptions = {}): Promise<OperationResult> {
+    return this.#request("assert", request, options);
+  }
+
+  async #request<Result>(method: string, params: object, options: TransportOptions): Promise<Result> {
+    if (this.#closed) throw new BilobaError({code: "DRIVER_CLOSED", message: "Biloba transport is closed"});
+    if (options.signal?.aborted) throw abortedError(options.signal.reason);
+    const id = this.#nextID++;
+    return await new Promise<Result>((resolve, reject) => {
+      let timer: NodeJS.Timeout | undefined;
+      const abort = () => {
+        this.#pending.delete(id);
+        cleanup();
+        this.#cancel(id);
+        reject(abortedError(options.signal?.reason));
+      };
+      const cleanup = () => {
+        if (timer) clearTimeout(timer);
+        options.signal?.removeEventListener("abort", abort);
+      };
+      this.#pending.set(id, {
+        resolve: (value) => resolve(value as Result),
+        reject,
+        cleanup,
+      });
+      options.signal?.addEventListener("abort", abort, {once: true});
+      const deadlineMs = options.deadlineMs ?? options.timeoutMs;
+      if (deadlineMs !== undefined) {
+        timer = setTimeout(() => {
+          this.#pending.delete(id);
+          cleanup();
+          this.#cancel(id);
+          reject(new BilobaError({code: "TIMEOUT", message: `Biloba request timed out after ${deadlineMs}ms`}));
+        }, deadlineMs);
+      }
+      void this.#write({
+        id,
+        method,
+        params,
+        ...(deadlineMs !== undefined && {timeoutMs: deadlineMs}),
+      }).catch((error: unknown) => {
+        const pending = this.#pending.get(id);
+        if (!pending) return;
+        this.#pending.delete(id);
+        pending.cleanup();
+        pending.reject(error);
+      });
+    });
+  }
+
+  // Cancellation is best effort: the caller's promise is already being rejected locally, so a cancel
+  // frame that cannot be written (closed transport, broken pipe) is nothing to report - and an
+  // unhandled rejection here would take the whole worker process down.
+  #cancel(id: number): void {
+    this.#write({id: 0, method: "cancel", params: {requestId: id}}).catch(() => undefined);
+  }
+
+  #receive(response: Response): void {
+    const pending = this.#pending.get(response.id);
+    if (!pending) return;
+    this.#pending.delete(response.id);
+    pending.cleanup();
+    if (response.error) pending.reject(protocolError(response.error));
+    else if (response.result === undefined) pending.reject(new BilobaError({code: "DRIVER_ERROR", message: "Biloba response contained no result"}));
+    else pending.resolve(response.result);
+  }
+
+  #write(value: unknown): Promise<void> {
+    const write = async () => {
+      if (this.#closed) throw new BilobaError({code: "DRIVER_CLOSED", message: "Biloba transport is closed"});
+      const frame = encodeFrame(value);
+      if (this.#output.write(frame)) return;
+      await new Promise<void>((resolve, reject) => {
+        const cleanup = () => { this.#output.removeListener("drain", drained); this.#output.removeListener("error", failed); };
+        const drained = () => { cleanup(); resolve(); };
+        const failed = (error: Error) => { cleanup(); reject(error); };
+        this.#output.once("drain", drained);
+        this.#output.once("error", failed);
+      });
+    };
+    const operation = this.#writeChain.then(write);
+    this.#writeChain = operation.catch(() => undefined);
+    return operation;
+  }
+}
+
+function protocolError(error: ProtocolError): BilobaError {
+  return new BilobaError({
+    code: error.code,
+    message: error.message,
+    ...(error.diagnostics?.locator && {locator: error.diagnostics.locator}),
+    ...(error.diagnostics?.expected && {expected: error.diagnostics.expected}),
+    ...(error.diagnostics?.domOutline && {domOutline: error.diagnostics.domOutline}),
+    ...(error.diagnostics?.screenshotPath && {screenshotPath: error.diagnostics.screenshotPath}),
+    ...(error.diagnostics?.daemonDetail && {daemonDetail: error.diagnostics.daemonDetail}),
+  });
+}
+
+function abortedError(reason: unknown): BilobaError {
+  const suffix = reason === undefined ? "" : `: ${String(reason)}`;
+  return new BilobaError({code: "CANCELLED", message: `Biloba operation cancelled${suffix}`});
+}

--- a/typescript/test/client.test.ts
+++ b/typescript/test/client.test.ts
@@ -1,0 +1,352 @@
+import {PassThrough} from "node:stream";
+import {afterEach, beforeEach, describe, expect, it} from "vitest";
+
+import {
+  BilobaError,
+  type AssertionResult,
+  type Browser,
+  type Cookie,
+} from "../src/index.js";
+import {connectWithTransport} from "../src/internal/client.js";
+import type {HandshakeResponse, OpenSessionResponse, OperationResult, Request} from "../src/generated/protocol.js";
+import {encodeFrame, FrameDecoder} from "../src/internal/framing.js";
+import {expectTimedOutAction, expectTimedOutAssertion} from "./support/assertions.js";
+import {StdioTransport} from "../src/internal/stdio-transport.js";
+
+// The stub daemon answers with the generated response types, not a free-form object.  A fake that
+// can emit shapes the real daemon never emits is a fake that silently drifts: before this was
+// typed, every operation here replied without timings/rpcRequestCount/rpcResponseCount, which
+// resultToWire (protocol/server.go) always sets and the generated declarations mark required.
+// These tests are about the client's translation layer - the wire shape they translate has to be
+// one the daemon could actually produce.
+type Respond = (result: OperationResult) => void;
+type Implementation = (request: Record<string, unknown>, respond: Respond) => void;
+
+// Fills in the fields resultToWire sets on every single response, so a test only has to state the
+// part it actually cares about.
+function operationResult(overrides: Partial<OperationResult> = {}): OperationResult {
+  return {
+    matched: true,
+    attemptCount: 1,
+    timings: {startedUnixMs: 1_700_000_000_000, elapsedMs: 0},
+    rpcRequestCount: 1,
+    rpcResponseCount: 1,
+    ...overrides,
+  };
+}
+
+describe("Biloba TypeScript client", () => {
+  let transport: StdioTransport;
+  let toClient: PassThrough;
+  let browser: Browser | undefined;
+  let assertImplementation: Implementation;
+  let clickImplementation: Implementation;
+  let observeCancel: (() => void) | undefined;
+  const requests: Array<{method: string; request: Record<string, unknown>}> = [];
+  let openedSessions = 0;
+
+  beforeEach(() => {
+    requests.length = 0;
+    openedSessions = 0;
+    assertImplementation = (_request, respond) => {
+      respond(operationResult({
+        observedJson: JSON.stringify("Saved"),
+        attemptCount: 2,
+        trajectory: [
+          {attempt: 1, elapsedMs: 0, observedJson: JSON.stringify("Saving")},
+          {attempt: 2, elapsedMs: 10, observedJson: JSON.stringify("Saved")},
+        ],
+      }));
+    };
+    clickImplementation = (_request, respond) => respond(operationResult());
+    observeCancel = undefined;
+    const fromClient = new PassThrough();
+    toClient = new PassThrough();
+    transport = new StdioTransport(toClient, fromClient);
+    const decoder = new FrameDecoder();
+    fromClient.pipe(decoder);
+    decoder.on("data", (request: Request) => handleRequest(request));
+  });
+
+  afterEach(async () => {
+    await browser?.close();
+    transport.close();
+  });
+
+  function handleRequest(envelope: Request): void {
+    const request = envelope.params as Record<string, unknown>;
+    const method = envelope.method[0]!.toUpperCase() + envelope.method.slice(1);
+    requests.push({method, request});
+    const reply = (result: unknown) => toClient.write(encodeFrame({id: envelope.id, result}));
+    const respond: Respond = reply;
+    switch (envelope.method) {
+      case "handshake": reply({protocolVersion: "1", capabilities: ["assertions", "evaluate"]} satisfies HandshakeResponse); break;
+      case "openSession": reply({sessionId: `session-${++openedSessions}`} satisfies OpenSessionResponse); break;
+      case "evaluate": respond(operationResult({observedJson: JSON.stringify({ready: true})})); break;
+      case "assert": assertImplementation(request, respond); break;
+      case "click": clickImplementation(request, respond); break;
+      case "cancel": observeCancel?.(); break;
+      case "closeSession":
+      case "prepareSession": reply({}); break;
+      default: respond(operationResult());
+    }
+  }
+
+  async function connectClient(): Promise<Browser> {
+    return await connectWithTransport(transport);
+  }
+
+  it("negotiates the protocol and sends idiomatic session operations over gRPC", async () => {
+    browser = await connectClient();
+    expect(browser.protocolVersion).toBe("1");
+    expect(browser.capabilities).toEqual(new Set(["assertions", "evaluate"]));
+
+    const session = await browser.openSession();
+    const cookies: Cookie[] = [{name: "auth", value: "abc", domain: "localhost", httpOnly: true}];
+    await session.prepare();
+    await session.setCookies(cookies);
+    await session.navigate("http://localhost/bookings");
+    await session.getByRole("button", {name: "Save", exact: true}).first().click();
+    await session.getByTestId("name").setValue("Ada");
+    expect(await session.evaluate<{ready: boolean}>("window.appState")).toEqual({ready: true});
+    await session.close();
+
+    expect(requests).toMatchObject([
+      {method: "Handshake", request: {protocolVersion: "1"}},
+      {method: "OpenSession"},
+      {method: "PrepareSession", request: {sessionId: "session-1"}},
+      {method: "SetCookies", request: {sessionId: "session-1", cookies}},
+      {method: "Navigate", request: {sessionId: "session-1", url: "http://localhost/bookings"}},
+      {
+        method: "Click",
+        request: {
+          sessionId: "session-1",
+          locator: {
+            kind: "ROLE",
+            role: "button",
+            name: "Save",
+            match: "EXACT",
+            first: true,
+          },
+        },
+      },
+      {
+        method: "SetValue",
+        request: {
+          sessionId: "session-1",
+          locator: {kind: "TEST_ID", value: "name", match: "EXACT", first: false},
+          valueJson: JSON.stringify("Ada"),
+        },
+      },
+      {
+        method: "Evaluate",
+        request: {sessionId: "session-1", expression: "window.appState", argumentsJson: "[]", invoke: false},
+      },
+      {method: "CloseSession", request: {sessionId: "session-1"}},
+    ]);
+  });
+
+  it("expresses every pilot locator and assertion as one RPC", async () => {
+    browser = await connectClient();
+    const session = await browser.openSession();
+
+    const results: AssertionResult[] = [
+      await session.locator("main").expectVisible(),
+      await session.getByText("Saved", {exact: false}).expectText("Saved", {exact: true, timeoutMs: 50}),
+      await session.locator("article").expectCount(3),
+      await session.getByTestId("save").expectAttribute("aria-busy", "false"),
+      await session.locator("input").expectValue("Ada"),
+      await session.expectUrl("/bookings", {pathname: true}),
+      await session.expectEvaluation("window.ready", true),
+    ];
+
+    expect(results.every((result) => result.attemptCount === 2)).toBe(true);
+    expect(results.every((result) => result.rpcRequestCount === 1 && result.rpcResponseCount === 1)).toBe(true);
+    expect(requests.filter(({method}) => method === "Assert")).toHaveLength(7);
+    expect(requests.at(-1)).toMatchObject({
+      method: "Assert",
+      request: {
+        sessionId: "session-1",
+        assertion: {
+          kind: "EVALUATE",
+          expression: "window.ready",
+          expectedJson: "true",
+        },
+      },
+    });
+  });
+
+  it("hands out an independent session per openSession call", async () => {
+    browser = await connectClient();
+
+    const first = await browser.openSession();
+    const second = await browser.openSession();
+
+    expect(first).not.toBe(second);
+    expect(first.id).not.toBe(second.id);
+    expect(requests.filter(({method}) => method === "OpenSession")).toHaveLength(2);
+
+    await first.close();
+    expect(requests.at(-1)).toMatchObject({method: "CloseSession", request: {sessionId: first.id}});
+
+    // Closing one session leaves its sibling usable - a spec that opens two to prove browser-context
+    // isolation must not silently be talking to one.
+    await second.navigate("http://localhost/other");
+    expect(requests.at(-1)).toMatchObject({method: "Navigate", request: {sessionId: second.id}});
+
+    await browser.close();
+    browser = undefined;
+    expect(requests.filter(({method}) => method === "CloseSession")).toHaveLength(2);
+  });
+
+  it("says whether an evaluation is a function call rather than leaving the daemon to guess", async () => {
+    browser = await connectClient();
+    const session = await browser.openSession();
+
+    // No args array at all: read the expression.
+    await session.evaluate("window.appState");
+    expect(requests.at(-1)).toMatchObject({method: "Evaluate", request: {invoke: false}});
+
+    // An empty args array is still a call - the daemon's pre-invoke inference read this one back as
+    // the function's source instead of running it.
+    await session.evaluate("() => 41 + 1", []);
+    expect(requests.at(-1)).toMatchObject({
+      method: "Evaluate",
+      request: {expression: "() => 41 + 1", argumentsJson: "[]", invoke: true},
+    });
+
+    await session.evaluate("(a) => a + 1", [41]);
+    expect(requests.at(-1)).toMatchObject({method: "Evaluate", request: {argumentsJson: "[41]", invoke: true}});
+  });
+
+  it("accepts cookie expiry timestamps returned by the SIV sign-in helper", async () => {
+    browser = await connectClient();
+    const session = await browser.openSession();
+
+    await session.setCookies([{name: "session", value: "abc", expires: 1_800_000_000}]);
+
+    expect(requests.at(-1)).toMatchObject({
+      method: "SetCookies",
+      request: {
+        cookies: [{name: "session", value: "abc", expiresUnix: 1_800_000_000}],
+      },
+    });
+  });
+
+  it("turns a structured assertion mismatch into a BilobaError at the TypeScript callsite", async () => {
+    assertImplementation = (_request, respond) => {
+      respond(operationResult({
+        matched: false,
+        observedJson: JSON.stringify("Saving"),
+        trajectory: [{attempt: 1, elapsedMs: 0, observedJson: JSON.stringify("Saving"), retryReason: "text mismatch"}],
+        diagnostics: {
+          locator: "getByText(Saved)",
+          expected: "Saved",
+          domOutline: "body\n  button Saving",
+          screenshotPath: "/tmp/failure.png",
+          daemonDetail: "timed out after 50ms",
+        },
+      }));
+    };
+    browser = await connectClient();
+    const session = await browser.openSession();
+
+    const invokeFromTest = () => session.getByText("Saved").expectText("Saved", {timeoutMs: 50});
+    const error = await invokeFromTest().catch((reason: unknown) => reason);
+
+    // the contract every timed-out assertion owes, stub or real daemon
+    expectTimedOutAssertion(error, {locator: "getByText(Saved)", expected: "Saved"});
+    expect(error.message).toContain("last observed: \"Saving\"");
+    expect(error.message).toContain("attempts: 1");
+    expect(error).toMatchObject({
+      code: "TIMEOUT",
+      locator: "getByText(Saved)",
+      expected: "Saved",
+      observed: "Saving",
+      domOutline: "body\n  button Saving",
+      screenshotPath: "/tmp/failure.png",
+      daemonDetail: "timed out after 50ms",
+      rpcRequestCount: 1,
+      rpcResponseCount: 1,
+    });
+    expect((error as Error).stack).toContain("invokeFromTest");
+    expect((error as BilobaError).trajectory).toEqual([
+      {attempt: 1, elapsedMs: 0, observed: "Saving", retryReason: "text mismatch"},
+    ]);
+  });
+
+  it("rejects a timed-out action instead of silently accepting a successful RPC envelope", async () => {
+    clickImplementation = (_request, respond) => respond(operationResult({
+      matched: false,
+      attemptCount: 3,
+      // The daemon builds this from engine.Poll's attempts, which always records at least one, so
+      // a timed-out operation without a trajectory is a shape it cannot produce.  The stub used to
+      // claim exactly that; the shared contract in support/assertions.ts caught it.
+      trajectory: [
+        {attempt: 1, elapsedMs: 0},
+        {attempt: 2, elapsedMs: 7},
+        {attempt: 3, elapsedMs: 14},
+      ],
+      diagnostics: {
+        locator: `locator("#missing")`,
+        expected: "operation to succeed",
+        daemonDetail: "poll: context deadline exceeded",
+      },
+    }));
+    browser = await connectClient();
+    const session = await browser.openSession();
+
+    const invokeFromTest = () => session.locator("#missing").click({timeoutMs: 20});
+    const error = await invokeFromTest().catch((reason: unknown) => reason);
+
+    expectTimedOutAction(error, {locator: `locator("#missing")`, operation: "click"});
+    expect(error.stack).toContain("invokeFromTest");
+  });
+
+  it("cancels the in-flight assertion when its AbortSignal aborts", async () => {
+    let observeStart!: () => void;
+    let observeCancellation!: () => void;
+    const started = new Promise<void>((resolve) => {
+      observeStart = resolve;
+    });
+    const cancelled = new Promise<void>((resolve) => {
+      observeCancellation = resolve;
+    });
+    assertImplementation = () => {
+      observeStart();
+    };
+    observeCancel = observeCancellation;
+    browser = await connectClient();
+    const session = await browser.openSession();
+    const controller = new AbortController();
+
+    const assertion = session.locator("main").expectVisible({signal: controller.signal});
+    await started;
+    controller.abort("worker stopped");
+
+    await expect(assertion).rejects.toMatchObject({code: "CANCELLED"});
+    await cancelled;
+  });
+
+  it("uses the assertion timeout as the request deadline and keeps the test callsite", async () => {
+    assertImplementation = () => {};
+    browser = await connectClient();
+    const session = await browser.openSession();
+
+    const invokeTimedAssertion = () => session.locator("main").expectVisible({timeoutMs: 20});
+    const error = await invokeTimedAssertion().catch((reason: unknown) => reason);
+
+    expect(error).toMatchObject({code: "TIMEOUT"});
+    expect((error as Error).stack).toContain("invokeTimedAssertion");
+  });
+});
+
+describe("published entry point", () => {
+  it("exposes only the public API, keeping internal seams out of dist/index.js", async () => {
+    // tsconfig.build.json's stripInternal deletes an `@internal` export from the .d.ts but not from
+    // the emitted JS, so anything exported here ships as an untyped escape hatch.  Internal modules
+    // are unreachable through the package's "exports" map, which is where seams belong.
+    const api: Record<string, unknown> = await import("../src/index.js");
+    expect(Object.keys(api).sort()).toEqual(["BilobaError", "connect", "startDaemon", "startSharedBrowser"]);
+  });
+});

--- a/typescript/test/daemon-manager.test.ts
+++ b/typescript/test/daemon-manager.test.ts
@@ -1,0 +1,138 @@
+import {mkdtemp, readFile, rm, writeFile, chmod} from "node:fs/promises";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterEach, describe, expect, it} from "vitest";
+
+import {connect, startDaemon, startSharedBrowser, type DaemonProcess, type SharedBrowserProcess} from "../src/index.js";
+
+describe("bilobad process manager", () => {
+  let daemon: DaemonProcess | undefined;
+  let browser: SharedBrowserProcess | undefined;
+  let directory: string | undefined;
+
+  afterEach(async () => {
+    await daemon?.stop();
+    await browser?.stop();
+    if (directory) await rm(directory, {recursive: true, force: true});
+  });
+
+  it("spawns a supplied executable with protocol-only stdio", async () => {
+    directory = await mkdtemp(join(tmpdir(), "biloba-daemon-test-"));
+    const executable = join(directory, "fake-bilobad");
+    const argumentsPath = join(directory, "arguments.json");
+    await writeFile(executable, `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.writeFileSync(${JSON.stringify(argumentsPath)}, JSON.stringify(process.argv.slice(2)));
+process.on("SIGTERM", () => process.exit(0));
+process.stdin.resume();
+process.stdin.on("end", () => process.exit(0));
+setInterval(() => {}, 1000);
+`);
+    await chmod(executable, 0o755);
+
+    daemon = await startDaemon({
+      executable,
+      chromePath: "/opt/chrome",
+      artifactDir: "/tmp/biloba-artifacts",
+    });
+
+    await expect.poll(async () => await readFile(argumentsPath, "utf8").catch(() => "")).not.toBe("");
+    expect(JSON.parse(await readFile(argumentsPath, "utf8"))).toEqual([
+      "--chrome-path=/opt/chrome",
+      "--artifact-dir=/tmp/biloba-artifacts",
+    ]);
+    expect(daemon.pid).toBeGreaterThan(0);
+
+    const pid = daemon.pid;
+    await daemon.stop();
+    expect(() => process.kill(pid, 0)).toThrow();
+  });
+
+  it("reports retained stderr when the daemon exits before handshake", async () => {
+    directory = await mkdtemp(join(tmpdir(), "biloba-daemon-test-"));
+    const executable = join(directory, "broken-bilobad");
+    await writeFile(executable, `#!/usr/bin/env node
+process.stderr.write("chrome executable is missing\\n");
+process.exit(7);
+`);
+    await chmod(executable, 0o755);
+
+    await expect(connect({daemonExecutable: executable})).rejects.toMatchObject({
+      code: "DRIVER_CLOSED",
+      daemonDetail: "chrome executable is missing\n",
+    });
+  });
+
+  it("starts a shared-browser host and reads its websocket endpoint", async () => {
+    directory = await mkdtemp(join(tmpdir(), "biloba-browser-test-"));
+    const executable = join(directory, "fake-bilobad");
+    await writeFile(executable, `#!/usr/bin/env node
+if (process.argv[2] !== "serve-browser") process.exit(2);
+console.log(JSON.stringify({wsURL: "ws://127.0.0.1:43123/devtools/browser/test", width: 1920, height: 1080}));
+process.stdin.resume();
+process.stdin.on("end", () => process.exit(0));
+setInterval(() => {}, 1000);
+`);
+    await chmod(executable, 0o755);
+
+    browser = await startSharedBrowser({executable, chromePath: "/opt/chrome"});
+    expect(browser.wsURL).toBe("ws://127.0.0.1:43123/devtools/browser/test");
+    expect(browser.pid).toBeGreaterThan(0);
+  });
+
+  it.runIf(process.platform !== "win32")("signals the process group while the daemon is still alive", async () => {
+    directory = await mkdtemp(join(tmpdir(), "biloba-daemon-test-"));
+    const executable = join(directory, "slow-bilobad");
+    const signalPath = join(directory, "sigterm.txt");
+    const readyPath = join(directory, "ready.txt");
+    // Exits a beat after stdin closes, so a group signal sent only from the exit handler - once the
+    // pgid may already have been recycled - would never reach this process at all.
+    await writeFile(executable, `#!/usr/bin/env node
+const fs = require("node:fs");
+process.on("SIGTERM", () => { fs.writeFileSync(${JSON.stringify(signalPath)}, "sigterm"); process.exit(0); });
+fs.writeFileSync(${JSON.stringify(readyPath)}, "ready");
+process.stdin.resume();
+process.stdin.on("end", () => setTimeout(() => process.exit(0), 100));
+setInterval(() => {}, 1000);
+`);
+    await chmod(executable, 0o755);
+    daemon = await startDaemon({executable});
+    await expect.poll(async () => await readFile(readyPath, "utf8").catch(() => "")).toBe("ready");
+
+    await daemon.stop();
+
+    expect(await readFile(signalPath, "utf8").catch(() => "")).toBe("sigterm");
+  });
+
+  it.runIf(process.platform !== "win32")("reaps descendant processes when the daemon stops", async () => {
+    directory = await mkdtemp(join(tmpdir(), "biloba-daemon-test-"));
+    const executable = join(directory, "daemon-with-child");
+    const descendantPath = join(directory, "descendant.pid");
+    await writeFile(executable, `#!/usr/bin/env node
+const fs = require("node:fs");
+const {spawn} = require("node:child_process");
+const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {stdio: "ignore"});
+fs.writeFileSync(${JSON.stringify(descendantPath)}, String(child.pid));
+process.stdin.resume();
+process.stdin.on("end", () => process.exit(0));
+setInterval(() => {}, 1000);
+`);
+    await chmod(executable, 0o755);
+    daemon = await startDaemon({executable});
+    await expect.poll(async () => await readFile(descendantPath, "utf8").catch(() => "")).not.toBe("");
+    const descendantPid = Number(await readFile(descendantPath, "utf8"));
+
+    await daemon.stop();
+
+    await expect.poll(() => processExists(descendantPid), {timeout: 2_000}).toBe(false);
+  });
+});
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+}

--- a/typescript/test/e2e/crash.e2e.test.ts
+++ b/typescript/test/e2e/crash.e2e.test.ts
@@ -1,0 +1,157 @@
+import {execSync, spawn} from "node:child_process";
+import {mkdtemp, writeFile} from "node:fs/promises";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {afterAll, beforeAll, expect, inject, it} from "vitest";
+
+import {BilobaError, connect} from "../../src/index.js";
+import {connectWorker, type Worker} from "./harness.js";
+
+// The crash scenarios, in one file and in a deliberate order: the recoverable ones first, the
+// terminal one last, because it destroys the Chrome the others need.  vitest runs `it`s in source
+// order within a file, which makes that ordering explicit and local rather than a property of how
+// the runner happens to schedule files.  This file gets its own vitest run - and so its own Chrome -
+// for the same reason (see vitest.e2e-crash.config.ts).
+//
+// What every case here pins is a *diagnosis*.  A crash that reports itself as an assertion timeout
+// is worse than useless: it says the page never reached the expected state, which sends the reader
+// off to debug a test that was fine.
+let worker: Worker;
+
+beforeAll(async () => { worker = await connectWorker("crash"); });
+afterAll(async () => { try { await worker?.browser.close(); } catch { /* expected once Chrome is gone */ } });
+
+it("names a crashed page instead of hanging until the deadline", async () => {
+  await worker.session.getByRole("heading", {name: "Biloba parity"}).expectVisible();
+
+  killRenderers();
+
+  // Chrome does not fail calls to a dead renderer, it stops answering them.  So this first call is
+  // the one that used to sit on a renderer that would never reply, for the whole 30s default
+  // deadline, before reporting a timeout - the session interrupts it on Inspector.targetCrashed
+  // instead.  The bound is what pins that: without the interrupt this takes 30s.
+  const started = Date.now();
+  const first = await codeOf(worker.session.evaluate("1 + 1"));
+  expect(Date.now() - started, "a call in flight when the renderer dies must be interrupted, not left to its deadline").toBeLessThan(10_000);
+  // Chrome announces the crash asynchronously, so this one may still land in the teardown window.
+  expect(["PAGE_CRASHED", "CANCELLED"]).toContain(first);
+
+  // What matters is where it settles, and that it settles at all.
+  await expect.poll(() => codeOf(worker.session.evaluate("1 + 1")), {timeout: 10_000}).toBe("PAGE_CRASHED");
+  const failure = await worker.session.evaluate("1 + 1").catch((error: unknown) => error);
+  expect(failure).toBeInstanceOf(BilobaError);
+  expect((failure as BilobaError).message).toMatch(/navigate the session again to recover/);
+});
+
+it("recovers a crashed page on the next navigation", async () => {
+  // The advice in that message has to be true, or it is just a nicer-sounding dead end.
+  await worker.session.navigate(worker.baseUrl);
+
+  await worker.session.getByRole("heading", {name: "Biloba parity"}).expectVisible();
+  expect(await worker.session.evaluate<number>("1 + 1")).toBe(2);
+});
+
+it("reaps a worker's daemon when the worker dies without closing, leaving the others alone", async () => {
+  // A vitest worker that is killed - or crashes - never runs its teardown.  Its daemon has to notice
+  // the pipe close on its own, and taking Chrome or anyone else's session with it is not an option.
+  // The helper spawns bilobad the way the client does - piped stdio, its own process group - rather
+  // than importing the client, because it runs under plain node with no transpiler.  The mechanism
+  // under test is the daemon noticing its stdin close, and this exercises exactly that.
+  const directory = await mkdtemp(join(tmpdir(), "biloba-crash-"));
+  const script = join(directory, "worker.mjs");
+  await writeFile(script, [
+    `import {spawn} from "node:child_process";`,
+    `const daemon = spawn(${JSON.stringify(inject("daemonExecutable"))}, ["--chrome-ws-url=" + ${JSON.stringify(inject("chromeWsUrl"))}], {stdio: ["pipe", "pipe", "pipe"], detached: true});`,
+    `daemon.once("spawn", () => console.log("READY"));`,
+    `setInterval(() => {}, 1000);`,
+  ].join("\n"));
+
+  const child = spawn(process.execPath, [script], {stdio: ["ignore", "pipe", "pipe"]});
+  await new Promise<void>((resolve, reject) => {
+    child.stdout.on("data", (chunk: Buffer) => { if (chunk.toString().includes("READY")) resolve(); });
+    child.once("error", reject);
+    child.once("exit", (code) => reject(new Error(`helper worker exited early (${String(code)})`)));
+  });
+  const before = daemonCount();
+  expect(before, "the helper worker should have started a daemon of its own").toBeGreaterThan(1);
+
+  child.kill("SIGKILL");
+
+  await expect.poll(() => daemonCount(), {timeout: 10_000}).toBe(before - 1);
+  expect(chromeIsRunning(), "one worker dying must not take the shared browser with it").toBe(true);
+  await worker.session.getByRole("heading", {name: "Biloba parity"}).expectVisible();
+});
+
+it("reports why it could not reach Chrome, rather than a bare startup failure", async () => {
+  // Nothing is listening on port 1.  The daemon exits during startup and the reason has to survive
+  // the trip back, or the user is left guessing at an exit code.
+  const failure = await connect({
+    daemonExecutable: inject("daemonExecutable"),
+    chromeWsUrl: "ws://127.0.0.1:1/devtools/browser/nope",
+  }).catch((error: unknown) => error);
+
+  expect(failure).toBeInstanceOf(BilobaError);
+  expect((failure as BilobaError).code).toBe("DRIVER_CLOSED");
+  expect((failure as BilobaError).daemonDetail, "the daemon's stderr is the only place the real cause exists").toMatch(/connect browser/);
+});
+
+// Terminal: everything above needs a live Chrome, so this runs last.
+it("tells a worker the browser is gone instead of blaming its assertion", async () => {
+  killSharedChrome();
+
+  const started = Date.now();
+  const failure = await worker.session.locator("h1").expectVisible({timeoutMs: 10_000, intervalMs: 50})
+    .catch((error: unknown) => error);
+
+  expect(failure).toBeInstanceOf(BilobaError);
+  expect((failure as BilobaError).code, "a dead browser is not an assertion timeout").toBe("BROWSER_GONE");
+  expect((failure as BilobaError).message).toMatch(/browser is no longer available/);
+  expect(Date.now() - started, "the poll must stop as soon as it learns the browser is gone").toBeLessThan(5_000);
+});
+
+it("reports the same thing for a one-shot operation", async () => {
+  const failure = await worker.session.evaluate("1 + 1").catch((error: unknown) => error);
+
+  expect((failure as BilobaError).code).toBe("BROWSER_GONE");
+});
+
+/** Resolves to the BilobaError code an operation fails with, or "OK" if it succeeds. */
+async function codeOf(operation: Promise<unknown>): Promise<string> {
+  try {
+    await operation;
+    return "OK";
+  } catch (error) {
+    return (error as BilobaError).code;
+  }
+}
+
+function pids(pattern: string): string[] {
+  return execSync(`pgrep -f -- ${JSON.stringify(pattern)} || true`).toString().trim().split("\n").filter(Boolean);
+}
+
+function daemonCount(): number {
+  return pids("--chrome-ws-url").length;
+}
+
+function chromeIsRunning(): boolean {
+  return pids("chrome-headless-shell").length > 0;
+}
+
+/** Kills the renderer processes, leaving the browser process alive - Chrome's "Aw, Snap". */
+function killRenderers(): void {
+  const renderers = pids("--type=renderer");
+  expect(renderers.length, "expected a renderer to be running").toBeGreaterThan(0);
+  for (const pid of renderers) {
+    try { process.kill(Number(pid), "SIGKILL"); } catch { /* already gone */ }
+  }
+}
+
+/** SIGKILL, so there is no orderly CDP shutdown - the daemon finds out the way it would if Chrome
+ *  had crashed or been OOM-killed, which is the case worth testing. */
+function killSharedChrome(): void {
+  const running = pids("chrome-headless-shell");
+  expect(running.length, "expected a shared Chrome to be running").toBeGreaterThan(0);
+  for (const pid of running) {
+    try { process.kill(Number(pid), "SIGKILL"); } catch { /* already gone */ }
+  }
+}

--- a/typescript/test/e2e/crash.e2e.test.ts
+++ b/typescript/test/e2e/crash.e2e.test.ts
@@ -125,33 +125,80 @@ async function codeOf(operation: Promise<unknown>): Promise<string> {
   }
 }
 
-function pids(pattern: string): string[] {
-  return execSync(`pgrep -f -- ${JSON.stringify(pattern)} || true`).toString().trim().split("\n").filter(Boolean);
+/**
+ * Every process on the machine, as (pgid, pid, command line).
+ *
+ * `ps -A` rather than `-e`: BSD ps (macOS) reads `-e` as "also show the environment".  `-ww` keeps
+ * the command line from being truncated, which the matching below depends on.
+ */
+function processTable(): {pgid: number; pid: number; args: string}[] {
+  return execSync("ps -A -ww -o pgid=,pid=,args=").toString().split("\n").flatMap((line) => {
+    const fields = /^\s*(\d+)\s+(\d+)\s+(\S.*?)\s*$/.exec(line);
+    if (!fields?.[3]) return [];
+    return [{pgid: Number(fields[1]), pid: Number(fields[2]), args: fields[3]}];
+  });
 }
 
-function daemonCount(): number {
-  return pids("--chrome-ws-url").length;
+/**
+ * The shared Chrome's processes - and only those.
+ *
+ * The scoping is the whole point of this helper, because everything below SIGKILLs what it finds.
+ * A `pgrep -f chrome-headless-shell` would sweep the entire machine and take out a developer's own
+ * browser, a concurrent `make test`, or another checkout's suite.  globalSetup spawns the browser
+ * host detached (browser-manager.ts), so the host leads a process group of its own and every
+ * process Chrome forks beneath it inherits that group id - which turns the pid vitest handed us
+ * into an exact, per-run boundary.  It is the same boundary the harness already uses to stop the
+ * browser (`process.kill(-pid)`), and unlike a parent-walk it still holds for a renderer that has
+ * been reparented away from its zygote.  The host itself is excluded: these tests kill Chrome, not
+ * the daemon that is supposed to notice.
+ */
+function chromeProcesses(): {pid: number; args: string}[] {
+  const host = inject("chromePid");
+  return processTable()
+    .filter((entry) => entry.pgid === host && entry.pid !== host)
+    .map((entry) => ({pid: entry.pid, args: entry.args}));
+}
+
+/** Chrome's browser process: the group member that is neither the host nor a `--type=` helper. */
+function chromeBrowserProcesses(): {pid: number; args: string}[] {
+  return chromeProcesses().filter((entry) => !entry.args.includes("--type="));
 }
 
 function chromeIsRunning(): boolean {
-  return pids("chrome-headless-shell").length > 0;
+  return chromeBrowserProcesses().length > 0;
+}
+
+/**
+ * How many bilobads are attached to *this run's* Chrome.
+ *
+ * Daemons cannot be scoped by process group the way Chrome is - the one this test cares about is
+ * deliberately orphaned when its worker is killed - so they are matched on a marker instead, and
+ * the websocket URL already is one: it carries the port and the per-launch browser guid, so no
+ * other run on the machine can share it.  Counting a bare `--chrome-ws-url` would make the
+ * assertion below depend on nothing else on the box running a daemon.
+ */
+function daemonCount(): number {
+  const marker = `--chrome-ws-url=${inject("chromeWsUrl")}`;
+  return processTable().filter((entry) => entry.args.includes(marker)).length;
 }
 
 /** Kills the renderer processes, leaving the browser process alive - Chrome's "Aw, Snap". */
 function killRenderers(): void {
-  const renderers = pids("--type=renderer");
+  const renderers = chromeProcesses().filter((entry) => entry.args.includes("--type=renderer"));
   expect(renderers.length, "expected a renderer to be running").toBeGreaterThan(0);
-  for (const pid of renderers) {
-    try { process.kill(Number(pid), "SIGKILL"); } catch { /* already gone */ }
-  }
+  sigkill(renderers);
 }
 
 /** SIGKILL, so there is no orderly CDP shutdown - the daemon finds out the way it would if Chrome
  *  had crashed or been OOM-killed, which is the case worth testing. */
 function killSharedChrome(): void {
-  const running = pids("chrome-headless-shell");
-  expect(running.length, "expected a shared Chrome to be running").toBeGreaterThan(0);
-  for (const pid of running) {
-    try { process.kill(Number(pid), "SIGKILL"); } catch { /* already gone */ }
+  const chrome = chromeProcesses();
+  expect(chromeBrowserProcesses().length, "expected a shared Chrome to be running").toBeGreaterThan(0);
+  sigkill(chrome);
+}
+
+function sigkill(processes: readonly {pid: number}[]): void {
+  for (const {pid} of processes) {
+    try { process.kill(pid, "SIGKILL"); } catch { /* already gone */ }
   }
 }

--- a/typescript/test/e2e/global-setup.ts
+++ b/typescript/test/e2e/global-setup.ts
@@ -1,0 +1,66 @@
+import {createReadStream} from "node:fs";
+import {mkdtemp, rm} from "node:fs/promises";
+import {createServer, type Server} from "node:http";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import type {TestProject} from "vitest/node";
+
+import {startSharedBrowser, type SharedBrowserProcess} from "../../src/index.js";
+
+const fixturePath = fileURLToPath(new URL("../../../fixtures/graft-parity.html", import.meta.url));
+
+declare module "vitest" {
+  export interface ProvidedContext {
+    chromeWsUrl: string;
+    chromePid: number;
+    baseUrl: string;
+    rendezvousDir: string;
+    daemonExecutable: string;
+  }
+}
+
+let browser: SharedBrowserProcess | undefined;
+let server: Server | undefined;
+let rendezvousDir: string | undefined;
+
+// One Chrome for the whole run, started here in the main process - before any worker exists - and
+// handed to every worker.  That is the topology this suite exists to prove: N test-runner worker
+// *processes*, one bilobad each, all attached to this single browser.
+export async function setup(project: TestProject): Promise<void> {
+  const daemonExecutable = process.env.BILOBA_DAEMON_EXECUTABLE;
+  if (!daemonExecutable) {
+    throw new Error(
+      "BILOBA_DAEMON_EXECUTABLE is not set, so the multi-worker end-to-end suite cannot run.\n" +
+      "Run `make driver-e2e` from the repository root, or build the daemon with " +
+      "`go build -o .bin/bilobad ./cmd/bilobad` and point BILOBA_DAEMON_EXECUTABLE at it.",
+    );
+  }
+
+  server = createServer((_request, response) => {
+    response.setHeader("content-type", "text/html");
+    createReadStream(fixturePath).pipe(response);
+  });
+  const listening = server;
+  await new Promise<void>((resolve, reject) => {
+    listening.once("error", reject);
+    listening.listen(0, "127.0.0.1", resolve);
+  });
+  const address = listening.address();
+  if (!address || typeof address === "string") throw new Error("fixture server did not bind TCP");
+
+  rendezvousDir = await mkdtemp(join(tmpdir(), "biloba-e2e-rendezvous-"));
+  browser = await startSharedBrowser({executable: daemonExecutable});
+
+  project.provide("chromeWsUrl", browser.wsURL);
+  project.provide("chromePid", browser.pid);
+  project.provide("baseUrl", `http://127.0.0.1:${address.port}`);
+  project.provide("rendezvousDir", rendezvousDir);
+  project.provide("daemonExecutable", daemonExecutable);
+}
+
+export async function teardown(): Promise<void> {
+  await browser?.stop();
+  if (server) await new Promise<void>((resolve, reject) => server!.close((error) => error ? reject(error) : resolve()));
+  if (rendezvousDir) await rm(rendezvousDir, {recursive: true, force: true});
+}

--- a/typescript/test/e2e/harness.ts
+++ b/typescript/test/e2e/harness.ts
@@ -1,0 +1,74 @@
+import {mkdir, readdir, readFile, writeFile} from "node:fs/promises";
+import {join} from "node:path";
+import {expect, inject} from "vitest";
+
+import {connect, type Browser, type Session} from "../../src/index.js";
+
+export interface Worker {
+  readonly name: string;
+  readonly browser: Browser;
+  readonly session: Session;
+  readonly baseUrl: string;
+}
+
+/**
+ * Attaches this worker process to the run's single shared Chrome, through a bilobad of its own.
+ * One daemon per worker, one Chrome for all of them.
+ */
+export async function connectWorker(name: string): Promise<Worker> {
+  const browser = await connect({
+    daemonExecutable: inject("daemonExecutable"),
+    chromeWsUrl: inject("chromeWsUrl"),
+  });
+  const session = await browser.openSession();
+  await session.prepare();
+  await session.navigate(inject("baseUrl"));
+  return {name, browser, session, baseUrl: inject("baseUrl")};
+}
+
+/**
+ * A file-backed barrier across worker processes.
+ *
+ * It is doing two jobs.  The obvious one is ordering: hold every worker at a known point so the
+ * next assertion happens while the others are demonstrably still live.  The subtler one is that it
+ * *proves the workers are concurrent processes at all* - if vitest ran these files serially, or in
+ * one process, the first worker to arrive would wait here until it timed out.  A green run is
+ * therefore evidence of the topology, not just of the assertions inside it.
+ */
+export async function rendezvous(stage: string, name: string, expected: number, payload: unknown = {}): Promise<Record<string, unknown>[]> {
+  const directory = join(inject("rendezvousDir"), stage);
+  await mkdir(directory, {recursive: true});
+  await writeFile(join(directory, `${name}.json`), JSON.stringify({name, pid: process.pid, ...(payload as object)}));
+
+  const deadline = Date.now() + 30_000;
+  for (;;) {
+    const entries = await readdir(directory);
+    if (entries.length >= expected) {
+      return await Promise.all(entries.map(async (entry) =>
+        JSON.parse(await readFile(join(directory, entry), "utf8")) as Record<string, unknown>));
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        `rendezvous "${stage}" timed out: saw ${entries.length} of ${expected} workers (${entries.join(", ") || "none"}).\n` +
+        "The e2e suite requires its test files to run concurrently, in separate processes - check " +
+        "fileParallelism/minForks in vitest.e2e.config.ts, and that no file failed before reaching this point.",
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+/** Asserts this worker sees only the state it created - no bleed from the workers beside it. */
+export async function expectOwnStateOnly(worker: Worker): Promise<void> {
+  const state = await worker.session.evaluate<{cookie: string; stored: string | null}>(
+    `({cookie: document.cookie, stored: window.localStorage.getItem("owner")})`,
+  );
+  expect(state.stored, `${worker.name} should see only its own localStorage`).toBe(worker.name);
+  expect(state.cookie, `${worker.name} should see only its own cookie`).toBe(`owner=${worker.name}`);
+}
+
+/** Writes this worker's marker state into its own isolated browser context. */
+export async function claimState(worker: Worker): Promise<void> {
+  await worker.session.setCookies([{name: "owner", value: worker.name, domain: "127.0.0.1", path: "/"}]);
+  await worker.session.evaluate(`window.localStorage.setItem("owner", ${JSON.stringify(worker.name)})`);
+}

--- a/typescript/test/e2e/harness.ts
+++ b/typescript/test/e2e/harness.ts
@@ -1,4 +1,4 @@
-import {mkdir, readdir, readFile, writeFile} from "node:fs/promises";
+import {mkdir, readdir, readFile, rename, writeFile} from "node:fs/promises";
 import {join} from "node:path";
 import {expect, inject} from "vitest";
 
@@ -38,7 +38,16 @@ export async function connectWorker(name: string): Promise<Worker> {
 export async function rendezvous(stage: string, name: string, expected: number, payload: unknown = {}): Promise<Record<string, unknown>[]> {
   const directory = join(inject("rendezvousDir"), stage);
   await mkdir(directory, {recursive: true});
-  await writeFile(join(directory, `${name}.json`), JSON.stringify({name, pid: process.pid, ...(payload as object)}));
+  // Arrive atomically.  writeFile creates the entry before it has any content, so a peer that
+  // listed the directory inside that window would count this worker as arrived and then throw
+  // inside JSON.parse on an empty read - a race that only shows up under load, in the one helper
+  // every file depends on.  Writing beside the barrier and rename()ing in makes the name and the
+  // content appear together (rename is atomic within a filesystem, and the run's rendezvous
+  // directory is one mkdtemp tree), so the reader below needs no tolerance for a half-written
+  // arrival.  The scratch file lives *outside* `directory` on purpose: in it, it would count.
+  const scratch = join(inject("rendezvousDir"), `.${stage}.${name}.${process.pid}.tmp`);
+  await writeFile(scratch, JSON.stringify({name, pid: process.pid, ...(payload as object)}));
+  await rename(scratch, join(directory, `${name}.json`));
 
   const deadline = Date.now() + 30_000;
   for (;;) {

--- a/typescript/test/e2e/worker-alpha.e2e.test.ts
+++ b/typescript/test/e2e/worker-alpha.e2e.test.ts
@@ -1,0 +1,39 @@
+import {afterAll, beforeAll, expect, inject, it} from "vitest";
+
+import {claimState, connectWorker, expectOwnStateOnly, rendezvous, type Worker} from "./harness.js";
+
+// One of three files, therefore one of three vitest worker processes, each with its own bilobad
+// attached to the run's single shared Chrome.  See worker-gamma.e2e.test.ts for the teardown half.
+const NAME = "alpha";
+let worker: Worker;
+
+beforeAll(async () => { worker = await connectWorker(NAME); });
+afterAll(async () => { await worker?.browser.close(); });
+
+it("runs in its own worker process alongside the others", async () => {
+  const peers = await rendezvous("connected", NAME, 3);
+
+  const pids = new Set(peers.map((peer) => peer["pid"]));
+  expect(pids.size, "each test file must get its own worker process").toBe(3);
+  expect(pids.has(process.pid)).toBe(true);
+  expect(pids.has(inject("chromePid")), "workers must be separate from the browser host").toBe(false);
+});
+
+it("keeps its browser state to itself while the other workers write theirs", async () => {
+  await claimState(worker);
+  // Everyone has written before anyone reads, so this is a genuine concurrent-isolation check
+  // rather than three sequential ones that would pass even with a shared context.
+  await rendezvous("claimed", NAME, 3);
+
+  await expectOwnStateOnly(worker);
+});
+
+it("survives another worker closing its daemon mid-run", async () => {
+  await rendezvous("ready-for-close", NAME, 3);
+  await rendezvous("gamma-closed", NAME, 3);
+
+  // gamma's daemon and session are gone.  Ours must be untouched, and the shared Chrome alive.
+  await expectOwnStateOnly(worker);
+  await worker.session.getByRole("heading", {name: "Biloba parity"}).expectVisible();
+  expect(await worker.session.evaluate<number>("1 + 1")).toBe(2);
+});

--- a/typescript/test/e2e/worker-beta.e2e.test.ts
+++ b/typescript/test/e2e/worker-beta.e2e.test.ts
@@ -1,0 +1,39 @@
+import {afterAll, beforeAll, expect, inject, it} from "vitest";
+
+import {claimState, connectWorker, expectOwnStateOnly, rendezvous, type Worker} from "./harness.js";
+
+// One of three files, therefore one of three vitest worker processes, each with its own bilobad
+// attached to the run's single shared Chrome.  See worker-gamma.e2e.test.ts for the teardown half.
+const NAME = "beta";
+let worker: Worker;
+
+beforeAll(async () => { worker = await connectWorker(NAME); });
+afterAll(async () => { await worker?.browser.close(); });
+
+it("runs in its own worker process alongside the others", async () => {
+  const peers = await rendezvous("connected", NAME, 3);
+
+  const pids = new Set(peers.map((peer) => peer["pid"]));
+  expect(pids.size, "each test file must get its own worker process").toBe(3);
+  expect(pids.has(process.pid)).toBe(true);
+  expect(pids.has(inject("chromePid")), "workers must be separate from the browser host").toBe(false);
+});
+
+it("keeps its browser state to itself while the other workers write theirs", async () => {
+  await claimState(worker);
+  // Everyone has written before anyone reads, so this is a genuine concurrent-isolation check
+  // rather than three sequential ones that would pass even with a shared context.
+  await rendezvous("claimed", NAME, 3);
+
+  await expectOwnStateOnly(worker);
+});
+
+it("survives another worker closing its daemon mid-run", async () => {
+  await rendezvous("ready-for-close", NAME, 3);
+  await rendezvous("gamma-closed", NAME, 3);
+
+  // gamma's daemon and session are gone.  Ours must be untouched, and the shared Chrome alive.
+  await expectOwnStateOnly(worker);
+  await worker.session.getByRole("heading", {name: "Biloba parity"}).expectVisible();
+  expect(await worker.session.evaluate<number>("1 + 1")).toBe(2);
+});

--- a/typescript/test/e2e/worker-gamma.e2e.test.ts
+++ b/typescript/test/e2e/worker-gamma.e2e.test.ts
@@ -1,0 +1,37 @@
+import {afterAll, beforeAll, expect, it} from "vitest";
+
+import {claimState, connectWorker, expectOwnStateOnly, rendezvous, type Worker} from "./harness.js";
+
+// The worker that leaves early.  Its job is to prove that one worker finishing - closing its
+// browser handle, which stops its bilobad and disposes its browser context - takes nothing away
+// from the workers still running, and in particular does not take down the shared Chrome.
+const NAME = "gamma";
+let worker: Worker;
+let closed = false;
+
+beforeAll(async () => { worker = await connectWorker(NAME); });
+afterAll(async () => { if (!closed) await worker?.browser.close(); });
+
+it("runs in its own worker process alongside the others", async () => {
+  const peers = await rendezvous("connected", NAME, 3);
+  expect(new Set(peers.map((peer) => peer["pid"])).size).toBe(3);
+});
+
+it("keeps its browser state to itself while the other workers write theirs", async () => {
+  await claimState(worker);
+  await rendezvous("claimed", NAME, 3);
+
+  await expectOwnStateOnly(worker);
+});
+
+it("closes its daemon while the other workers are still working", async () => {
+  await rendezvous("ready-for-close", NAME, 3);
+
+  await worker.browser.close();
+  closed = true;
+
+  // Announce only after the close has fully returned, so alpha and beta assert against a world
+  // where this worker's daemon is genuinely gone rather than on its way out.
+  await rendezvous("gamma-closed", NAME, 3);
+  expect(closed).toBe(true);
+});

--- a/typescript/test/framing.test.ts
+++ b/typescript/test/framing.test.ts
@@ -1,0 +1,40 @@
+import {once} from "node:events";
+import {describe, expect, it} from "vitest";
+
+import {encodeFrame, FrameDecoder, MAX_FRAME_SIZE} from "../src/internal/framing.js";
+
+describe("length-prefixed JSON framing", () => {
+  it("round-trips multiline values fragmented across arbitrary chunks", async () => {
+    const original = {id: 17, method: "evaluate", script: "return `first\nsecond`\n"};
+    const frame = encodeFrame(original);
+    const decoder = new FrameDecoder();
+    const decoded: unknown[] = [];
+    decoder.on("data", (value: unknown) => decoded.push(value));
+
+    for (const byte of frame) decoder.write(Buffer.of(byte));
+    decoder.end();
+    await once(decoder, "end");
+
+    expect(decoded).toEqual([original]);
+  });
+
+  it("decodes consecutive frames from one chunk", async () => {
+    const decoder = new FrameDecoder();
+    const decoded: unknown[] = [];
+    decoder.on("data", (value: unknown) => decoded.push(value));
+    decoder.end(Buffer.concat([encodeFrame({id: 1}), encodeFrame({id: 2})]));
+    await once(decoder, "end");
+
+    expect(decoded).toEqual([{id: 1}, {id: 2}]);
+  });
+
+  it("rejects an oversized frame before buffering its payload", async () => {
+    const decoder = new FrameDecoder();
+    const error = once(decoder, "error");
+    const header = Buffer.alloc(4);
+    header.writeUInt32LE(MAX_FRAME_SIZE + 1);
+    decoder.end(header);
+
+    await expect(error).resolves.toMatchObject([{message: expect.stringContaining("maximum")}]);
+  });
+});

--- a/typescript/test/parity.test.ts
+++ b/typescript/test/parity.test.ts
@@ -1,0 +1,140 @@
+import {createReadStream} from "node:fs";
+import {mkdtemp, readFile, rm} from "node:fs/promises";
+import {createServer, type Server} from "node:http";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, beforeAll, describe, expect, it} from "vitest";
+
+import {
+  BilobaError,
+  connect,
+  startSharedBrowser,
+  type Browser,
+  type Session,
+  type SharedBrowserProcess,
+} from "../src/index.js";
+import {expectTimedOutAction, expectTimedOutAssertion} from "./support/assertions.js";
+
+const fixturePath = fileURLToPath(new URL("../../fixtures/graft-parity.html", import.meta.url));
+const expectedPath = fileURLToPath(new URL("../../fixtures/graft-parity-expected.json", import.meta.url));
+const daemonExecutable = process.env.BILOBA_DAEMON_EXECUTABLE;
+
+// This is the only test that drives the real daemon against a real Chrome, so it fails loudly when
+// it is not configured rather than skipping.  A suite that silently reports 4 skipped, exit 0 looks
+// exactly like a suite that passed.  Opt out deliberately with BILOBA_SKIP_PARITY=true.
+describe.skipIf(process.env.BILOBA_SKIP_PARITY === "true")("Go and TypeScript parity contract", () => {
+  let server: Server;
+  let baseUrl: string;
+  let browser: Browser;
+  let session: Session;
+  let sharedBrowser: SharedBrowserProcess;
+  let artifactDir: string;
+
+  beforeAll(async () => {
+    if (!daemonExecutable) {
+      throw new Error(
+        "BILOBA_DAEMON_EXECUTABLE is not set, so the Go/TypeScript parity contract cannot run.\n" +
+        "Run `make driver-parity` from the repository root, or build the daemon with " +
+        "`go build -o .bin/bilobad ./cmd/bilobad` and point BILOBA_DAEMON_EXECUTABLE at it.\n" +
+        "Set BILOBA_SKIP_PARITY=true to skip this suite on purpose.",
+      );
+    }
+    server = createServer((_request, response) => {
+      response.setHeader("content-type", "text/html");
+      createReadStream(fixturePath).pipe(response);
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("fixture server did not bind TCP");
+    baseUrl = `http://127.0.0.1:${address.port}`;
+    artifactDir = await mkdtemp(join(tmpdir(), "biloba-parity-"));
+    // No chromePath: bilobad runs the same runner-neutral Chrome search the Go suite does, so this
+    // exercises the resolution path a real worker takes.
+    sharedBrowser = await startSharedBrowser({executable: daemonExecutable});
+    browser = await connect({daemonExecutable: daemonExecutable, chromeWsUrl: sharedBrowser.wsURL, artifactDir});
+    session = await browser.openSession();
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await sharedBrowser?.stop();
+    if (server) {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+    if (artifactDir) await rm(artifactDir, {recursive: true, force: true});
+  });
+
+  it("reaches the same shared observable outcome through the TypeScript API", async () => {
+    await session.prepare();
+    await session.navigate(baseUrl);
+    await session.getByRole("heading", {name: "Biloba parity"}).expectVisible();
+    const delayed = await session.locator("#delayed").expectText("ready", {timeoutMs: 1_000, intervalMs: 5});
+    expect(delayed.attemptCount).toBeGreaterThan(1);
+
+    await session.getByTestId("name").setValue("Ada");
+    await session.getByTestId("name").expectValue("Ada");
+    await session.getByRole("button", {name: "Increment"}).click();
+
+    const actual = await session.evaluate(`({
+      count: document.querySelector('#count').innerText,
+      delayed: document.querySelector('#delayed').innerText,
+      echo: document.querySelector('#echo').innerText,
+      heading: document.querySelector('h1').innerText,
+      value: document.querySelector('[data-testid="name"]').value,
+    })`);
+    const expected = JSON.parse(await readFile(expectedPath, "utf8")) as unknown;
+    expect(actual).toEqual(expected);
+
+    // An args array - empty or not - means "call this function"; no args array means "read this
+    // expression".  The daemon is told which, so neither reading depends on the argument count.
+    expect(await session.evaluate<number>("() => 41 + 1", [])).toBe(42);
+    expect(await session.evaluate<number>("(a, b) => a + b", [40, 2])).toBe(42);
+  });
+
+  it("returns structured failure output from the real daemon", async () => {
+    await session.prepare();
+    await session.navigate(baseUrl);
+
+    const failure = await session.locator("#never").expectText("ready", {timeoutMs: 40, intervalMs: 5})
+      .catch((error: unknown) => error);
+
+    // Same contract the stub daemon is held to in client.test.ts - if the stub ever drifts from
+    // what a real bilobad does here, this line fails.
+    expectTimedOutAssertion(failure, {locator: `locator("#never")`, expected: "ready"});
+    expect(failure.trajectory.length).toBeGreaterThan(1);
+    expect(failure.domOutline).toContain("Biloba parity");
+    expect(failure.screenshotPath).toMatch(/biloba-failure-\d+\.png$/);
+  });
+
+  it("rejects an action that exhausts its server-side poll", async () => {
+    await session.prepare();
+    await session.navigate(baseUrl);
+
+    const failure = await session.locator("#never").click({timeoutMs: 40, intervalMs: 5})
+      .catch((error: unknown) => error);
+
+    expectTimedOutAction(failure, {locator: `locator("#never")`, operation: "click"});
+    expect(failure.trajectory.length).toBeGreaterThan(1);
+    expect(failure.domOutline).toContain("Biloba parity");
+  });
+
+  it("runs independent worker daemons concurrently against the shared Chrome", async () => {
+    const secondBrowser = await connect({daemonExecutable: daemonExecutable!, chromeWsUrl: sharedBrowser.wsURL});
+    const secondSession = await secondBrowser.openSession();
+    try {
+      await Promise.all([session.prepare(), secondSession.prepare()]);
+      await Promise.all([session.navigate(baseUrl), secondSession.navigate(baseUrl)]);
+      const [firstValue, secondValue] = await Promise.all([
+        session.evaluate<number>("1 + 1"),
+        secondSession.evaluate<number>("2 + 2"),
+      ]);
+      expect([firstValue, secondValue]).toEqual([2, 4]);
+    } finally {
+      await secondBrowser.close();
+    }
+  });
+});

--- a/typescript/test/protocol-golden.test.ts
+++ b/typescript/test/protocol-golden.test.ts
@@ -1,0 +1,54 @@
+import {readFile} from "node:fs/promises";
+import {describe, expect, it} from "vitest";
+
+import type {OperationResult, ProtocolError, Request, Response} from "../src/generated/protocol.js";
+import {encodeFrame} from "../src/internal/framing.js";
+
+// These assert with toEqual, not toMatchObject: the goldens exist to catch a field the daemon
+// starts or stops emitting, and toMatchObject ignores exactly that.  The Go side has the mirror of
+// this check (protocol/encoding_test.go) tying the generated declarations to what json.Marshal
+// actually produces.
+describe("Go-generated protocol goldens", () => {
+  it("matches the TypeScript request envelope and framing", async () => {
+    const golden = await loadGolden<Request>("handshake-request.json");
+    expect(golden).toEqual({id: 1, method: "handshake", params: {protocolVersion: "1"}});
+
+    const frame = encodeFrame(golden);
+    expect(frame.readUInt32LE(0)).toBe(frame.length - 4);
+    expect(JSON.parse(frame.subarray(4).toString("utf8"))).toEqual(golden);
+  });
+
+  it("keeps structured errors stable", async () => {
+    const golden = await loadGolden<Response<never>>("protocol-error-response.json");
+    expect(golden).toEqual({
+      id: 7,
+      error: {code: "PROTOCOL_MISMATCH", message: "protocol version mismatch"} satisfies ProtocolError,
+    });
+  });
+
+  it("keeps operation metadata stable, and omits diagnostics when there are none", async () => {
+    const golden = await loadGolden<Response<OperationResult>>("operation-response.json");
+    expect(golden).toEqual({
+      id: 9,
+      result: {
+        matched: true,
+        observedJson: '"Saved"',
+        attemptCount: 2,
+        trajectory: [
+          {attempt: 1, elapsedMs: 0, observedJson: '"Saving"'},
+          {attempt: 2, elapsedMs: 10, observedJson: '"Saved"'},
+        ],
+        timings: {startedUnixMs: 1_700_000_000_000, elapsedMs: 10},
+        rpcRequestCount: 1,
+        rpcResponseCount: 1,
+      } satisfies OperationResult,
+    });
+    // diagnostics is declared optional, so it must genuinely be absent rather than an empty object
+    expect(golden.result).not.toHaveProperty("diagnostics");
+  });
+});
+
+async function loadGolden<T>(name: string): Promise<T> {
+  const contents = await readFile(new URL(`../../protocol/testdata/golden/${name}`, import.meta.url), "utf8");
+  return JSON.parse(contents) as T;
+}

--- a/typescript/test/stdio-transport.test.ts
+++ b/typescript/test/stdio-transport.test.ts
@@ -1,0 +1,132 @@
+import {once} from "node:events";
+import {PassThrough} from "node:stream";
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
+
+import type {Request} from "../src/generated/protocol.js";
+import {encodeFrame, FrameDecoder} from "../src/internal/framing.js";
+import {StdioTransport} from "../src/internal/stdio-transport.js";
+
+describe("stdio transport", () => {
+  let fromClient: PassThrough;
+  let toClient: PassThrough;
+  let requests: FrameDecoder;
+  let transport: StdioTransport;
+
+  beforeEach(() => {
+    fromClient = new PassThrough();
+    toClient = new PassThrough();
+    requests = new FrameDecoder();
+    fromClient.pipe(requests);
+    transport = new StdioTransport(toClient, fromClient);
+  });
+
+  afterEach(() => transport.close());
+
+  it("correlates a fragmented framed response by request id", async () => {
+    const handshake = transport.handshake({protocolVersion: "1"});
+    const request = await nextRequest(requests);
+    expect(request).toEqual({id: 1, method: "handshake", params: {protocolVersion: "1"}, timeoutMs: 30_000});
+
+    const frame = encodeFrame({id: request.id, result: {protocolVersion: "1", capabilities: ["evaluate"]}});
+    toClient.write(frame.subarray(0, 3));
+    toClient.write(frame.subarray(3));
+
+    await expect(handshake).resolves.toEqual({protocolVersion: "1", capabilities: ["evaluate"]});
+  });
+
+  it("gives every non-polling operation a default deadline the caller can override", async () => {
+    // These requests are never answered; the afterEach close rejects them.
+    transport.navigate({sessionId: "session-1", url: "http://localhost/"}).catch(() => undefined);
+    expect(await nextRequest(requests)).toMatchObject({method: "navigate", timeoutMs: 30_000});
+
+    transport.prepareSession({sessionId: "session-1"}, {timeoutMs: 250}).catch(() => undefined);
+    expect(await nextRequest(requests)).toMatchObject({method: "prepareSession", timeoutMs: 250});
+
+    // The polling operations derive their deadline from the poll budget instead - a default here
+    // would race the daemon's own poll timeout.
+    transport.assert({
+      sessionId: "session-1",
+      assertion: {kind: "VISIBLE", locator: {kind: "CSS", value: "main", first: false}},
+    }).catch(() => undefined);
+    expect(await nextRequest(requests)).not.toHaveProperty("timeoutMs");
+  });
+
+  it("fails a silent non-polling operation locally once its default deadline passes", async () => {
+    vi.useFakeTimers();
+    try {
+      const navigation = transport.navigate({sessionId: "session-1", url: "http://localhost/"});
+      const failure = navigation.catch((reason: unknown) => reason);
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(await failure).toMatchObject({code: "TIMEOUT", message: "Biloba request timed out after 30000ms"});
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("maps structured daemon errors without transport-specific status codes", async () => {
+    const session = transport.openSession({});
+    const request = await nextRequest(requests);
+    toClient.write(encodeFrame({
+      id: request.id,
+      error: {code: "DRIVER_ERROR", message: "chrome disconnected", diagnostics: {daemonDetail: "websocket EOF"}},
+    }));
+
+    await expect(session).rejects.toMatchObject({
+      code: "DRIVER_ERROR",
+      message: "chrome disconnected",
+      daemonDetail: "websocket EOF",
+    });
+  });
+
+  it("sends an explicit cancellation frame for an AbortSignal", async () => {
+    const controller = new AbortController();
+    const assertion = transport.assert({
+      sessionId: "session-1",
+      assertion: {kind: "VISIBLE", locator: {kind: "CSS", value: "main", first: false}},
+    }, {signal: controller.signal});
+    const request = await nextRequest(requests);
+    controller.abort("worker stopped");
+
+    await expect(assertion).rejects.toMatchObject({code: "CANCELLED"});
+    expect(await nextRequest(requests)).toEqual({
+      id: 0,
+      method: "cancel",
+      params: {requestId: request.id},
+    });
+  });
+  it("does not leak an unhandled rejection when the cancel frame cannot be written", async () => {
+    const rejections: unknown[] = [];
+    const record = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", record);
+    try {
+      const controller = new AbortController();
+      const assertion = transport.assert({
+        sessionId: "session-1",
+        assertion: {kind: "VISIBLE", locator: {kind: "CSS", value: "main", first: false}},
+      }, {signal: controller.signal});
+      await nextRequest(requests);
+
+      // A worker that aborts its in-flight work and tears the browser down in the same turn: the
+      // best-effort cancel frame is queued behind a closed transport and can never be written.  Its
+      // rejection must not escape - an unhandled rejection here takes the whole worker process down.
+      controller.abort("worker stopped");
+      transport.close();
+
+      await expect(assertion).rejects.toMatchObject({code: "CANCELLED"});
+      await settleRejections();
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", record);
+    }
+  });
+});
+
+// unhandledRejection is emitted a turn after the microtask queue drains, so give it a few.
+async function settleRejections(): Promise<void> {
+  for (let turn = 0; turn < 3; turn++) await new Promise((resolve) => setTimeout(resolve, 5));
+}
+
+async function nextRequest(decoder: FrameDecoder): Promise<Request> {
+  const [value] = await once(decoder, "data");
+  return value as Request;
+}

--- a/typescript/test/support/assertions.ts
+++ b/typescript/test/support/assertions.ts
@@ -1,0 +1,62 @@
+import {expect} from "vitest";
+
+import {BilobaError} from "../../src/index.js";
+
+/**
+ * The contract a timed-out Biloba operation must satisfy, asserted identically against the stub
+ * daemon in client.test.ts and against a real bilobad in the parity suite.
+ *
+ * This is the answer to "what stops the stub from lying?".  Generated types constrain the *shape*
+ * of what the stub sends; nothing constrains its *behaviour* - a stub is free to claim a failed
+ * click succeeded, and no type will notice.  Sharing the assertion means the fast stub tests and
+ * the slow real-daemon tests are held to one definition: if the stub drifts from the daemon on
+ * anything asserted here, the parity run fails on the same line.
+ *
+ * Keep this about the invariants both can honour.  Anything that depends on a specific payload
+ * (an exact observed value, a screenshot path) belongs at the call site.
+ */
+export function expectTimedOutOperation(
+  error: unknown,
+  expectations: {locator: string; expected?: string; summary: string},
+): asserts error is BilobaError {
+  expect(error, "a Biloba operation that exhausts its budget must reject with a BilobaError").toBeInstanceOf(BilobaError);
+  const failure = error as BilobaError;
+
+  expect(failure.code).toBe("TIMEOUT");
+  expect(failure.locator).toBe(expectations.locator);
+  if (expectations.expected !== undefined) expect(failure.expected).toBe(expectations.expected);
+
+  // One protocol request, however many times the daemon polled inside it.  This is the whole
+  // premise of server-side polling; a client-side retry loop would show up here.
+  expect(failure.rpcRequestCount).toBe(1);
+  expect(failure.rpcResponseCount).toBe(1);
+
+  // The message has to name what was being looked for and how hard it was tried - that is what
+  // makes a timeout actionable rather than just late.
+  expect(failure.message).toContain(expectations.summary);
+  expect(failure.message).toContain(`locator: ${expectations.locator}`);
+  expect(failure.message).toMatch(/attempts: \d+/);
+
+  expect(failure.trajectory.length, "a timeout must carry the attempts it made").toBeGreaterThan(0);
+  for (const observation of failure.trajectory) {
+    expect(observation.attempt).toBeGreaterThan(0);
+    expect(typeof observation.elapsedMs).toBe("number");
+  }
+}
+
+/** The assertion form: `expectText`, `expectVisible`, and friends. */
+export function expectTimedOutAssertion(error: unknown, expectations: {locator: string; expected?: string}): asserts error is BilobaError {
+  expectTimedOutOperation(error, {...expectations, summary: "Biloba assertion timed out"});
+}
+
+/** The action form: `click`, `setValue`. */
+export function expectTimedOutAction(
+  error: unknown,
+  expectations: {locator: string; operation: "click" | "setValue"},
+): asserts error is BilobaError {
+  expectTimedOutOperation(error, {
+    locator: expectations.locator,
+    expected: "operation to succeed",
+    summary: `Biloba ${expectations.operation} operation timed out`,
+  });
+}

--- a/typescript/tsconfig.build.json
+++ b/typescript/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "stripInternal": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts", "vitest.config.ts"]
+}

--- a/typescript/vitest.config.ts
+++ b/typescript/vitest.config.ts
@@ -1,0 +1,15 @@
+import {defineConfig} from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    testTimeout: 5_000,
+    // The two real-daemon suites need a Go binary that pnpm has no business building, and both
+    // fail rather than skip when it is missing, so neither can ride along here.  `pnpm test`
+    // covers the unit suites; `pnpm test:parity` and `pnpm test:e2e` (via `make driver-parity` and
+    // `make driver-e2e`, which build the daemon first) run them through their own configs - the
+    // e2e one needs a globalSetup and a forked, genuinely parallel pool that would be wrong for
+    // unit tests.  CI runs all three; see the driver job in .github/workflows/test.yml.
+    exclude: ["**/node_modules/**", "**/dist/**", "test/parity.test.ts", "test/e2e/**"],
+  },
+});

--- a/typescript/vitest.e2e-crash.config.ts
+++ b/typescript/vitest.e2e-crash.config.ts
@@ -1,0 +1,17 @@
+import {defineConfig} from "vitest/config";
+
+// The crash file gets its own run, and therefore its own shared Chrome, because it kills that
+// Chrome on purpose.  Sharing a browser with the worker-* files would mean destroying theirs
+// mid-assertion and reporting it as their failure.  One fork: these are about what a worker sees
+// when things die, not about concurrency, and the file's specs run in a deliberate order.
+export default defineConfig({
+  test: {
+    environment: "node",
+    globalSetup: ["./test/e2e/global-setup.ts"],
+    include: ["test/e2e/crash.e2e.test.ts"],
+    pool: "forks",
+    poolOptions: {forks: {minForks: 1, maxForks: 1}},
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});

--- a/typescript/vitest.e2e.config.ts
+++ b/typescript/vitest.e2e.config.ts
@@ -1,0 +1,24 @@
+import {defineConfig} from "vitest/config";
+
+// The multi-worker end-to-end suite.  Every knob here is load-bearing:
+//
+//   globalSetup      starts exactly one Chrome, in the main process, and provides its websocket
+//                    URL to the workers - so the browser is genuinely shared rather than one
+//                    browser per file pretending to be.
+//   pool: "forks"    each test file gets its own OS process.  This is the point: the topology
+//                    claim is about worker *processes*, and a thread pool would not test it.
+//   fileParallelism  the files must run at the same time, or the rendezvous barriers below never
+//   + min/maxForks   release and the suite fails - which is the correct outcome, because a serial
+//                    run has not exercised concurrent workers at all.
+export default defineConfig({
+  test: {
+    environment: "node",
+    globalSetup: ["./test/e2e/global-setup.ts"],
+    include: ["test/e2e/worker-*.e2e.test.ts"],
+    pool: "forks",
+    fileParallelism: true,
+    poolOptions: {forks: {minForks: 3, maxForks: 3, isolate: true}},
+    testTimeout: 60_000,
+    hookTimeout: 60_000,
+  },
+});

--- a/typescript/vitest.parity.config.ts
+++ b/typescript/vitest.parity.config.ts
@@ -1,0 +1,14 @@
+import {defineConfig} from "vitest/config";
+
+// The Go/TypeScript parity contract: a real bilobad, a real shared Chrome, and the same fixture
+// and expectations the Go suite asserts against (see graft_parity_test.go).  Run it with
+// `make driver-parity`, which builds the daemon and points BILOBA_DAEMON_EXECUTABLE at it.
+export default defineConfig({
+  test: {
+    environment: "node",
+    // A real browser start plus a shared-Chrome handshake needs more room than a unit test.
+    testTimeout: 30_000,
+    hookTimeout: 60_000,
+    include: ["test/parity.test.ts"],
+  },
+});


### PR DESCRIPTION
**Stack 4 of 17** · base [#19](https://github.com/onsi/biloba/pull/19) · next: [#21](https://github.com/onsi/biloba/pull/21)

The TypeScript half: a client that drives `bilobad` over the framed protocol, and the tests that hold it to the same behavior as the Go API. It also wires everything into CI.

**One daemon per worker, all attached to one shared Chrome.** `startSharedBrowser` brings up the browser, and each worker's `connect()` spawns its own daemon against that websocket. A worker that closes, or dies, must not disturb the others.

**Assertions and actions send their poll budget to the daemon** and get back the full attempt history. Failures arrive as a `BilobaError` carrying the locator, the expectation, the attempts, and the DOM outline and screenshot when those exist.

## Three deliberate choices in the tests

### `test/e2e/` is the only place the real topology exists

Three test files means three worker processes, one daemon each, one Chrome. Every other suite approximates this from inside a single process.

The `rendezvous()` barriers do two jobs. They order the workers, and they prove the workers are concurrent at all. Run the files serially and the first one blocks until it times out:

```
rendezvous "connected" timed out: saw 1 of 3 workers (alpha.json).
The e2e suite requires its test files to run concurrently, in separate processes...
```

So a green run is evidence of the topology, not of three sequential runs that happened to pass. The isolation check works the same way: all three workers set `owner=<name>` on the same origin, and three different values coexisting is what browser-context isolation means.

### `test/support/assertions.ts` is one contract, checked against both a stub and a real daemon

Generated types constrain the shape a stub can send, but nothing constrains its behavior. A stub is free to claim a failed click succeeded, and no type will notice. Sharing the assertion between `client.test.ts` (fast, stub) and `parity.test.ts` (slow, real `bilobad`) is what prevents that. It immediately caught the stub reporting a timed-out click with no attempt history, which a real daemon can't produce.

### `crash.e2e.test.ts` checks the diagnosis, not just the failure

It covers a crashed renderer, a dead browser, a worker killed without teardown, and Chrome unreachable at startup.

Its timing bounds do real work. CDP doesn't return errors for calls against a dead renderer or browser, it stops answering them, so both cases used to sit until their deadline and then report a timeout. Reverting the in-flight interrupt reproduces it exactly: `30031ms` and the wrong error code.

## A test that could kill your browser, fixed here

Reviewing this stack turned up a problem in that crash suite, fixed by the last commit.

`killRenderers` and `killSharedChrome` searched for processes across the whole machine and sent SIGKILL to every Chrome renderer and every `chrome-headless-shell` they found. Running `make driver-e2e` would kill your own browser, a concurrent `make test`, or another checkout's suite. `daemonCount()` had the same problem, which made one assertion depend on nothing else on the machine running a daemon.

The suite now scopes the kills by process group. Global setup already spawns the browser host detached, so every Chrome process it forks inherits that group ID. Unlike walking the parent chain, this still works for a renderer that Chrome has reparented away from its zygote. Daemons can't be scoped by group, because the one under test is deliberately orphaned, so they're matched on the per-run `--chrome-ws-url`, which carries the port and Chrome's launch GUID.

Verified by running the suite next to a decoy Chrome tree and a decoy daemon. All decoys survived.

The same commit makes `rendezvous()` write its marker atomically. It used to create the file before writing its contents, so a peer could list the directory, read an empty file, and throw inside `JSON.parse`.

## The suites fail instead of skipping

`parity` and `e2e` both fail outright when they're misconfigured. "4 skipped, exit 0" looks just like a pass, and that's how the parity suite silently covered nothing under its own make target. To opt out on purpose, set `BILOBA_SKIP_PARITY=true`.

CI gains a `driver` job that runs `make driver-test`, `driver-parity`, and `driver-e2e`.

## Verification

Biloba 1039/1039 · Engine 23/23 · Protocol 35/35 · Bilobad 15/15 · TypeScript 27 unit, 4 parity, 15 e2e. All three `make driver-*` targets exit 0. `go vet` and `gofmt` are clean, and no processes are left behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/856687b8-c710-4231-b967-2d79ae359cfe)