### PR TITLE
6/17 engine: move the remaining direct browser calls off the Go API

### DIFF
--- a/a11y.go
+++ b/a11y.go
@@ -1,13 +1,12 @@
 package biloba
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/onsi/biloba/engine"
 	"strings"
 
 	"github.com/chromedp/cdproto/accessibility"
-	"github.com/chromedp/chromedp"
 )
 
 /*
@@ -34,12 +33,7 @@ func (b *Biloba) A11yOutline() string {
 }
 
 func (b *Biloba) a11yOutline() (string, error) {
-	var nodes []*accessibility.Node
-	err := b.runCDP("capture the accessibility tree", chromedp.ActionFunc(func(ctx context.Context) error {
-		var err error
-		nodes, err = accessibility.GetFullAXTree().Do(ctx)
-		return err
-	}))
+	nodes, err := engine.AccessibilityTreeContext(b.Context)
 	if err != nil {
 		return "", err
 	}

--- a/a11y.go
+++ b/a11y.go
@@ -1,6 +1,7 @@
 package biloba
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/onsi/biloba/engine"
@@ -33,7 +34,12 @@ func (b *Biloba) A11yOutline() string {
 }
 
 func (b *Biloba) a11yOutline() (string, error) {
-	nodes, err := engine.AccessibilityTreeContext(b.Context)
+	var nodes []*accessibility.Node
+	err := b.runEngine("capture the accessibility tree", func(ctx context.Context) error {
+		var err error
+		nodes, err = engine.AccessibilityTreeContext(ctx)
+		return err
+	})
 	if err != nil {
 		return "", err
 	}

--- a/engine/capture.go
+++ b/engine/capture.go
@@ -1,0 +1,93 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/chromedp/cdproto/emulation"
+	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/chromedp"
+)
+
+// PageCaptureAction captures the whole page, expanding the viewport only when the document is
+// actually bigger than it.
+//
+// The exact-equality test is the load-bearing part.  Anything looser - "fits within" - and the
+// expanded capture and the plain one could differ in size, which would invalidate every baseline
+// taken with the other one.  Chrome reports both in CSS pixels off the same layout, so a document
+// that measures equal really is the viewport.  When the content already fits, the two captures are
+// the same pixels, so skipping the expansion changes nothing except that the page stops being told
+// its viewport resized - which is the app-shell case, a document that never scrolls because an
+// inner pane does.
+//
+// It returns an Action rather than doing the work so callers can compose it into a Run alongside
+// their own steps, which is how the visual-regression path settles a capture.
+func PageCaptureAction(img *[]byte, cssWidth *float64) chromedp.ActionFunc {
+	return func(ctx context.Context) error {
+		_, _, _, cssLayoutViewport, _, cssContentSize, err := page.GetLayoutMetrics().Do(ctx)
+		if err != nil {
+			return err
+		}
+		if cssWidth != nil {
+			*cssWidth = cssContentSize.Width
+		}
+		fits := cssLayoutViewport != nil &&
+			cssContentSize.Width == float64(cssLayoutViewport.ClientWidth) &&
+			cssContentSize.Height == float64(cssLayoutViewport.ClientHeight) &&
+			cssContentSize.X == 0 && cssContentSize.Y == 0
+		*img, err = page.CaptureScreenshot().
+			WithFromSurface(true).
+			WithCaptureBeyondViewport(!fits).
+			WithFormat(page.CaptureScreenshotFormatPng).
+			Do(ctx)
+		return err
+	}
+}
+
+// CapturePageContext captures the whole page.
+func CapturePageContext(ctx context.Context, cssWidth *float64) ([]byte, error) {
+	var img []byte
+	if err := chromedp.Run(ctx, PageCaptureAction(&img, cssWidth)); err != nil {
+		return nil, err
+	}
+	return img, nil
+}
+
+// CaptureClipContext captures one region of the page.
+func CaptureClipContext(ctx context.Context, clip *page.Viewport, beyondViewport bool) ([]byte, error) {
+	var img []byte
+	err := chromedp.Run(ctx, chromedp.ActionFunc(func(runCtx context.Context) error {
+		var captureErr error
+		img, captureErr = page.CaptureScreenshot().
+			WithClip(clip).
+			WithFromSurface(true).
+			WithCaptureBeyondViewport(beyondViewport).
+			Do(runCtx)
+		return captureErr
+	}))
+	if err != nil {
+		return nil, err
+	}
+	return img, nil
+}
+
+// CaptureFullScreenshotContext captures the page at full size and reads its title in the same round
+// trip, which is what the on-failure artifact path wants: a picture and something to label it with.
+func CaptureFullScreenshotContext(ctx context.Context, quality int) (img []byte, title string, err error) {
+	err = chromedp.Run(ctx,
+		chromedp.Title(&title),
+		chromedp.FullScreenshot(&img, quality),
+	)
+	return img, title, err
+}
+
+// EmulateColorSchemeContext overrides the page's prefers-color-scheme, or clears the override when
+// scheme is empty.  Callers track whether an override is outstanding themselves: a command that
+// reports an error may still have landed, so the flag has to go up before the call and only come
+// down when a clear actually succeeds.
+func EmulateColorSchemeContext(ctx context.Context, scheme string) error {
+	params := emulation.SetEmulatedMedia()
+	if scheme != "" {
+		params = params.WithFeatures([]*emulation.MediaFeature{{Name: "prefers-color-scheme", Value: scheme}})
+	}
+	return chromedp.Run(ctx, params)
+}

--- a/engine/input.go
+++ b/engine/input.go
@@ -1,0 +1,135 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/chromedp/cdproto/accessibility"
+	"github.com/chromedp/cdproto/dom"
+	"github.com/chromedp/cdproto/emulation"
+	"github.com/chromedp/cdproto/input"
+	"github.com/chromedp/cdproto/runtime"
+	"github.com/chromedp/chromedp"
+)
+
+// The browser interactions that cannot be simulated in JavaScript and so have to go over CDP:
+// trusted keyboard and pointer input, a file input's file list, and the accessibility tree.  They
+// live here rather than in the Ginkgo adapter for the same reason everything else does - the
+// daemon needs them too, and two implementations of "dispatch a real click" would drift in exactly
+// the ways that are hardest to notice.
+
+// EmulateViewportContext resizes the tab's emulated viewport.  Options are chromedp's, deliberately:
+// SetWindowSize takes them in its public signature, and Biloba does not hide chromedp from callers.
+func EmulateViewportContext(ctx context.Context, width, height int, opts ...chromedp.EmulateViewportOption) error {
+	return chromedp.Run(ctx, chromedp.EmulateViewport(int64(width), int64(height), opts...))
+}
+
+// KeyEventContext dispatches keys as real keyboard events, so keydown/keypress/keyup all fire.
+func KeyEventContext(ctx context.Context, keys string, opts ...chromedp.KeyOption) error {
+	if keys == "" {
+		return nil
+	}
+	return chromedp.Run(ctx, chromedp.KeyEvent(keys, opts...))
+}
+
+// MouseClickContext dispatches a press/release pair at a point, with modifiers held, repeated for
+// each click count so a double click reports detail=1 then detail=2 the way a real one does.
+func MouseClickContext(ctx context.Context, x, y float64, button input.MouseButton, clickCount int, modifiers input.Modifier) error {
+	actions := []chromedp.Action{chromedp.MouseEvent(input.MouseMoved, x, y)}
+	for count := int64(1); count <= int64(clickCount); count++ {
+		actions = append(actions,
+			input.DispatchMouseEvent(input.MousePressed, x, y).WithButton(button).WithClickCount(count).WithModifiers(modifiers),
+			input.DispatchMouseEvent(input.MouseReleased, x, y).WithButton(button).WithClickCount(count).WithModifiers(modifiers),
+		)
+	}
+	return chromedp.Run(ctx, actions...)
+}
+
+// TapContext dispatches a touch start/end pair at a point.
+func TapContext(ctx context.Context, x, y float64) error {
+	return chromedp.Run(ctx,
+		input.DispatchTouchEvent(input.TouchStart, []*input.TouchPoint{{X: x, Y: y}}),
+		input.DispatchTouchEvent(input.TouchEnd, []*input.TouchPoint{}),
+	)
+}
+
+// SetFileInputFilesContext points a file input at paths.  The browser forbids doing this from
+// JavaScript, so it is one of the few interactions that must go over CDP: resolve the element to a
+// remote object, then hand DOM.setFileInputFiles its object id.  Reports false when the selector
+// matched nothing, so a caller can poll rather than fail.
+func SetFileInputFilesContext(ctx context.Context, nodeScript string, paths []string) (bool, error) {
+	var node *runtime.RemoteObject
+	if err := chromedp.Run(ctx, chromedp.Evaluate(nodeScript, &node)); err != nil {
+		return false, err
+	}
+	if node == nil || node.ObjectID == "" {
+		return false, nil
+	}
+	if err := chromedp.Run(ctx, dom.SetFileInputFiles(paths).WithObjectID(node.ObjectID)); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// AccessibilityTreeContext reads the full accessibility tree for the tab.
+func AccessibilityTreeContext(ctx context.Context) ([]*accessibility.Node, error) {
+	var nodes []*accessibility.Node
+	err := chromedp.Run(ctx, chromedp.ActionFunc(func(runCtx context.Context) error {
+		var readErr error
+		nodes, readErr = accessibility.GetFullAXTree().Do(runCtx)
+		return readErr
+	}))
+	if err != nil {
+		return nil, err
+	}
+	return nodes, nil
+}
+
+// MouseMoveContext moves the real pointer, which is what activates genuine CSS :hover.
+func MouseMoveContext(ctx context.Context, x, y float64) error {
+	return chromedp.Run(ctx, chromedp.MouseEvent(input.MouseMoved, x, y))
+}
+
+// ClickXYContext moves to a point and clicks it - the simple case, no modifiers or repeat counts.
+func ClickXYContext(ctx context.Context, x, y float64) error {
+	return chromedp.Run(ctx,
+		chromedp.MouseEvent(input.MouseMoved, x, y),
+		chromedp.MouseClickXY(x, y),
+	)
+}
+
+// TouchTapContext enables touch emulation and dispatches a tap.  Emulation is enabled per call
+// because a tap can be the first touch interaction a page ever sees.
+func TouchTapContext(ctx context.Context, x, y float64) error {
+	return chromedp.Run(ctx,
+		emulation.SetTouchEmulationEnabled(true),
+		input.DispatchTouchEvent(input.TouchStart, []*input.TouchPoint{{X: x, Y: y}}),
+		input.DispatchTouchEvent(input.TouchEnd, []*input.TouchPoint{}),
+	)
+}
+
+// ScrollWheelContext dispatches a real wheel event at a point.
+func ScrollWheelContext(ctx context.Context, x, y, deltaX, deltaY float64) error {
+	return chromedp.Run(ctx, input.DispatchMouseEvent(input.MouseWheel, x, y).WithDeltaX(deltaX).WithDeltaY(deltaY))
+}
+
+// DragContext presses at src, moves to tgt in steps, and releases - the intermediate moves matter,
+// because a drag implementation watching mousemove needs to see the path, not just the endpoints.
+func DragContext(ctx context.Context, srcX, srcY, tgtX, tgtY float64, steps int) error {
+	actions := []chromedp.Action{
+		chromedp.MouseEvent(input.MouseMoved, srcX, srcY),
+		chromedp.MouseEvent(input.MousePressed, srcX, srcY, chromedp.ButtonType(input.Left), chromedp.ClickCount(1)),
+	}
+	// Inclusive of steps: the last interpolated point already lands on the target, and the explicit
+	// move below repeats it.  That duplicate is deliberate - it is what the Go API dispatched before
+	// this moved, and a drag implementation watching mousemove can count events.
+	for step := 1; step <= steps; step++ {
+		x := srcX + (tgtX-srcX)*float64(step)/float64(steps)
+		y := srcY + (tgtY-srcY)*float64(step)/float64(steps)
+		actions = append(actions, chromedp.MouseEvent(input.MouseMoved, x, y, chromedp.ButtonType(input.Left)))
+	}
+	actions = append(actions,
+		chromedp.MouseEvent(input.MouseMoved, tgtX, tgtY, chromedp.ButtonType(input.Left)),
+		chromedp.MouseEvent(input.MouseReleased, tgtX, tgtY, chromedp.ButtonType(input.Left), chromedp.ClickCount(1)),
+	)
+	return chromedp.Run(ctx, actions...)
+}

--- a/engine/network.go
+++ b/engine/network.go
@@ -1,0 +1,41 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/chromedp/cdproto/fetch"
+	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/chromedp"
+)
+
+// EnableInterceptionContext turns on request interception for every URL.
+//
+// The order is load-bearing: the cache is disabled first, then Fetch is enabled.  The other way
+// round leaves a window in which requests are being intercepted but could still be answered from
+// cache, which reads as an interceptor that silently did not fire.
+func EnableInterceptionContext(ctx context.Context) error {
+	return chromedp.Run(ctx,
+		network.SetCacheDisabled(true),
+		fetch.Enable().WithPatterns([]*fetch.RequestPattern{{URLPattern: "*"}}),
+	)
+}
+
+// RunActionContext dispatches one CDP action against the target.  Interception handlers resolve
+// which action to take (continue, fulfil, fail) from their own policy and then need it sent; the
+// choice is the caller's, the dispatch is the engine's.
+func RunActionContext(ctx context.Context, action chromedp.Action) error {
+	return chromedp.Run(ctx, action)
+}
+
+// ResponseBodyContext reads a paused response's body.  Only valid at the response stage, and it has
+// to go through chromedp.Run so it picks up the target's CDP executor from the context; chromedp
+// decodes the base64 for us.
+func ResponseBodyContext(ctx context.Context, requestID fetch.RequestID) ([]byte, error) {
+	var body []byte
+	err := chromedp.Run(ctx, chromedp.ActionFunc(func(runCtx context.Context) error {
+		var readErr error
+		body, readErr = fetch.GetResponseBody(requestID).Do(runCtx)
+		return readErr
+	}))
+	return body, err
+}

--- a/keyboard.go
+++ b/keyboard.go
@@ -3,6 +3,7 @@ package biloba
 import (
 	"github.com/chromedp/chromedp"
 	"github.com/chromedp/chromedp/kb"
+	"github.com/onsi/biloba/engine"
 	"github.com/onsi/gomega/gcustom"
 	"github.com/onsi/gomega/types"
 )
@@ -166,7 +167,7 @@ func (b *Biloba) dispatchKeys(keys string, mods []clickModifier) error {
 	if len(mods) > 0 {
 		opts = append(opts, chromedp.KeyModifiers(modifierMask(mods)))
 	}
-	return b.runCDP("dispatch keyboard input", chromedp.KeyEvent(keys, opts...))
+	return engine.KeyEventContext(b.Context, keys, opts...)
 }
 
 // focusAndSendKeys focuses the element matching selector (failing if it is missing, hidden, or

--- a/keyboard.go
+++ b/keyboard.go
@@ -1,6 +1,8 @@
 package biloba
 
 import (
+	"context"
+
 	"github.com/chromedp/chromedp"
 	"github.com/chromedp/chromedp/kb"
 	"github.com/onsi/biloba/engine"
@@ -167,7 +169,9 @@ func (b *Biloba) dispatchKeys(keys string, mods []clickModifier) error {
 	if len(mods) > 0 {
 		opts = append(opts, chromedp.KeyModifiers(modifierMask(mods)))
 	}
-	return engine.KeyEventContext(b.Context, keys, opts...)
+	return b.runEngine("dispatch keyboard input", func(ctx context.Context) error {
+		return engine.KeyEventContext(ctx, keys, opts...)
+	})
 }
 
 // focusAndSendKeys focuses the element matching selector (failing if it is missing, hidden, or

--- a/network.go
+++ b/network.go
@@ -1,9 +1,9 @@
 package biloba
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/onsi/biloba/engine"
 	"maps"
 	"net/http"
 	"reflect"
@@ -1154,12 +1154,7 @@ func (b *Biloba) ensureFetchEnabled() {
 		return
 	}
 
-	// cache first, then Fetch: that way there is no window in which requests are being intercepted
-	// but could still be answered from cache.
-	if err := b.runCDP("enable network interception",
-		network.SetCacheDisabled(true),
-		fetch.Enable().WithPatterns([]*fetch.RequestPattern{{URLPattern: "*"}}),
-	); err != nil {
+	if err := engine.EnableInterceptionContext(b.Context); err != nil {
 		b.gt.Fatalf("Failed to enable network interception:\n%s", err.Error())
 	}
 }
@@ -1322,7 +1317,7 @@ func (b *Biloba) handleRequestStagePause(ev *fetch.EventRequestPaused) {
 		default:
 			action = fetch.ContinueRequest(ev.RequestID)
 		}
-		b.runCDP("answer the intercepted request", action)
+		engine.RunActionContext(b.Context, action)
 	}()
 }
 
@@ -1331,7 +1326,7 @@ func (b *Biloba) handleResponseStagePause(ev *fetch.EventRequestPaused) {
 	go func() {
 		if handler == nil {
 			// Not ours to modify: hand the real response straight back to the page.
-			b.runCDP("continue the intercepted response", fetch.ContinueResponse(ev.RequestID))
+			engine.RunActionContext(b.Context, fetch.ContinueResponse(ev.RequestID))
 			return
 		}
 
@@ -1342,14 +1337,7 @@ func (b *Biloba) handleResponseStagePause(ev *fetch.EventRequestPaused) {
 		for _, h := range ev.ResponseHeaders {
 			original.Headers[h.Name] = h.Value
 		}
-		// GetResponseBody is only valid at the response stage; chromedp decodes base64 for us.  It
-		// must run through chromedp.Run so it picks up the target's CDP executor from the context.
-		var body []byte
-		b.runCDP("read the intercepted response body", chromedp.ActionFunc(func(ctx context.Context) error {
-			var err error
-			body, err = fetch.GetResponseBody(ev.RequestID).Do(ctx)
-			return err
-		}))
+		body, _ := engine.ResponseBodyContext(b.Context, ev.RequestID)
 		original.Body = string(body)
 
 		response := handler.resolve(original)
@@ -1361,7 +1349,7 @@ func (b *Biloba) handleResponseStagePause(ev *fetch.EventRequestPaused) {
 		if headers := response.headerEntries(); len(headers) > 0 {
 			params = params.WithResponseHeaders(headers)
 		}
-		b.runCDP("fulfil the intercepted response", params)
+		engine.RunActionContext(b.Context, params)
 	}()
 }
 

--- a/network.go
+++ b/network.go
@@ -1,6 +1,7 @@
 package biloba
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"github.com/onsi/biloba/engine"
@@ -1154,7 +1155,9 @@ func (b *Biloba) ensureFetchEnabled() {
 		return
 	}
 
-	if err := engine.EnableInterceptionContext(b.Context); err != nil {
+	if err := b.runEngine("enable network interception", func(ctx context.Context) error {
+		return engine.EnableInterceptionContext(ctx)
+	}); err != nil {
 		b.gt.Fatalf("Failed to enable network interception:\n%s", err.Error())
 	}
 }
@@ -1317,7 +1320,9 @@ func (b *Biloba) handleRequestStagePause(ev *fetch.EventRequestPaused) {
 		default:
 			action = fetch.ContinueRequest(ev.RequestID)
 		}
-		engine.RunActionContext(b.Context, action)
+		_ = b.runEngine("answer a paused network request", func(ctx context.Context) error {
+			return engine.RunActionContext(ctx, action)
+		})
 	}()
 }
 
@@ -1326,7 +1331,9 @@ func (b *Biloba) handleResponseStagePause(ev *fetch.EventRequestPaused) {
 	go func() {
 		if handler == nil {
 			// Not ours to modify: hand the real response straight back to the page.
-			engine.RunActionContext(b.Context, fetch.ContinueResponse(ev.RequestID))
+			_ = b.runEngine("continue an unmodified network response", func(ctx context.Context) error {
+				return engine.RunActionContext(ctx, fetch.ContinueResponse(ev.RequestID))
+			})
 			return
 		}
 
@@ -1337,7 +1344,12 @@ func (b *Biloba) handleResponseStagePause(ev *fetch.EventRequestPaused) {
 		for _, h := range ev.ResponseHeaders {
 			original.Headers[h.Name] = h.Value
 		}
-		body, _ := engine.ResponseBodyContext(b.Context, ev.RequestID)
+		var body []byte
+		_ = b.runEngine("read a paused network response", func(ctx context.Context) error {
+			var err error
+			body, err = engine.ResponseBodyContext(ctx, ev.RequestID)
+			return err
+		})
 		original.Body = string(body)
 
 		response := handler.resolve(original)
@@ -1349,7 +1361,9 @@ func (b *Biloba) handleResponseStagePause(ev *fetch.EventRequestPaused) {
 		if headers := response.headerEntries(); len(headers) > 0 {
 			params = params.WithResponseHeaders(headers)
 		}
-		engine.RunActionContext(b.Context, params)
+		_ = b.runEngine("fulfill a modified network response", func(ctx context.Context) error {
+			return engine.RunActionContext(ctx, params)
+		})
 	}()
 }
 

--- a/outline.go
+++ b/outline.go
@@ -3,12 +3,11 @@ package biloba
 import (
 	"context"
 	"fmt"
+	"github.com/onsi/biloba/engine"
 	"os"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/chromedp/chromedp"
 )
 
 const outlineMaxBytes = 32768 // 32 KB hard cap (default; override with BILOBA_OUTLINE_MAX)
@@ -78,8 +77,8 @@ func (b *Biloba) safeAllTabOutlines() []tabOutline {
 		ctx, cancel := context.WithTimeout(tab.Context, time.Second)
 		defer cancel()
 
-		var title string
-		if err := chromedp.Run(ctx, chromedp.Title(&title)); err != nil {
+		title, err := engine.TitleContext(ctx)
+		if err != nil {
 			out = append(out, tabOutline{failure: fmt.Sprintf("Failed to fetch title for DOM outline: %s", err.Error())})
 			continue
 		}

--- a/realistic.go
+++ b/realistic.go
@@ -2,10 +2,9 @@ package biloba
 
 import (
 	"fmt"
+	"github.com/onsi/biloba/engine"
 
-	"github.com/chromedp/cdproto/emulation"
 	"github.com/chromedp/cdproto/input"
-	"github.com/chromedp/chromedp"
 )
 
 /*
@@ -93,10 +92,7 @@ func (b *Biloba) realisticClickEach(selector any) error {
 		if !ok || !pt.enabled || !pt.inViewport || !pt.hittable {
 			continue
 		}
-		if err := b.runCDP("dispatch the mouse click",
-			chromedp.MouseEvent(input.MouseMoved, pt.x, pt.y),
-			chromedp.MouseClickXY(pt.x, pt.y),
-		); err != nil {
+		if err := engine.ClickXYContext(b.Context, pt.x, pt.y); err != nil {
 			return err
 		}
 	}
@@ -172,19 +168,7 @@ func (b *Biloba) realisticMouseClick(selector any, cfg pointerConfig, button inp
 	if err != nil || !ok {
 		return ok, err
 	}
-	mods := modifierMask(cfg.modifiers)
-	actions := []chromedp.Action{chromedp.MouseEvent(input.MouseMoved, x, y)}
-	counts := []int64{1}
-	if clickCount >= 2 {
-		counts = []int64{1, 2}
-	}
-	for _, c := range counts {
-		actions = append(actions,
-			input.DispatchMouseEvent(input.MousePressed, x, y).WithButton(button).WithClickCount(c).WithModifiers(mods),
-			input.DispatchMouseEvent(input.MouseReleased, x, y).WithButton(button).WithClickCount(c).WithModifiers(mods),
-		)
-	}
-	if err := b.runCDP("dispatch the mouse click", actions...); err != nil {
+	if err := engine.MouseClickContext(b.Context, x, y, button, clickCount, modifierMask(cfg.modifiers)); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -216,11 +200,7 @@ func (b *Biloba) realisticTap(selector any, cfg pointerConfig) (bool, error) {
 	if err != nil || !ok {
 		return ok, err
 	}
-	if err := b.runCDP("dispatch the touch tap",
-		emulation.SetTouchEmulationEnabled(true),
-		input.DispatchTouchEvent(input.TouchStart, []*input.TouchPoint{{X: x, Y: y}}),
-		input.DispatchTouchEvent(input.TouchEnd, []*input.TouchPoint{}),
-	); err != nil {
+	if err := engine.TouchTapContext(b.Context, x, y); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -290,21 +270,7 @@ func (b *Biloba) realisticDragTo(source any, target any) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	actions := []chromedp.Action{
-		chromedp.MouseEvent(input.MouseMoved, src.x, src.y),
-		chromedp.MouseEvent(input.MousePressed, src.x, src.y, chromedp.ButtonType(input.Left), chromedp.ClickCount(1)),
-	}
-	steps := 5
-	for i := 1; i <= steps; i++ {
-		x := src.x + (tgt.x-src.x)*float64(i)/float64(steps)
-		y := src.y + (tgt.y-src.y)*float64(i)/float64(steps)
-		actions = append(actions, chromedp.MouseEvent(input.MouseMoved, x, y, chromedp.ButtonType(input.Left)))
-	}
-	actions = append(actions,
-		chromedp.MouseEvent(input.MouseMoved, tgt.x, tgt.y, chromedp.ButtonType(input.Left)),
-		chromedp.MouseEvent(input.MouseReleased, tgt.x, tgt.y, chromedp.ButtonType(input.Left), chromedp.ClickCount(1)),
-	)
-	if err := b.runCDP("dispatch the pointer drag", actions...); err != nil {
+	if err := engine.DragContext(b.Context, src.x, src.y, tgt.x, tgt.y, 5); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -323,7 +289,7 @@ func (b *Biloba) realisticScrollWheel(selector any, deltaX, deltaY float64) erro
 	if !pt.inViewport || !pt.hittable {
 		return fmt.Errorf("element is not actionable (it is off-screen or obscured by another element)")
 	}
-	return b.runCDP("dispatch the wheel event", input.DispatchMouseEvent(input.MouseWheel, pt.x, pt.y).WithDeltaX(deltaX).WithDeltaY(deltaY))
+	return engine.ScrollWheelContext(b.Context, pt.x, pt.y, deltaX, deltaY)
 }
 
 // realisticSetValue implements SetValue for realistic mode.  Text inputs are focused with a real
@@ -359,7 +325,7 @@ func (b *Biloba) realisticSetValue(selector any, value any) (bool, error) {
 		if r := b.runBilobaHandler("setProperty", selector, "value", ""); r.Error() != nil {
 			return false, r.Error()
 		}
-		if err := b.runCDP("type into the focused element", chromedp.KeyEvent(toString(value))); err != nil {
+		if err := engine.KeyEventContext(b.Context, toString(value)); err != nil {
 			return false, err
 		}
 		if r := b.runBilobaHandler("blur", selector); r.Error() != nil {
@@ -381,7 +347,7 @@ func (b *Biloba) realisticHover(selector any) (bool, error) {
 	if !pt.inViewport {
 		return false, nil
 	}
-	if err := b.runCDP("move the mouse", chromedp.MouseEvent(input.MouseMoved, pt.x, pt.y)); err != nil {
+	if err := engine.MouseMoveContext(b.Context, pt.x, pt.y); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/realistic.go
+++ b/realistic.go
@@ -1,6 +1,7 @@
 package biloba
 
 import (
+	"context"
 	"fmt"
 	"github.com/onsi/biloba/engine"
 
@@ -92,7 +93,9 @@ func (b *Biloba) realisticClickEach(selector any) error {
 		if !ok || !pt.enabled || !pt.inViewport || !pt.hittable {
 			continue
 		}
-		if err := engine.ClickXYContext(b.Context, pt.x, pt.y); err != nil {
+		if err := b.runEngine("dispatch realistic click input", func(ctx context.Context) error {
+			return engine.ClickXYContext(ctx, pt.x, pt.y)
+		}); err != nil {
 			return err
 		}
 	}
@@ -168,7 +171,9 @@ func (b *Biloba) realisticMouseClick(selector any, cfg pointerConfig, button inp
 	if err != nil || !ok {
 		return ok, err
 	}
-	if err := engine.MouseClickContext(b.Context, x, y, button, clickCount, modifierMask(cfg.modifiers)); err != nil {
+	if err := b.runEngine("dispatch realistic mouse input", func(ctx context.Context) error {
+		return engine.MouseClickContext(ctx, x, y, button, clickCount, modifierMask(cfg.modifiers))
+	}); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -200,7 +205,9 @@ func (b *Biloba) realisticTap(selector any, cfg pointerConfig) (bool, error) {
 	if err != nil || !ok {
 		return ok, err
 	}
-	if err := engine.TouchTapContext(b.Context, x, y); err != nil {
+	if err := b.runEngine("dispatch realistic touch input", func(ctx context.Context) error {
+		return engine.TouchTapContext(ctx, x, y)
+	}); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -270,7 +277,9 @@ func (b *Biloba) realisticDragTo(source any, target any) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if err := engine.DragContext(b.Context, src.x, src.y, tgt.x, tgt.y, 5); err != nil {
+	if err := b.runEngine("dispatch realistic drag input", func(ctx context.Context) error {
+		return engine.DragContext(ctx, src.x, src.y, tgt.x, tgt.y, 5)
+	}); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -289,7 +298,9 @@ func (b *Biloba) realisticScrollWheel(selector any, deltaX, deltaY float64) erro
 	if !pt.inViewport || !pt.hittable {
 		return fmt.Errorf("element is not actionable (it is off-screen or obscured by another element)")
 	}
-	return engine.ScrollWheelContext(b.Context, pt.x, pt.y, deltaX, deltaY)
+	return b.runEngine("dispatch realistic scroll input", func(ctx context.Context) error {
+		return engine.ScrollWheelContext(ctx, pt.x, pt.y, deltaX, deltaY)
+	})
 }
 
 // realisticSetValue implements SetValue for realistic mode.  Text inputs are focused with a real
@@ -325,7 +336,9 @@ func (b *Biloba) realisticSetValue(selector any, value any) (bool, error) {
 		if r := b.runBilobaHandler("setProperty", selector, "value", ""); r.Error() != nil {
 			return false, r.Error()
 		}
-		if err := engine.KeyEventContext(b.Context, toString(value)); err != nil {
+		if err := b.runEngine("dispatch realistic keyboard input", func(ctx context.Context) error {
+			return engine.KeyEventContext(ctx, toString(value))
+		}); err != nil {
 			return false, err
 		}
 		if r := b.runBilobaHandler("blur", selector); r.Error() != nil {
@@ -347,7 +360,9 @@ func (b *Biloba) realisticHover(selector any) (bool, error) {
 	if !pt.inViewport {
 		return false, nil
 	}
-	if err := engine.MouseMoveContext(b.Context, pt.x, pt.y); err != nil {
+	if err := b.runEngine("dispatch realistic mouse movement", func(ctx context.Context) error {
+		return engine.MouseMoveContext(ctx, pt.x, pt.y)
+	}); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/screenshots.go
+++ b/screenshots.go
@@ -134,20 +134,21 @@ func (b *Biloba) CaptureScreenshot() []byte {
 // WithTimeout/WithContext knobs a waiting command is allowed.
 func (b *Biloba) captureScreenshot() []byte {
 	b.gt.Helper()
+	timeout := b.waitingTimeout(screenshotCaptureTimeout)
 	ctx, cancel := b.waitingContext(screenshotCaptureTimeout)
 	defer cancel()
 	var img []byte
-	img, err := engine.CapturePageContext(ctx, nil)
+	err := b.runEngineIn(ctx, timeout, "capture a screenshot", func(runCtx context.Context) error {
+		var err error
+		img, err = engine.CapturePageContext(runCtx, nil)
+		return err
+	})
 	if err != nil {
 		b.gt.Fatalf("Failed to capture screenshot:\n%s", err.Error())
 	}
 	return img
 }
 
-// capturePageAction captures the whole document as a PNG, and optionally reports the document's width
-// in CSS pixels (which is what the visual-regression path divides by to recover the device scale
-// factor).  Both come out of the same round trip, so they describe the same layout.
-//
 /*
 CaptureImgCatScreenshot() returns a full screenshot of the current tab as an iTerm2 imgcat-compatible string.  Simply print it out to see images on your terminal.
 
@@ -331,9 +332,15 @@ func (b *Biloba) elementScreenshot(selector any) ([]byte, *page.Viewport, captur
 		Scale:  1,
 	}
 	beyondViewport := expandsViewport(box)
+	timeout := b.waitingTimeout(screenshotCaptureTimeout)
 	cctx, cancel := b.waitingContext(screenshotCaptureTimeout)
 	defer cancel()
-	img, err := engine.CaptureClipContext(cctx, clip, beyondViewport)
+	var img []byte
+	err := b.runEngineIn(cctx, timeout, "capture an element screenshot", func(runCtx context.Context) error {
+		var err error
+		img, err = engine.CaptureClipContext(runCtx, clip, beyondViewport)
+		return err
+	})
 	if err != nil {
 		return nil, clip, notes, err
 	}
@@ -473,15 +480,25 @@ func (b *Biloba) safeAllTabScreenshots(width int, height int) []tabScreenshot {
 		var originalWidth, originalHeight int
 		if width > 0 && height > 0 {
 			originalWidth, originalHeight = b.WindowSize()
-			err := engine.EmulateViewportContext(ctx, width, height)
+			err := tab.runEngineIn(ctx, screenshotCaptureTimeout, "set the failure-screenshot window size", func(runCtx context.Context) error {
+				return engine.EmulateViewportContext(runCtx, width, height)
+			})
 			if err != nil {
 				out = append(out, tabScreenshot{failure: fmt.Sprintf("failed to set window size: %s", err.Error())})
 				continue
 			}
 		}
-		img, title, err := engine.CaptureFullScreenshotContext(ctx, 100)
+		var img []byte
+		var title string
+		err := tab.runEngineIn(ctx, screenshotCaptureTimeout, "capture a failure screenshot", func(runCtx context.Context) error {
+			var err error
+			img, title, err = engine.CaptureFullScreenshotContext(runCtx, 100)
+			return err
+		})
 		if width > 0 && height > 0 {
-			err := engine.EmulateViewportContext(ctx, originalWidth, originalHeight, chromedp.EmulatePortrait)
+			err := tab.runEngineIn(ctx, screenshotCaptureTimeout, "reset the failure-screenshot window size", func(runCtx context.Context) error {
+				return engine.EmulateViewportContext(runCtx, originalWidth, originalHeight, chromedp.EmulatePortrait)
+			})
 			if err != nil {
 				out = append(out, tabScreenshot{failure: fmt.Sprintf("failed to reset window size: %s", err.Error())})
 				continue

--- a/screenshots.go
+++ b/screenshots.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"github.com/onsi/biloba/engine"
 	"image"
 	"image/color/palette"
 	"image/draw"
@@ -136,7 +137,7 @@ func (b *Biloba) captureScreenshot() []byte {
 	ctx, cancel := b.waitingContext(screenshotCaptureTimeout)
 	defer cancel()
 	var img []byte
-	err := b.runCDPIn(ctx, b.waitingTimeout(screenshotCaptureTimeout), "capture a screenshot of the page", capturePageAction(&img, nil))
+	img, err := engine.CapturePageContext(ctx, nil)
 	if err != nil {
 		b.gt.Fatalf("Failed to capture screenshot:\n%s", err.Error())
 	}
@@ -147,36 +148,6 @@ func (b *Biloba) captureScreenshot() []byte {
 // in CSS pixels (which is what the visual-regression path divides by to recover the device scale
 // factor).  Both come out of the same round trip, so they describe the same layout.
 //
-// It expands the viewport only when the document is actually bigger than it - see expandsViewport for
-// why that expansion is worth avoiding.  When the content already fits, the expanded capture and the
-// plain one are the same pixels, so skipping it changes nothing except that the page stops being told
-// its viewport resized.  That is the app-shell case: a document that never scrolls because an inner
-// pane does.
-func capturePageAction(img *[]byte, cssWidth *float64) chromedp.ActionFunc {
-	return func(ctx context.Context) error {
-		_, _, _, cssLayoutViewport, _, cssContentSize, err := page.GetLayoutMetrics().Do(ctx)
-		if err != nil {
-			return err
-		}
-		if cssWidth != nil {
-			*cssWidth = cssContentSize.Width
-		}
-		// Exact equality, not "fits within": anything looser and the two captures could differ in size,
-		// which would invalidate every baseline taken with the other one.  Chrome reports both in CSS
-		// pixels off the same layout, so a document that measures equal really is the viewport.
-		fits := cssLayoutViewport != nil &&
-			cssContentSize.Width == float64(cssLayoutViewport.ClientWidth) &&
-			cssContentSize.Height == float64(cssLayoutViewport.ClientHeight) &&
-			cssContentSize.X == 0 && cssContentSize.Y == 0
-		*img, err = page.CaptureScreenshot().
-			WithFromSurface(true).
-			WithCaptureBeyondViewport(!fits).
-			WithFormat(page.CaptureScreenshotFormatPng).
-			Do(ctx)
-		return err
-	}
-}
-
 /*
 CaptureImgCatScreenshot() returns a full screenshot of the current tab as an iTerm2 imgcat-compatible string.  Simply print it out to see images on your terminal.
 
@@ -362,16 +333,7 @@ func (b *Biloba) elementScreenshot(selector any) ([]byte, *page.Viewport, captur
 	beyondViewport := expandsViewport(box)
 	cctx, cancel := b.waitingContext(screenshotCaptureTimeout)
 	defer cancel()
-	var img []byte
-	err := b.runCDPIn(cctx, b.waitingTimeout(screenshotCaptureTimeout), "capture a screenshot of the element", chromedp.ActionFunc(func(ctx context.Context) error {
-		var captureErr error
-		img, captureErr = page.CaptureScreenshot().
-			WithClip(clip).
-			WithFromSurface(true).
-			WithCaptureBeyondViewport(beyondViewport).
-			Do(ctx)
-		return captureErr
-	}))
+	img, err := engine.CaptureClipContext(cctx, clip, beyondViewport)
 	if err != nil {
 		return nil, clip, notes, err
 	}
@@ -511,20 +473,15 @@ func (b *Biloba) safeAllTabScreenshots(width int, height int) []tabScreenshot {
 		var originalWidth, originalHeight int
 		if width > 0 && height > 0 {
 			originalWidth, originalHeight = b.WindowSize()
-			err := chromedp.Run(ctx, chromedp.EmulateViewport(int64(width), int64(height)))
+			err := engine.EmulateViewportContext(ctx, width, height)
 			if err != nil {
 				out = append(out, tabScreenshot{failure: fmt.Sprintf("failed to set window size: %s", err.Error())})
 				continue
 			}
 		}
-		var img []byte
-		var title string
-		err := chromedp.Run(ctx,
-			chromedp.Title(&title),
-			chromedp.FullScreenshot(&img, 100),
-		)
+		img, title, err := engine.CaptureFullScreenshotContext(ctx, 100)
 		if width > 0 && height > 0 {
-			err := chromedp.Run(ctx, chromedp.EmulateViewport(int64(originalWidth), int64(originalHeight), chromedp.EmulatePortrait))
+			err := engine.EmulateViewportContext(ctx, originalWidth, originalHeight, chromedp.EmulatePortrait)
 			if err != nil {
 				out = append(out, tabScreenshot{failure: fmt.Sprintf("failed to reset window size: %s", err.Error())})
 				continue

--- a/upload.go
+++ b/upload.go
@@ -1,9 +1,7 @@
 package biloba
 
 import (
-	"github.com/chromedp/cdproto/dom"
-	"github.com/chromedp/cdproto/runtime"
-	"github.com/chromedp/chromedp"
+	"github.com/onsi/biloba/engine"
 	"github.com/onsi/gomega/gcustom"
 	"github.com/onsi/gomega/types"
 )
@@ -89,17 +87,5 @@ func (b *Biloba) performSetUpload(selector any, paths []string) (bool, error) {
 		return false, err
 	}
 
-	var node *runtime.RemoteObject
-	script := b.JSFunc("_biloba.node").Invoke(encoded)
-	if err := b.runCDP("resolve the file input element", chromedp.Evaluate(script, &node)); err != nil {
-		return false, err
-	}
-	if node == nil || node.ObjectID == "" {
-		return false, nil
-	}
-
-	if err := b.runCDP("set the file input's files", dom.SetFileInputFiles(paths).WithObjectID(node.ObjectID)); err != nil {
-		return false, err
-	}
-	return true, nil
+	return engine.SetFileInputFilesContext(b.Context, b.JSFunc("_biloba.node").Invoke(encoded), paths)
 }

--- a/upload.go
+++ b/upload.go
@@ -1,6 +1,8 @@
 package biloba
 
 import (
+	"context"
+
 	"github.com/onsi/biloba/engine"
 	"github.com/onsi/gomega/gcustom"
 	"github.com/onsi/gomega/types"
@@ -87,5 +89,11 @@ func (b *Biloba) performSetUpload(selector any, paths []string) (bool, error) {
 		return false, err
 	}
 
-	return engine.SetFileInputFilesContext(b.Context, b.JSFunc("_biloba.node").Invoke(encoded), paths)
+	var found bool
+	err = b.runEngine("set files on an upload input", func(ctx context.Context) error {
+		var runErr error
+		found, runErr = engine.SetFileInputFilesContext(ctx, b.JSFunc("_biloba.node").Invoke(encoded), paths)
+		return runErr
+	})
+	return found, err
 }

--- a/visual.go
+++ b/visual.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/onsi/biloba/engine"
 	"image"
 	"image/png"
 	"math"
@@ -13,7 +14,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/chromedp/cdproto/emulation"
 	"github.com/chromedp/cdproto/page"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
@@ -650,12 +650,10 @@ func (b *Biloba) captureForComparison(selector any, cfg screenshotConfig, scheme
 func (b *Biloba) emulateColorScheme(scheme string) error {
 	ctx, cancel := b.waitingContext(screenshotCaptureTimeout)
 	defer cancel()
-	params := emulation.SetEmulatedMedia()
 	if scheme != "" {
-		params = params.WithFeatures([]*emulation.MediaFeature{{Name: "prefers-color-scheme", Value: scheme}})
 		b.setColorSchemeEmulated(true)
 	}
-	err := b.runCDPIn(ctx, b.waitingTimeout(screenshotCaptureTimeout), "emulate the color scheme", params)
+	err := engine.EmulateColorSchemeContext(ctx, scheme)
 	if scheme == "" && err == nil {
 		b.setColorSchemeEmulated(false)
 	}
@@ -697,7 +695,7 @@ func (b *Biloba) fullPageScreenshot() ([]byte, float64, error) {
 	defer cancel()
 	var img []byte
 	var cssWidth float64
-	err := b.runCDPIn(ctx, b.waitingTimeout(screenshotCaptureTimeout), "capture a screenshot of the page", capturePageAction(&img, &cssWidth))
+	img, err := engine.CapturePageContext(ctx, &cssWidth)
 	return img, cssWidth, err
 }
 

--- a/visual.go
+++ b/visual.go
@@ -2,6 +2,7 @@ package biloba
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"github.com/onsi/biloba/engine"
@@ -648,12 +649,15 @@ func (b *Biloba) captureForComparison(selector any, cfg screenshotConfig, scheme
 // clean up: the flag goes up BEFORE the command that sets the override (a command that reports an
 // error may still have landed) and only comes down when a clear actually succeeds.
 func (b *Biloba) emulateColorScheme(scheme string) error {
+	timeout := b.waitingTimeout(screenshotCaptureTimeout)
 	ctx, cancel := b.waitingContext(screenshotCaptureTimeout)
 	defer cancel()
 	if scheme != "" {
 		b.setColorSchemeEmulated(true)
 	}
-	err := engine.EmulateColorSchemeContext(ctx, scheme)
+	err := b.runEngineIn(ctx, timeout, "emulate the page color scheme", func(runCtx context.Context) error {
+		return engine.EmulateColorSchemeContext(runCtx, scheme)
+	})
 	if scheme == "" && err == nil {
 		b.setColorSchemeEmulated(false)
 	}
@@ -691,11 +695,16 @@ func (b *Biloba) clearLeakedColorSchemeEmulation() {
 // the page stops being told its viewport resized.  That is the app-shell case: a document that never
 // scrolls because an inner pane does.
 func (b *Biloba) fullPageScreenshot() ([]byte, float64, error) {
+	timeout := b.waitingTimeout(screenshotCaptureTimeout)
 	ctx, cancel := b.waitingContext(screenshotCaptureTimeout)
 	defer cancel()
 	var img []byte
 	var cssWidth float64
-	img, err := engine.CapturePageContext(ctx, &cssWidth)
+	err := b.runEngineIn(ctx, timeout, "capture a full-page screenshot", func(runCtx context.Context) error {
+		var err error
+		img, err = engine.CapturePageContext(runCtx, &cssWidth)
+		return err
+	})
 	return img, cssWidth, err
 }
 

--- a/windows.go
+++ b/windows.go
@@ -1,6 +1,8 @@
 package biloba
 
 import (
+	"context"
+
 	"github.com/chromedp/chromedp"
 	"github.com/onsi/biloba/engine"
 )
@@ -20,7 +22,9 @@ func (b *Biloba) SetWindowSize(width, height int, opts ...chromedp.EmulateViewpo
 	if b.ChromeConnection.HighFidelity {
 		opts = append([]chromedp.EmulateViewportOption{emulateViewportMatchingScreen}, opts...)
 	}
-	err := engine.EmulateViewportContext(b.Context, width, height, opts...)
+	err := b.runEngine("set the window size", func(ctx context.Context) error {
+		return engine.EmulateViewportContext(ctx, width, height, opts...)
+	})
 	if err != nil {
 		b.gt.Fatalf("failed to set window size: %s", err.Error())
 	}
@@ -30,7 +34,9 @@ func (b *Biloba) SetWindowSize(width, height int, opts ...chromedp.EmulateViewpo
 		if b.ChromeConnection.HighFidelity {
 			resetOpts = append(resetOpts, emulateViewportMatchingScreen)
 		}
-		err := engine.EmulateViewportContext(b.Context, originalWidth, originalHeight, resetOpts...)
+		err := b.runEngine("reset the window size", func(ctx context.Context) error {
+			return engine.EmulateViewportContext(ctx, originalWidth, originalHeight, resetOpts...)
+		})
 		if err != nil {
 			b.gt.Fatalf("failed to reset window size: %s", err.Error())
 		}

--- a/windows.go
+++ b/windows.go
@@ -2,6 +2,7 @@ package biloba
 
 import (
 	"github.com/chromedp/chromedp"
+	"github.com/onsi/biloba/engine"
 )
 
 /*
@@ -19,7 +20,7 @@ func (b *Biloba) SetWindowSize(width, height int, opts ...chromedp.EmulateViewpo
 	if b.ChromeConnection.HighFidelity {
 		opts = append([]chromedp.EmulateViewportOption{emulateViewportMatchingScreen}, opts...)
 	}
-	err := b.runCDP("set the window size", chromedp.EmulateViewport(int64(width), int64(height), opts...))
+	err := engine.EmulateViewportContext(b.Context, width, height, opts...)
 	if err != nil {
 		b.gt.Fatalf("failed to set window size: %s", err.Error())
 	}
@@ -29,7 +30,7 @@ func (b *Biloba) SetWindowSize(width, height int, opts ...chromedp.EmulateViewpo
 		if b.ChromeConnection.HighFidelity {
 			resetOpts = append(resetOpts, emulateViewportMatchingScreen)
 		}
-		err := b.runCDP("reset the window size", chromedp.EmulateViewport(int64(originalWidth), int64(originalHeight), resetOpts...))
+		err := engine.EmulateViewportContext(b.Context, originalWidth, originalHeight, resetOpts...)
 		if err != nil {
 			b.gt.Fatalf("failed to reset window size: %s", err.Error())
 		}


### PR DESCRIPTION
**Stack 6 of 17** · base [#21](https://github.com/onsi/biloba/pull/21) · next: [#23](https://github.com/onsi/biloba/pull/23)

Nine families of calls still talked to Chrome themselves. They don't now. Capture, input, upload, accessibility, viewport emulation, and network interception all go through engine primitives, which leaves the Go API as the adapter it's meant to be.

After this, 15 direct browser calls remain in the root package, all in `biloba.go` for connection and tab lifecycle, and in `dialog_handling.go` and `listeners.go` for event subscription. Those are #7.

## New engine surface, grouped by what it owns

**`engine/capture.go`** handles whole-page and clipped screenshots, full-page artifact capture, and `prefers-color-scheme` emulation. `PageCaptureAction` keeps its exact-equality viewport test. Anything looser lets an expanded capture come out a different size from a plain one, which invalidates every baseline taken the other way.

**`engine/input.go`** handles trusted keyboard and pointer input, taps, wheels, drags, a file input's file list, and the accessibility tree. The browser forbids simulating these in JavaScript, so they have to go over CDP. Two implementations of "dispatch a real click" would drift apart in the ways hardest to notice.

**`engine/network.go`** handles interception enable, action dispatch, and response bodies. `EnableInterceptionContext` keeps its ordering: disable the cache, then enable Fetch. The other order leaves a window where requests are intercepted but can still be served from cache, which looks like an interceptor that never fired.

## Two things that deliberately didn't move

**chromedp types stay in public signatures**, such as `SetWindowSize(..., opts ...chromedp.EmulateViewportOption)` and `ChromeFlags(...chromedp.ExecAllocatorOption)`. Not hiding chromedp is a documented promise in `CLAUDE.md`, not an oversight. What moved is the `chromedp.Run` inside those functions.

**The tree rendering in `a11y.go` stays in the adapter.** It's presentation logic over `accessibility.Node`, not browser interaction. Only the `GetFullAXTree` call moved.

## One behavior difference caught while moving

The drag loop includes its step count, so the final interpolated point lands on the target and the explicit move after it repeats that point. My first version of `DragContext` made the loop exclusive, which was tidier and wrong. The duplicate point is what the Go API dispatched before, and a drag implementation that watches `mousemove` can count events, so this reproduces the old behavior rather than cleaning it up.

## A stale doc comment, fixed here

Reviewing this stack caught one thing this PR introduced. Moving `capturePageAction` to `engine/capture.go` took the function but left its doc comment behind, where it merged into `CaptureImgcatScreenshot`'s godoc. The published docs for that method described a different function's return values. The last commit deletes it.

## Verification

Biloba 1039/1039 · Engine 25/25 · Protocol 35/35 · Bilobad 15/15. All three `make driver-*` targets exit 0. `go vet` and `gofmt` are clean.

One note: `visual_test.go`'s "is not fooled by a page that repeats on a period" flakes about 1 run in 4 under full parallel load. This is pre-existing. It reproduces without these changes, and fails 0 times out of 5 in isolation. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/856687b8-c710-4231-b967-2d79ae359cfe)