### PR TITLE
7/17 engine: move connection and tab lifecycle — the Go API is now purely an adapter

### DIFF
--- a/biloba.go
+++ b/biloba.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/onsi/biloba/engine"
 	"math/rand/v2"
 	"os"
 	"path/filepath"
@@ -27,10 +28,8 @@ import (
 
 	"github.com/jehiah/agentdetection"
 
-	"github.com/chromedp/cdproto/browser"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/emulation"
-	"github.com/chromedp/cdproto/fetch"
 	"github.com/chromedp/cdproto/inspector"
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/cdproto/page"
@@ -71,12 +70,7 @@ func chromeMajorVersion(product string) int {
 // minimumSupportedChromeMajor, prints a one-time warning with upgrade instructions.  It is
 // best-effort: any probe/parse failure is silently ignored so a version check never breaks startup.
 func warnIfChromeUnsupported(ginkgoT GinkgoTInterface, browserCtx context.Context, highFidelity bool) {
-	var product string
-	err := chromedp.Run(browserCtx, chromedp.ActionFunc(func(ctx context.Context) error {
-		_, p, _, _, _, err := browser.GetVersion().Do(ctx)
-		product = p
-		return err
-	}))
+	product, err := engine.ChromeProductContext(browserCtx)
 	if err != nil {
 		return
 	}
@@ -231,11 +225,13 @@ func (b *Biloba) applyHighFidelityViewport() error {
 		return nil
 	}
 	return retryTransientCDP(func() error {
-		return b.runCDP("apply the high-fidelity viewport emulation", chromedp.EmulateViewport(
-			int64(b.ChromeConnection.WindowWidth),
-			int64(b.ChromeConnection.WindowHeight),
-			emulateViewportMatchingScreen,
-		))
+		return b.runEngine("apply the high-fidelity viewport emulation", func(ctx context.Context) error {
+			return engine.EmulateViewportContext(ctx,
+				b.ChromeConnection.WindowWidth,
+				b.ChromeConnection.WindowHeight,
+				emulateViewportMatchingScreen,
+			)
+		})
 	})
 }
 
@@ -250,11 +246,18 @@ func (b *Biloba) reassertViewportForCompositor() {
 	if !b.ChromeConnection.HighFidelity || b.ChromeConnection.WindowWidth <= 0 || b.ChromeConnection.WindowHeight <= 0 {
 		return
 	}
-	var dims []int64
-	if err := b.runCDP("measure the viewport", chromedp.Evaluate("[window.innerWidth, window.innerHeight]", &dims)); err != nil || len(dims) != 2 || dims[0] <= 0 || dims[1] <= 0 {
+	var width, height int64
+	err := b.runEngine("measure the viewport", func(ctx context.Context) error {
+		var err error
+		width, height, err = engine.ViewportDimensionsContext(ctx)
+		return err
+	})
+	if err != nil || width <= 0 || height <= 0 {
 		return
 	}
-	_ = b.runCDP("re-apply the viewport emulation", chromedp.EmulateViewport(dims[0], dims[1], emulateViewportMatchingScreen))
+	_ = b.runEngine("re-apply the viewport emulation", func(ctx context.Context) error {
+		return engine.EmulateViewportContext(ctx, int(width), int(height), emulateViewportMatchingScreen)
+	})
 }
 
 // applyFocusEmulation makes this tab behave as though its page always holds the system focus.  An
@@ -267,7 +270,9 @@ func (b *Biloba) reassertViewportForCompositor() {
 // page as focused.
 func (b *Biloba) applyFocusEmulation() error {
 	return retryTransientCDP(func() error {
-		return b.runCDP("enable focus emulation", emulation.SetFocusEmulationEnabled(true))
+		return b.runEngine("enable focus emulation", func(ctx context.Context) error {
+			return engine.SetFocusEmulationContext(ctx)
+		})
 	})
 }
 
@@ -340,16 +345,16 @@ func SpinUpChrome(ginkgoT GinkgoTInterface, options ...SpinUpOption) ChromeConne
 		// EmulateViewport each tab back up to that size (see applyHighFidelityViewport).
 		// chrome-headless-shell has no such virtual-screen clamp, so this probe and the EmulateViewport
 		// workaround are skipped in the default mode.
-		var outerDims []int
-		if err := chromedp.Run(browserCtx, chromedp.Evaluate("[window.outerWidth, window.outerHeight]", &outerDims)); err != nil {
+		outerWidth, outerHeight, err := engine.OuterWindowSizeContext(browserCtx)
+		if err != nil {
 			ginkgoT.Fatalf("failed to spin up chrome: %s", err)
 			return ChromeConnection{}
 		}
-		if len(outerDims) == 2 {
-			cc.WindowWidth = outerDims[0]
-			cc.WindowHeight = outerDims[1]
+		if outerWidth > 0 && outerHeight > 0 {
+			cc.WindowWidth = outerWidth
+			cc.WindowHeight = outerHeight
 		}
-	} else if err := chromedp.Run(browserCtx, chromedp.Evaluate("1", nil)); err != nil {
+	} else if err := engine.PingContext(browserCtx); err != nil {
 		ginkgoT.Fatalf("failed to spin up chrome: %s", err)
 		return ChromeConnection{}
 	}
@@ -711,10 +716,7 @@ func (b *Biloba) bootstrapIsolatedTab(allocatorContext context.Context, bootstra
 		}
 
 		bootstrapCtx, cancelBootstrap := chromedp.NewContext(allocatorContext, bootstrapOpts...)
-		// Unbounded on purpose: this Run is what allocates the browser and its target on bootstrapCtx,
-		// so a deadline here would own - and then kill - the Chrome connection.  See the note in
-		// SpinUpChrome.
-		if err := chromedp.Run(bootstrapCtx, chromedp.Evaluate("1", nil)); err != nil {
+		if err := engine.PingContext(bootstrapCtx); err != nil {
 			cancelBootstrap()
 			lastErr = err
 			continue
@@ -1027,7 +1029,9 @@ func (b *Biloba) Prepare() {
 	// ensureFetchEnabled turned off (a cached response raises no Fetch event, so interception
 	// would silently miss it)
 	if wasFetchEnabled {
-		b.runCDP("disable network interception", fetch.Disable(), network.SetCacheDisabled(false))
+		_ = b.runEngine("disable network interception", func(ctx context.Context) error {
+			return engine.DisableInterceptionContext(ctx)
+		})
 	}
 
 	// attachFailureArtifactsIfFailed clears the per-spec poll diagnostics on its way out, but it is
@@ -1352,22 +1356,7 @@ func (b *Biloba) progressReporter() string {
 // (tab) within it, returning both IDs. Chrome 149+ requires WithNewWindow(true) when
 // creating a target in a non-default browser context.
 func newIsolatedBrowserContextAndTarget(ctx context.Context) (cdp.BrowserContextID, target.ID, error) {
-	var browserContextID cdp.BrowserContextID
-	var targetID target.ID
-	err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
-		c := chromedp.FromContext(ctx)
-		be := cdp.WithExecutor(ctx, c.Browser)
-		var err error
-		browserContextID, err = target.CreateBrowserContext().WithDisposeOnDetach(true).Do(be)
-		if err != nil {
-			return err
-		}
-		targetID, err = target.CreateTarget("about:blank").
-			WithBrowserContextID(browserContextID).
-			WithNewWindow(true).
-			Do(be)
-		return err
-	}))
+	browserContextID, targetID, err := engine.NewIsolatedTargetContext(ctx)
 	return browserContextID, targetID, err
 }
 
@@ -1423,13 +1412,9 @@ func (b *Biloba) registerTabFor(c context.Context, cancel context.CancelFunc) *B
 
 	var browserContextID cdp.BrowserContextID
 	err := retryTransientCDP(func() error {
-		return chromedp.Run(c,
-			chromedp.ActionFunc(func(ctx context.Context) error {
-				info, err := target.GetTargetInfo().Do(ctx)
-				browserContextID = info.BrowserContextID
-				return err
-			}),
-		)
+		var infoErr error
+		browserContextID, infoErr = engine.TargetBrowserContextContext(c)
+		return infoErr
 	})
 	if err != nil {
 		cancel()

--- a/dialog_handling.go
+++ b/dialog_handling.go
@@ -1,7 +1,10 @@
 package biloba
 
 import (
+	"context"
+
 	"github.com/chromedp/cdproto/page"
+	"github.com/onsi/biloba/engine"
 	"github.com/onsi/gomega/types"
 )
 
@@ -181,7 +184,9 @@ func (b *Biloba) dismissDialog(response bool, text string) {
 		if text != "" {
 			action = action.WithPromptText(text)
 		}
-		b.runCDP("dismiss the JavaScript dialog", action)
+		_ = b.runEngine("dismiss the JavaScript dialog", func(ctx context.Context) error {
+			return engine.RunActionContext(ctx, action)
+		})
 	}()
 }
 

--- a/engine/lifecycle.go
+++ b/engine/lifecycle.go
@@ -1,0 +1,137 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/chromedp/cdproto/browser"
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/emulation"
+	"github.com/chromedp/cdproto/fetch"
+	"github.com/chromedp/cdproto/inspector"
+	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/cdproto/target"
+	"github.com/chromedp/chromedp"
+)
+
+// The browser- and target-level commands that set a tab up, tear it down, or ask Chrome about
+// itself.  They are separated from the per-operation primitives because most of them run once, at
+// connect or reset time, and because several are browser-scoped: they take a BrowserContextID and
+// must be dispatched on the Browser connection rather than the target's.
+
+// ChromeProductContext reports Chrome's product string, e.g. "HeadlessChrome/152.0.7977.64".
+func ChromeProductContext(ctx context.Context) (string, error) {
+	var product string
+	err := chromedp.Run(ctx, chromedp.ActionFunc(func(runCtx context.Context) error {
+		_, p, _, _, _, versionErr := browser.GetVersion().Do(runCtx)
+		product = p
+		return versionErr
+	}))
+	return product, err
+}
+
+// ViewportDimensionsContext reads the tab's current inner width and height in CSS pixels.
+func ViewportDimensionsContext(ctx context.Context) (width, height int64, err error) {
+	var dims []int64
+	if err = chromedp.Run(ctx, chromedp.Evaluate("[window.innerWidth, window.innerHeight]", &dims)); err != nil {
+		return 0, 0, err
+	}
+	if len(dims) != 2 {
+		return 0, 0, nil
+	}
+	return dims[0], dims[1], nil
+}
+
+// SetFocusEmulationContext makes the tab behave as though its page always holds the system focus.
+// An automated headless window never actually has OS focus, and full ("new") headless Chrome gates
+// focus/blur *event* dispatch on it - element.focus() still moves activeElement, but the events
+// never fire, so onBlur handlers silently never run.  Per-target, so every tab must opt in.
+func SetFocusEmulationContext(ctx context.Context) error {
+	return chromedp.Run(ctx, emulation.SetFocusEmulationEnabled(true))
+}
+
+// EnableCrashReportingContext enables the target-level event Chrome uses to report a dead renderer.
+func EnableCrashReportingContext(ctx context.Context) error {
+	return chromedp.Run(ctx, inspector.Enable())
+}
+
+// InstallScriptOnNewDocumentContext asks Chrome to evaluate script at the start of every new document.
+func InstallScriptOnNewDocumentContext(ctx context.Context, script string) error {
+	return chromedp.Run(ctx, chromedp.ActionFunc(func(runCtx context.Context) error {
+		_, err := page.AddScriptToEvaluateOnNewDocument(script).Do(runCtx)
+		return err
+	}))
+}
+
+// DisableInterceptionContext tears request interception down and restores the HTTP cache.
+// Symmetric with EnableInterceptionContext, and just as order-dependent in reverse: leaving the
+// cache disabled would silently change how later work is served.
+func DisableInterceptionContext(ctx context.Context) error {
+	return chromedp.Run(ctx, fetch.Disable(), network.SetCacheDisabled(false))
+}
+
+// ConfigureDownloadsContext points a browser context's downloads at a directory and asks Chrome to
+// report download events.  Browser-scoped: it takes a BrowserContextID.
+func ConfigureDownloadsContext(ctx context.Context, browserContextID cdp.BrowserContextID, downloadDir string) error {
+	return chromedp.Run(ctx, browser.SetDownloadBehavior(browser.SetDownloadBehaviorBehaviorAllowAndName).
+		WithDownloadPath(downloadDir).
+		WithEventsEnabled(true).
+		WithBrowserContextID(browserContextID))
+}
+
+// NewIsolatedTargetContext creates an isolated browser context and a target within it, returning
+// both ids.  Chrome 149+ requires WithNewWindow(true) for a target in a non-default browser
+// context, and DisposeOnDetach ties the context's lifetime to the connection that made it.
+func NewIsolatedTargetContext(ctx context.Context) (cdp.BrowserContextID, target.ID, error) {
+	var browserContextID cdp.BrowserContextID
+	var targetID target.ID
+	err := chromedp.Run(ctx, chromedp.ActionFunc(func(runCtx context.Context) error {
+		chrome := chromedp.FromContext(runCtx)
+		browserExecutor := cdp.WithExecutor(runCtx, chrome.Browser)
+		var createErr error
+		browserContextID, createErr = target.CreateBrowserContext().WithDisposeOnDetach(true).Do(browserExecutor)
+		if createErr != nil {
+			return createErr
+		}
+		targetID, createErr = target.CreateTarget("about:blank").
+			WithBrowserContextID(browserContextID).
+			WithNewWindow(true).
+			Do(browserExecutor)
+		return createErr
+	}))
+	return browserContextID, targetID, err
+}
+
+// TargetBrowserContextContext reports which browser context a target belongs to - the way a tab
+// Chrome opened for us (a spawned tab) reveals whose isolation it inherited.
+func TargetBrowserContextContext(ctx context.Context) (cdp.BrowserContextID, error) {
+	var browserContextID cdp.BrowserContextID
+	err := chromedp.Run(ctx, chromedp.ActionFunc(func(runCtx context.Context) error {
+		info, infoErr := target.GetTargetInfo().Do(runCtx)
+		if infoErr != nil {
+			return infoErr
+		}
+		browserContextID = info.BrowserContextID
+		return nil
+	}))
+	return browserContextID, err
+}
+
+// PingContext is the cheapest round trip that proves a target is attached and answering.
+func PingContext(ctx context.Context) error {
+	return chromedp.Run(ctx, chromedp.Evaluate("1", nil))
+}
+
+// OuterWindowSizeContext reads the browser window's outer dimensions.  Zero width and height with a
+// nil error means the page answered with something unusable, which callers treat as "leave it alone"
+// rather than as a failure.
+func OuterWindowSizeContext(ctx context.Context) (width, height int, err error) {
+	var dims []int
+	if err = chromedp.Run(ctx, chromedp.Evaluate("[window.outerWidth, window.outerHeight]", &dims)); err != nil {
+		return 0, 0, err
+	}
+	if len(dims) != 2 {
+		return 0, 0, nil
+	}
+	return dims[0], dims[1], nil
+}

--- a/listeners.go
+++ b/listeners.go
@@ -12,6 +12,7 @@ import (
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
 	"github.com/chromedp/chromedp"
+	"github.com/onsi/biloba/engine"
 )
 
 func (b *Biloba) configureDownloadBehaviorForAllTabsWithBrowserContextID(browserContextId cdp.BrowserContextID) {
@@ -23,17 +24,17 @@ func (b *Biloba) configureDownloadBehaviorForAllTabsWithBrowserContextID(browser
 }
 
 func (b *Biloba) configureDownloadBehavior() {
-	b.runCDP("configure the download behavior",
-		browser.SetDownloadBehavior(browser.SetDownloadBehaviorBehaviorAllowAndName).
-			WithDownloadPath(b.root.downloadDir).
-			WithEventsEnabled(true).
-			WithBrowserContextID(b.browserContextID))
+	_ = b.runEngine("configure the download behavior", func(ctx context.Context) error {
+		return engine.ConfigureDownloadsContext(ctx, b.browserContextID, b.root.downloadDir)
+	})
 }
 
 // enableCrashReporting turns on the Inspector domain, which is one of the two ways Chrome announces a
 // dead renderer.  chromedp enables Page/Runtime/Network/DOM on its own but not this one.
 func (b *Biloba) enableCrashReporting() {
-	b.runCDP("enable crash reporting", inspector.Enable())
+	_ = b.runEngine("enable crash reporting", func(ctx context.Context) error {
+		return engine.EnableCrashReportingContext(ctx)
+	})
 }
 
 // installBilobaOnEveryDocument hands biloba.js to Chrome once, to run at the start of every document
@@ -58,10 +59,9 @@ func (b *Biloba) enableCrashReporting() {
 // not.  Nothing about this may become load-bearing without a fallback - a silent failure would
 // otherwise turn every command after a navigation into a "_biloba is not defined" round trip.
 func (b *Biloba) installBilobaOnEveryDocument() {
-	err := b.runCDP("install biloba.js on every new document", chromedp.ActionFunc(func(ctx context.Context) error {
-		_, err := page.AddScriptToEvaluateOnNewDocument(bilobaJS).Do(ctx)
-		return err
-	}))
+	err := b.runEngine("install biloba.js on every new document", func(ctx context.Context) error {
+		return engine.InstallScriptOnNewDocumentContext(ctx, bilobaJS)
+	})
 	b.lock.Lock()
 	defer b.lock.Unlock()
 	b.state.bilobaAutoInstalled = err == nil


### PR DESCRIPTION
**Stack 7 of 17** · base [#22](https://github.com/onsi/biloba/pull/22) · next: [#24](https://github.com/onsi/biloba/pull/24)

The last 15 direct browser calls: connection and tab bootstrap, focus and viewport emulation, download configuration, interception teardown, and dialog dispatch.

With these gone, no file in the Go API calls chromedp directly. The engine owns browser interaction, and the Go API is purely the Ginkgo/Gomega adapter it was meant to be.

## Where it lives

`engine/lifecycle.go`, kept separate from the per-operation primitives for two reasons. Most of these run once, at connect or reset time. And several are browser-scoped: they take a `BrowserContextID` and have to be dispatched on the Browser connection rather than the target's.

The reasoning travels with the calls, because this is the kind that gets lost and then rediscovered the hard way.

**`SetFocusEmulationContext`** explains why it exists at all. An automated headless window never holds OS focus, and full headless Chrome won't dispatch focus and blur events without it. `element.focus()` still moves `activeElement`, but the events never fire, so `onBlur` handlers never run and nothing reports an error. It's per-target, so every tab has to opt in.

**`NewIsolatedTargetContext`** keeps the note that Chrome 149 and later require `WithNewWindow(true)` for a target in a non-default browser context.

**`DisableInterceptionContext`** restores the HTTP cache as well as disabling Fetch. It's symmetric with the enable path, and just as order-dependent.

## What deliberately didn't move

chromedp types in public signatures, and Chrome allocation itself (`ExecAllocator` and `RemoteAllocator` setup).

That second one is `ConnectToChrome`'s own retry-and-backoff logic, which is a Ginkgo lifecycle concern rather than a browser interaction. Moving it would drag suite semantics into a runner-neutral package.

## Verification, and why the second lane matters here

Both fidelity lanes pass 1039/1039.

That matters for this PR specifically. Viewport re-assertion and focus emulation do nothing in `chrome-headless-shell`, so the default lane couldn't have caught a mistake in either. `applyHighFidelityViewport`, `reassertViewportForCompositor`, and `applyFocusEmulation` only run under `BILOBA_TEST_HIGH_FIDELITY=true`.

Also Engine 25/25 · Protocol 35/35 · Bilobad 15/15. All three `make driver-*` targets exit 0. `go vet` and `gofmt` are clean.

## The migration is complete

| | Before the stack | Now |
|---|---|---|
| Go API files calling chromedp directly | 18 | 0 |
| Direct browser call sites in the Go API | ~44 | 0 |

Every browser interaction goes through one engine that the Ginkgo API and the `bilobad` daemon share: navigation, cookies, JavaScript, the `biloba.js` handler bridge, capture, input, upload, accessibility, network interception, and lifecycle.

PRs #8 through #10 build on this rather than continuing it: a fix, a missing feature, and the documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/856687b8-c710-4231-b967-2d79ae359cfe)