### PR TITLE
8/17 fix: cap the DOM outline the daemon attaches to a failure

### DIFF
--- a/engine/session.go
+++ b/engine/session.go
@@ -5,6 +5,8 @@ import (
 	_ "embed"
 	"errors"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -266,7 +268,8 @@ func (s *Session) CaptureDiagnostics(ctx context.Context, prefix string) (Diagno
 		}
 		response, err := s.runHandler(opCtx, "outline", Selector{})
 		if err == nil {
-			diagnostics.DOMOutline, _ = response.Result.(string)
+			outline, _ := response.Result.(string)
+			diagnostics.DOMOutline = capOutline(outline)
 		}
 		path := artifactPath(s.artifactDir, prefix, "png")
 		if path == "" {
@@ -290,6 +293,49 @@ func (s *Session) CaptureDiagnostics(ctx context.Context, prefix string) (Diagno
 		return err
 	})
 	return diagnostics, err
+}
+
+// outlineMaxBytes and outlineTruncationMarker mirror the root package's outline.go.  The engine
+// cannot import the root package (the root imports the engine), so the cap is restated here rather
+// than shared - it has to stay character-for-character identical to the runner's, since a truncated
+// outline is a failure artifact a human compares across the two paths.
+const outlineMaxBytes = 32768 // 32 KB hard cap (default; override with BILOBA_OUTLINE_MAX)
+const outlineTruncationMarker = "\n... [truncated]"
+
+// outlineCap resolves the byte cap for a captured DOM outline.  By default it is outlineMaxBytes,
+// but BILOBA_OUTLINE_MAX lets you raise it (when a failing spec's DOM is truncated right where you
+// need it) or disable truncation entirely: set it to a byte count (e.g. "131072") to raise the cap,
+// or to "0"/"off"/"none"/"unlimited" to emit the whole outline.  An unparseable value falls back to
+// the default.  Keep in sync with the root package's outlineCap.
+func outlineCap() int {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("BILOBA_OUTLINE_MAX")))
+	if v == "" {
+		return outlineMaxBytes
+	}
+	switch v {
+	case "0", "off", "none", "unlimited":
+		return -1 // no cap
+	}
+	if n, err := strconv.Atoi(v); err == nil && n > 0 {
+		return n
+	}
+	return outlineMaxBytes
+}
+
+func capOutline(s string) string {
+	return capOutlineWithCap(s, outlineCap())
+}
+
+func capOutlineWithCap(s string, maxBytes int) string {
+	if maxBytes < 0 || len(s) <= maxBytes {
+		return s
+	}
+	// Find a newline boundary near the cap so we don't cut mid-line.
+	cut := strings.LastIndex(s[:maxBytes], "\n")
+	if cut < 0 {
+		cut = maxBytes
+	}
+	return s[:cut] + outlineTruncationMarker
 }
 
 func (r HandlerResponse) observation(value any) Observation {

--- a/engine/session_internal_test.go
+++ b/engine/session_internal_test.go
@@ -1,0 +1,53 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+// These are plain testing-based units (not Ginkgo specs) because dot-importing Gomega into package
+// engine collides with the engine's own Assertion type.  They need no browser: the diagnostics
+// outline just has to be truncated exactly the way the Go runner's Outline() truncates it (see the
+// root package's outline.go) - same cap, same newline-boundary cut, same marker, same
+// BILOBA_OUTLINE_MAX override.
+
+func TestCapOutlineWithCap(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	// under the cap: left alone
+	g.Expect(capOutlineWithCap("a\nb\nc", 1024)).To(gomega.Equal("a\nb\nc"))
+
+	// over the cap: cut back to a newline boundary, marker appended
+	truncated := capOutlineWithCap("a\nb\nc\nd\ne\nf", 5)
+	g.Expect(truncated).To(gomega.HaveSuffix("\n... [truncated]"))
+	g.Expect(truncated).NotTo(gomega.ContainSubstring("f"))
+
+	// no newline to cut at: cut at the cap itself
+	g.Expect(capOutlineWithCap("abcdefgh", 3)).To(gomega.Equal("abc\n... [truncated]"))
+
+	// cap disabled
+	g.Expect(capOutlineWithCap("a\nb\nc\nd\ne\nf", -1)).To(gomega.Equal("a\nb\nc\nd\ne\nf"))
+}
+
+func TestOutlineCap(t *testing.T) {
+	for _, testCase := range []struct {
+		env      string
+		expected int
+	}{
+		{"", outlineMaxBytes},
+		{"131072", 131072},
+		{"0", -1},
+		{"OFF", -1},
+		{"none", -1},
+		{"unlimited", -1},
+		{"lots", outlineMaxBytes},
+		{"-5", outlineMaxBytes},
+	} {
+		t.Run("BILOBA_OUTLINE_MAX="+testCase.env, func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			t.Setenv("BILOBA_OUTLINE_MAX", testCase.env)
+			g.Expect(outlineCap()).To(gomega.Equal(testCase.expected))
+		})
+	}
+}


### PR DESCRIPTION
**Stack 8 of 17** · base [#23](https://github.com/onsi/biloba/pull/23) · next: [#25](https://github.com/onsi/biloba/pull/25)

When a daemon-driven assertion fails, `CaptureDiagnostics` attaches the page's DOM outline. It attached the whole thing, with no size limit. The Go runner caps the same outline at 32 KB.

So the same failure produced very differently sized artifacts depending on which client you were driving, and a large page could attach megabytes of DOM to a single failure.

## Why the cap is copied instead of shared

The engine can't import the root package, because the root package imports the engine. So `outlineCap` and its truncation logic are restated in `engine/session.go`, with a comment naming `outline.go` as the original and a note to keep them in sync.

The copy is character-for-character identical, including the `BILOBA_OUTLINE_MAX` override and the byte-based cut back to the last newline. A truncated outline is something a person compares across the two clients, so the two have to agree exactly.

A unit test covers the truncation boundary, the no-newline fallback, and every `BILOBA_OUTLINE_MAX` branch.

## Verification

Biloba 1039/1039 · Engine 25/25 · Protocol 35/35 · Bilobad 15/15. `go vet` and `gofmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)