### PR TITLE
9/17 add navigateWithStatus, and fix the error codes the daemon reports

### DIFF
--- a/cmd/bilobad/engine_adapter.go
+++ b/cmd/bilobad/engine_adapter.go
@@ -34,7 +34,7 @@ func (s *engineSession) Execute(ctx context.Context, operation protocol.Operatio
 	started := time.Now()
 	switch operation.Kind {
 	case protocol.OperationNavigate:
-		return oneAttempt(started, s.session.Navigate(ctx, operation.URL))
+		return oneAttempt(started, s.session.NavigateWithStatus(ctx, operation.URL, operation.ExpectedStatus))
 	case protocol.OperationSetCookies:
 		cookies := make([]engine.Cookie, len(operation.Cookies))
 		for i, cookie := range operation.Cookies {
@@ -356,6 +356,38 @@ func expectedDescription(operation protocol.Operation) string {
 	}
 }
 
+// engineProtocolCodes is the whole engine-to-protocol error vocabulary, in one place.  A code that
+// is missing here reaches the client as a generic DRIVER_ERROR - which reads as "the daemon broke"
+// for a failure the page caused, and buries the one thing the client could act on (a page-level
+// JavaScript error is JAVASCRIPT_ERROR; a navigation that never landed leaves the target not
+// ready).  The two codes with no honest counterpart are listed with the reason rather than left
+// out, so a code added to the engine shows up as a missing key - see the exhaustiveness spec in
+// main_test.go - instead of silently inheriting a plausible-looking default.
+var engineProtocolCodes = map[engine.ErrorCode]protocol.ErrorCode{
+	engine.CodeInvalidSelector: protocol.CodeInvalidArgument,
+	engine.CodeInvalidArgument: protocol.CodeInvalidArgument,
+	engine.CodeSessionClosed:   protocol.CodeTargetNotFound,
+	engine.CodeNotFound:        protocol.CodeTargetNotFound,
+	// The target was found and refused the operation - a click on a hidden element.  That is a page
+	// state, not a driver fault, and it is the one bucket where a retry might succeed.
+	engine.CodeActionFailed: protocol.CodeTargetNotReady,
+	// A navigation that landed on a status the caller did not ask for.  Deliberately not
+	// TARGET_NOT_READY: the page loaded fine, so waiting will never change the answer.
+	engine.CodeNavigation:    protocol.CodeNavigation,
+	engine.CodeJavaScript:    protocol.CodeJavaScript,
+	engine.CodeInvalidScript: protocol.CodeJavaScript,
+	engine.CodeBrowserGone:   protocol.CodeBrowserGone,
+	engine.CodePageCrashed:   protocol.CodePageCrashed,
+	engine.CodeCanceled:      protocol.CodeCancelled,
+	engine.CodeTimeout:       protocol.CodeTimeout,
+	engine.CodeDeadline:      protocol.CodeTimeout,
+	// No counterpart, deliberately.  Both are the daemon failing to bring its own Chrome up, before
+	// there is a session to report against - BROWSER_GONE means a live Chrome died underneath a
+	// worker, which is a different thing to tell a client.
+	engine.CodeBrowserStart: protocol.CodeDriver,
+	engine.CodeIO:           protocol.CodeDriver,
+}
+
 func engineRPCError(err error) error {
 	// A ProtocolError that travelled out through the engine (an engine.Fatal wrapping one, say)
 	// already knows its own code - do not flatten it to DRIVER_ERROR on the way past.
@@ -367,22 +399,9 @@ func engineRPCError(err error) error {
 	if !errors.As(err, &engineErr) {
 		return protocol.NewError(protocol.CodeDriver, err.Error())
 	}
-	switch engineErr.Code {
-	case engine.CodeInvalidSelector:
-		return protocol.NewError(protocol.CodeInvalidArgument, engineErr.Error())
-	case engine.CodeSessionClosed, engine.CodeNotFound:
-		return protocol.NewError(protocol.CodeTargetNotFound, engineErr.Error())
-	case engine.CodeBrowserGone:
-		return protocol.NewError(protocol.CodeBrowserGone, engineErr.Error())
-	case engine.CodeInvalidScript:
-		return protocol.NewError(protocol.CodeJavaScript, engineErr.Error())
-	case engine.CodePageCrashed:
-		return protocol.NewError(protocol.CodePageCrashed, engineErr.Error())
-	case engine.CodeCanceled:
-		return protocol.NewError(protocol.CodeCancelled, engineErr.Error())
-	case engine.CodeDeadline, engine.CodeTimeout:
-		return protocol.NewError(protocol.CodeTimeout, engineErr.Error())
-	default:
-		return protocol.NewError(protocol.CodeDriver, engineErr.Error())
+	code, ok := engineProtocolCodes[engineErr.Code]
+	if !ok {
+		code = protocol.CodeDriver
 	}
+	return protocol.NewError(code, engineErr.Error())
 }

--- a/cmd/bilobad/main_test.go
+++ b/cmd/bilobad/main_test.go
@@ -6,6 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -186,6 +190,61 @@ var _ = Describe("bilobad", func() {
 		Expect(stdoutReader.Close()).To(Succeed())
 		Expect(stdinReader.Close()).To(Succeed())
 	}, SpecTimeout(90*time.Second))
+
+	Describe("mapping engine error codes onto the protocol", func() {
+		It("gives every engine code an explicit mapping", func() {
+			// Falling through to DRIVER_ERROR is silent: the client is told the daemon broke for a
+			// failure the page caused.  A code added to the engine has to be classified here.
+			for code := range engineErrorCodesInSource() {
+				Expect(engineProtocolCodes).To(HaveKey(code), "engine.ErrorCode %q has no protocol counterpart in engineProtocolCodes", code)
+			}
+		})
+
+		It("maps nothing the engine no longer defines", func() {
+			declared := engineErrorCodesInSource()
+			for code := range engineProtocolCodes {
+				Expect(declared).To(HaveKey(code), "engineProtocolCodes maps %q, which the engine does not define", code)
+			}
+		})
+
+		DescribeTable("converting an engine failure", func(code engine.ErrorCode, expected protocol.ErrorCode) {
+			converted := engineRPCError(&engine.Error{Code: code, Operation: "evaluate", Message: "boom"})
+			var protocolErr *protocol.ProtocolError
+			Expect(errors.As(converted, &protocolErr)).To(BeTrue())
+			Expect(protocolErr.Code).To(Equal(expected))
+			Expect(protocolErr.Message).To(Equal("evaluate: boom"))
+		},
+			Entry("a page-level JavaScript error", engine.CodeJavaScript, protocol.CodeJavaScript),
+			Entry("a script that will never parse", engine.CodeInvalidScript, protocol.CodeJavaScript),
+			Entry("a navigation that landed on the wrong status", engine.CodeNavigation, protocol.CodeNavigation),
+			Entry("an action the target refused", engine.CodeActionFailed, protocol.CodeTargetNotReady),
+			Entry("an argument the caller got wrong", engine.CodeInvalidArgument, protocol.CodeInvalidArgument),
+			Entry("a browser that never started", engine.CodeBrowserStart, protocol.CodeDriver),
+			Entry("an unrecognized code", engine.ErrorCode("brand_new"), protocol.CodeDriver),
+		)
+	})
 })
+
+// engineErrorCodesInSource reads the engine's own declarations rather than a list kept here, which
+// would go stale in exactly the way the mapping did.
+func engineErrorCodesInSource() map[engine.ErrorCode]string {
+	GinkgoHelper()
+	paths, err := filepath.Glob(filepath.Join("..", "..", "engine", "*.go"))
+	Expect(err).NotTo(HaveOccurred())
+	pattern := regexp.MustCompile(`(?m)^\s*(Code\w+)\s+ErrorCode\s+=\s+"([a-z_]+)"`)
+	codes := map[engine.ErrorCode]string{}
+	for _, path := range paths {
+		if strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		source, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+		for _, match := range pattern.FindAllStringSubmatch(string(source), -1) {
+			codes[engine.ErrorCode(match[2])] = match[1]
+		}
+	}
+	Expect(codes).NotTo(BeEmpty(), "could not find the engine's ErrorCode declarations")
+	return codes
+}
 
 func boolPointer(value bool) *bool { return &value }

--- a/engine/cookies.go
+++ b/engine/cookies.go
@@ -26,7 +26,7 @@ func SetCookiesContext(targetCtx context.Context, browserContextID cdp.BrowserCo
 		}
 		if cookie.Domain == "" {
 			if !IsUsableCookieOrigin(location) {
-				return &Error{Code: CodeActionFailed, Operation: "set cookies", Message: "cookie needs a Domain or a session navigated to an HTTP origin", Observed: cookie.Name}
+				return &Error{Code: CodeInvalidArgument, Operation: "set cookies", Message: "cookie needs a Domain or a session navigated to an HTTP origin", Observed: cookie.Name}
 			}
 			param.URL = location
 		}

--- a/engine/poll.go
+++ b/engine/poll.go
@@ -11,6 +11,10 @@ type ErrorCode string
 
 const (
 	CodeInvalidSelector ErrorCode = "invalid_selector"
+	// CodeInvalidArgument is the caller handing an operation something it cannot act on - a cookie
+	// with no domain, say.  Distinct from CodeActionFailed, which is the target refusing an
+	// operation whose arguments were fine: that one can come good on a retry, this one never can.
+	CodeInvalidArgument ErrorCode = "invalid_argument"
 	CodeBrowserStart    ErrorCode = "browser_start"
 	CodeSessionClosed   ErrorCode = "session_closed"
 	CodeNavigation      ErrorCode = "navigation"

--- a/engine/session.go
+++ b/engine/session.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	_ "embed"
 	"errors"
+	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -156,6 +158,16 @@ func (s *Session) Prepare(ctx context.Context) error {
 
 // Navigate loads a URL and requires the main document response to have HTTP status 200.
 func (s *Session) Navigate(ctx context.Context, destination string) error {
+	return s.NavigateWithStatus(ctx, destination, http.StatusOK)
+}
+
+// NavigateWithStatus loads a URL and requires the main document response to have expectedStatus.
+// A 4xx or 5xx page that renders perfectly good HTML is a legitimate thing to test - this is how you
+// say so, and it mirrors the Go runner's Biloba.NavigateWithStatus.  Navigate's insistence on 200 is
+// an assertion, not a transport rule: unexpected error pages are a broken fixture far more often
+// than they are the subject of the test, and letting one through surfaces later as a confusing
+// downstream failure instead of at the navigation that caused it.
+func (s *Session) NavigateWithStatus(ctx context.Context, destination string, expectedStatus int) error {
 	return s.serial(ctx, "navigate", func(opCtx context.Context) error {
 		result, err := NavigateContext(opCtx, destination)
 		// A navigation gives the target a fresh renderer, which is how a crashed page recovers - but
@@ -175,8 +187,8 @@ func (s *Session) Navigate(ctx context.Context, destination string) error {
 			return err
 		}
 		if result.Status != 0 {
-			if result.Status != 200 {
-				return &Error{Code: CodeNavigation, Operation: "navigate", Message: "expected HTTP status 200", Observed: result.Status}
+			if result.Status != expectedStatus {
+				return &Error{Code: CodeNavigation, Operation: "navigate", Message: fmt.Sprintf("expected HTTP status %d", expectedStatus), Observed: result.Status}
 			}
 			return nil
 		}

--- a/graft_parity_test.go
+++ b/graft_parity_test.go
@@ -2,6 +2,7 @@ package biloba_test
 
 import (
 	"encoding/json"
+	"net/http"
 	"os"
 	"time"
 
@@ -30,6 +31,16 @@ var _ = Describe("TypeScript driver parity contract", func() {
 		var expected any
 		Expect(json.Unmarshal(expectedJSON, &expected)).To(Succeed())
 		Expect(actual).To(Equal(expected))
+	})
+
+	It("treats a non-200 page as navigable when the spec asks for that status", func() {
+		// The 200 check is an assertion, not a transport rule, and both APIs have to offer the same
+		// way out of it - otherwise an error page is testable from Go and unreachable from
+		// TypeScript.  The TypeScript half of this pair lives in typescript/test/parity.test.ts.
+		b.NavigateWithStatus(fixtureServer+"/non-existing", http.StatusNotFound)
+
+		b.Navigate(fixtureServer + "/non-existing")
+		ExpectFailures(ContainSubstring("expected status code 200, got 404"))
 	})
 
 	It("preserves Biloba's failure semantics for a missing element", func() {

--- a/protocol/encoding_test.go
+++ b/protocol/encoding_test.go
@@ -91,7 +91,8 @@ var _ = Describe("the generated protocol declarations", func() {
 
 		Expect(declared).To(ConsistOf(
 			string(protocol.CodeInvalidArgument), string(protocol.CodeTimeout), string(protocol.CodeTargetNotFound),
-			string(protocol.CodeTargetNotReady), string(protocol.CodeJavaScript), string(protocol.CodeProtocolMismatch),
+			string(protocol.CodeTargetNotReady), string(protocol.CodeNavigation), string(protocol.CodeJavaScript),
+			string(protocol.CodeProtocolMismatch),
 			string(protocol.CodeDriverClosed), string(protocol.CodeDriver), string(protocol.CodeCancelled),
 			string(protocol.CodeBrowserGone), string(protocol.CodePageCrashed),
 		), "a code the daemon can send but TypeScript does not declare is a code the client cannot narrow on")

--- a/protocol/internal/protocolgen/protocolgen.go
+++ b/protocol/internal/protocolgen/protocolgen.go
@@ -68,7 +68,7 @@ func typeScript() string {
 	var output strings.Builder
 	output.WriteString("// Code generated from the Go protocol definition; DO NOT EDIT.\n\n")
 	output.WriteString("export type ErrorCode =\n")
-	for _, code := range []protocol.ErrorCode{protocol.CodeInvalidArgument, protocol.CodeTimeout, protocol.CodeTargetNotFound, protocol.CodeTargetNotReady, protocol.CodeJavaScript, protocol.CodeProtocolMismatch, protocol.CodeDriverClosed, protocol.CodeDriver, protocol.CodeCancelled, protocol.CodeBrowserGone, protocol.CodePageCrashed} {
+	for _, code := range []protocol.ErrorCode{protocol.CodeInvalidArgument, protocol.CodeTimeout, protocol.CodeTargetNotFound, protocol.CodeTargetNotReady, protocol.CodeNavigation, protocol.CodeJavaScript, protocol.CodeProtocolMismatch, protocol.CodeDriverClosed, protocol.CodeDriver, protocol.CodeCancelled, protocol.CodeBrowserGone, protocol.CodePageCrashed} {
 		fmt.Fprintf(&output, "  | %q\n", code)
 	}
 	output.WriteString(";\n\n")

--- a/protocol/server.go
+++ b/protocol/server.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
 	"time"
 )
@@ -23,10 +24,20 @@ var Capabilities = []string{
 type ErrorCode string
 
 const (
-	CodeInvalidArgument  ErrorCode = "INVALID_ARGUMENT"
-	CodeTimeout          ErrorCode = "TIMEOUT"
-	CodeTargetNotFound   ErrorCode = "TARGET_NOT_FOUND"
-	CodeTargetNotReady   ErrorCode = "TARGET_NOT_READY"
+	CodeInvalidArgument ErrorCode = "INVALID_ARGUMENT"
+	CodeTimeout         ErrorCode = "TIMEOUT"
+	CodeTargetNotFound  ErrorCode = "TARGET_NOT_FOUND"
+	// CodeTargetNotReady is a target that was found and refused the operation - a click on a hidden
+	// element, say.  It means "not yet", so it is the one failure code that implies a retry might
+	// succeed; do not reach for it as a general-purpose bucket for page-caused errors that will
+	// never come good (an argument the caller got wrong is INVALID_ARGUMENT, a navigation that
+	// landed on the wrong status is NAVIGATION).
+	CodeTargetNotReady ErrorCode = "TARGET_NOT_READY"
+	// CodeNavigation is a navigation whose main document answered with a status the caller did not
+	// ask for.  Distinct from TARGET_NOT_READY because waiting cannot change it: the page loaded,
+	// it simply is not the page the caller said it expected.  Navigate to the same URL with a
+	// matching expectedStatus if the error page is what you meant to test.
+	CodeNavigation       ErrorCode = "NAVIGATION"
 	CodeJavaScript       ErrorCode = "JAVASCRIPT_ERROR"
 	CodeProtocolMismatch ErrorCode = "PROTOCOL_MISMATCH"
 	CodeDriverClosed     ErrorCode = "DRIVER_CLOSED"
@@ -76,16 +87,19 @@ const (
 )
 
 type Operation struct {
-	Kind          OperationKind
-	URL           string
-	Cookies       []Cookie
-	Locator       Locator
-	Poll          PollPolicy
-	ValueJSON     string
-	Expression    string
-	ArgumentsJSON string
-	Invoke        *bool
-	Assertion     Assertion
+	Kind OperationKind
+	URL  string
+	// ExpectedStatus is always concrete by the time an Operation is built - Dispatch resolves the
+	// request's omitted 0 to 200 - so nothing downstream has to know the default.
+	ExpectedStatus int
+	Cookies        []Cookie
+	Locator        Locator
+	Poll           PollPolicy
+	ValueJSON      string
+	Expression     string
+	ArgumentsJSON  string
+	Invoke         *bool
+	Assertion      Assertion
 }
 
 type LocatorKind uint8
@@ -207,6 +221,9 @@ type SessionRequest struct {
 type NavigateRequest struct {
 	SessionID string `json:"sessionId"`
 	URL       string `json:"url"`
+	// ExpectedStatus is the HTTP status the main document must answer with.  Omitted (0) means 200,
+	// so a client that does not care keeps sending exactly what it sent before.
+	ExpectedStatus int `json:"expectedStatus,omitempty"`
 }
 
 type PollOptions struct {
@@ -380,7 +397,14 @@ func (s *Server) Dispatch(ctx context.Context, method string, params json.RawMes
 		if request.URL == "" {
 			return nil, NewError(CodeInvalidArgument, "url is required")
 		}
-		return s.execute(ctx, request.SessionID, Operation{Kind: OperationNavigate, URL: request.URL})
+		expectedStatus := request.ExpectedStatus
+		if expectedStatus == 0 {
+			expectedStatus = http.StatusOK
+		}
+		if expectedStatus < 100 || expectedStatus > 599 {
+			return nil, NewError(CodeInvalidArgument, fmt.Sprintf("expectedStatus must be a valid HTTP status code, got %d", expectedStatus))
+		}
+		return s.execute(ctx, request.SessionID, Operation{Kind: OperationNavigate, URL: request.URL, ExpectedStatus: expectedStatus})
 	case "setCookies":
 		var request SetCookiesRequest
 		if err := decodeParams(params, &request); err != nil {

--- a/typescript/src/generated/protocol.ts
+++ b/typescript/src/generated/protocol.ts
@@ -5,6 +5,7 @@ export type ErrorCode =
   | "TIMEOUT"
   | "TARGET_NOT_FOUND"
   | "TARGET_NOT_READY"
+  | "NAVIGATION"
   | "JAVASCRIPT_ERROR"
   | "PROTOCOL_MISMATCH"
   | "DRIVER_CLOSED"
@@ -55,6 +56,7 @@ export interface SessionRequest {
 export interface NavigateRequest {
   sessionId: string;
   url: string;
+  expectedStatus?: number;
 }
 
 export interface PollOptions {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -21,21 +21,27 @@ export type SerializableValue =
   | readonly SerializableValue[]
   | {readonly [key: string]: SerializableValue};
 
+// Option bags the caller *builds* spell their optional members `?: T | undefined` throughout.  The
+// project compiles with exactOptionalPropertyTypes, under which a bare `?: T` rejects an explicit
+// undefined - so `{timeoutMs: config.timeout}` or `{daemonExecutable: process.env.FOO}` would not
+// compile, and every caller threading a maybe-value through would have to write a conditional
+// spread.  Types Biloba *returns* (AssertionResult, PollObservation, BilobaError) keep the strict
+// form, where distinguishing absent from present-but-undefined is worth having.
 export interface WaitOptions {
-  timeoutMs?: number;
-  intervalMs?: number;
-  signal?: AbortSignal;
+  timeoutMs?: number | undefined;
+  intervalMs?: number | undefined;
+  signal?: AbortSignal | undefined;
 }
 
 export interface Cookie {
   name: string;
   value: string;
-  domain?: string;
-  path?: string;
-  expires?: Date | number;
-  secure?: boolean;
-  httpOnly?: boolean;
-  sameSite?: string;
+  domain?: string | undefined;
+  path?: string | undefined;
+  expires?: Date | number | undefined;
+  secure?: boolean | undefined;
+  httpOnly?: boolean | undefined;
+  sameSite?: string | undefined;
 }
 
 export interface PollObservation {
@@ -59,6 +65,9 @@ export type BilobaErrorCode =
   | "TIMEOUT"
   | "TARGET_NOT_FOUND"
   | "TARGET_NOT_READY"
+  /** A navigation landed on an HTTP status the caller did not ask for. Retrying will not change it -
+   *  pass `expectedStatus` to `navigate` if the error page is what you meant to test. */
+  | "NAVIGATION"
   | "JAVASCRIPT_ERROR"
   | "PROTOCOL_MISMATCH"
   | "DRIVER_CLOSED"
@@ -120,9 +129,9 @@ export interface Locator {
   click(options?: WaitOptions): Promise<void>;
   setValue(value: SerializableValue, options?: WaitOptions): Promise<void>;
   expectVisible(options?: WaitOptions): Promise<AssertionResult>;
-  expectText(expected: string, options?: WaitOptions & {exact?: boolean}): Promise<AssertionResult>;
+  expectText(expected: string, options?: WaitOptions & {exact?: boolean | undefined}): Promise<AssertionResult>;
   expectCount(expected: number, options?: WaitOptions): Promise<AssertionResult>;
-  expectAttribute(name: string, expected: string, options?: WaitOptions & {exact?: boolean}): Promise<AssertionResult>;
+  expectAttribute(name: string, expected: string, options?: WaitOptions & {exact?: boolean | undefined}): Promise<AssertionResult>;
   expectValue(expected: SerializableValue, options?: WaitOptions): Promise<AssertionResult>;
 }
 
@@ -130,14 +139,15 @@ export interface Session {
   readonly id: string;
   prepare(): Promise<void>;
   navigate(url: string, options?: WaitOptions): Promise<void>;
+  navigateWithStatus(url: string, expectedStatus: number, options?: WaitOptions): Promise<void>;
   setCookies(cookies: readonly Cookie[]): Promise<void>;
   evaluate<T = unknown>(expression: string, args?: readonly SerializableValue[], options?: WaitOptions): Promise<T>;
   close(): Promise<void>;
   locator(css: string): Locator;
   getByTestId(value: string): Locator;
-  getByText(value: string, options?: {exact?: boolean}): Locator;
-  getByRole(role: string, options?: {name?: string; exact?: boolean}): Locator;
-  expectUrl(expected: string, options?: WaitOptions & {exact?: boolean; pathname?: boolean}): Promise<AssertionResult>;
+  getByText(value: string, options?: {exact?: boolean | undefined}): Locator;
+  getByRole(role: string, options?: {name?: string | undefined; exact?: boolean | undefined}): Locator;
+  expectUrl(expected: string, options?: WaitOptions & {exact?: boolean | undefined; pathname?: boolean | undefined}): Promise<AssertionResult>;
   expectEvaluation(expression: string, expected: SerializableValue, options?: WaitOptions): Promise<AssertionResult>;
 }
 
@@ -149,11 +159,11 @@ export interface Browser {
 }
 
 export interface ConnectOptions {
-  daemonExecutable?: string;
-  chromePath?: string;
-  chromeWsUrl?: string;
-  artifactDir?: string;
-  signal?: AbortSignal;
+  daemonExecutable?: string | undefined;
+  chromePath?: string | undefined;
+  chromeWsUrl?: string | undefined;
+  artifactDir?: string | undefined;
+  signal?: AbortSignal | undefined;
 }
 
 export async function connect(options: ConnectOptions = {}): Promise<Browser> {

--- a/typescript/src/internal/browser-manager.ts
+++ b/typescript/src/internal/browser-manager.ts
@@ -6,8 +6,8 @@ import {BilobaError} from "../index.js";
 
 export interface StartSharedBrowserOptions {
   executable: string;
-  chromePath?: string;
-  readyTimeoutMs?: number;
+  chromePath?: string | undefined;
+  readyTimeoutMs?: number | undefined;
 }
 
 export interface SharedBrowserProcess {

--- a/typescript/src/internal/client.ts
+++ b/typescript/src/internal/client.ts
@@ -93,12 +93,30 @@ class ClientSession implements Session {
     await this.#transport.navigate({sessionId: this.id, url}, options);
   }
 
+  // Mirrors the Go runner's NavigateWithStatus.  navigate() asserting 200 is what makes a broken
+  // fixture fail at the navigation rather than as a baffling assertion three lines later; this is
+  // the way to say the 4xx/5xx page is the page you meant to load.
+  async navigateWithStatus(url: string, expectedStatus: number, options: WaitOptions = {}): Promise<void> {
+    this.#assertOpen();
+    await this.#transport.navigate({sessionId: this.id, url, expectedStatus}, options);
+  }
+
   async setCookies(cookies: readonly Cookie[]): Promise<void> {
     this.#assertOpen();
     await this.#transport.setCookies({
       sessionId: this.id,
+      // The public Cookie lets a caller pass an explicit undefined for any optional member; the
+      // generated wire type does not.  Spreading each field only when it is set is what keeps that
+      // convenience from reaching the protocol - and omitted vs. present-and-undefined encode
+      // identically anyway, since JSON.stringify drops both.
       cookies: cookies.map(({expires, ...cookie}) => ({
-        ...cookie,
+        name: cookie.name,
+        value: cookie.value,
+        ...(cookie.domain !== undefined && {domain: cookie.domain}),
+        ...(cookie.path !== undefined && {path: cookie.path}),
+        ...(cookie.secure !== undefined && {secure: cookie.secure}),
+        ...(cookie.httpOnly !== undefined && {httpOnly: cookie.httpOnly}),
+        ...(cookie.sameSite !== undefined && {sameSite: cookie.sameSite}),
         ...(expires !== undefined && {
           expiresUnix: typeof expires === "number" ? expires : expires.getTime() / 1_000,
         }),

--- a/typescript/src/internal/daemon-manager.ts
+++ b/typescript/src/internal/daemon-manager.ts
@@ -7,10 +7,10 @@ import {StdioTransport} from "./stdio-transport.js";
 
 export interface StartDaemonOptions {
   executable: string;
-  chromePath?: string;
-  chromeWsUrl?: string;
-  artifactDir?: string;
-  readyTimeoutMs?: number;
+  chromePath?: string | undefined;
+  chromeWsUrl?: string | undefined;
+  artifactDir?: string | undefined;
+  readyTimeoutMs?: number | undefined;
 }
 
 export interface DaemonProcess {

--- a/typescript/test/parity.test.ts
+++ b/typescript/test/parity.test.ts
@@ -40,8 +40,11 @@ describe.skipIf(process.env.BILOBA_SKIP_PARITY === "true")("Go and TypeScript pa
         "Set BILOBA_SKIP_PARITY=true to skip this suite on purpose.",
       );
     }
-    server = createServer((_request, response) => {
+    server = createServer((request, response) => {
       response.setHeader("content-type", "text/html");
+      // A 4xx that still renders HTML - the case that makes navigate()'s 200 assertion something you
+      // need a way out of, rather than a rule that is always right.
+      if (request.url === "/not-found") response.statusCode = 404;
       createReadStream(fixturePath).pipe(response);
     });
     await new Promise<void>((resolve, reject) => {
@@ -93,6 +96,20 @@ describe.skipIf(process.env.BILOBA_SKIP_PARITY === "true")("Go and TypeScript pa
     // expression".  The daemon is told which, so neither reading depends on the argument count.
     expect(await session.evaluate<number>("() => 41 + 1", [])).toBe(42);
     expect(await session.evaluate<number>("(a, b) => a + b", [40, 2])).toBe(42);
+  });
+
+  it("treats a non-200 page as navigable when the caller asks for that status", async () => {
+    // Pairs with "treats a non-200 page as navigable when the spec asks for that status" in
+    // graft_parity_test.go.  Go has Navigate/NavigateWithStatus; if TypeScript has only the former,
+    // an error page is testable from one API and unreachable from the other.
+    await session.prepare();
+    await session.navigateWithStatus(`${baseUrl}/not-found`, 404);
+    await session.getByRole("heading", {name: "Biloba parity"}).expectVisible();
+
+    const failure = await session.navigate(`${baseUrl}/not-found`).catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(BilobaError);
+    expect((failure as BilobaError).code, "a wrong status is not a driver fault and not a retryable one").toBe("NAVIGATION");
+    expect((failure as BilobaError).message).toContain("expected HTTP status 200");
   });
 
   it("returns structured failure output from the real daemon", async () => {


### PR DESCRIPTION
**Stack 9 of 17** · base [#24](https://github.com/onsi/biloba/pull/24) · next: [#26](https://github.com/onsi/biloba/pull/26)

## You couldn't test an error page from TypeScript

The Go API has two methods. `Navigate` requires HTTP 200, and `NavigateWithStatus` lets you say which status you expect. The TypeScript port only got the first one, with 200 hard-coded.

That made a 4xx or 5xx page that renders perfectly good HTML testable from Go and unreachable from TypeScript. There was nowhere on the wire to say which status you meant.

Requiring 200 is the right default. An unexpected error page is a broken fixture far more often than it's the subject of the test, and letting one through fails later in a way that's hard to trace back. But a default needs a way out, and the port didn't bring one.

**What changes:**

- `NavigateRequest` gains `expectedStatus`. Omitting it means 200, so existing clients send byte-identical frames.
- `Dispatch` resolves the default and rejects anything outside 100 to 599.
- The client gains `session.navigateWithStatus(url, expectedStatus, options)`.

A paired parity case now covers both halves. `make driver-parity` exists to catch exactly this kind of divergence between Go and TypeScript, and it missed this one because the contract never covered navigation status.

## Every JavaScript error looked like a driver bug

`engineRPCError` maps engine error codes onto protocol codes with a switch. The switch had no case for `CodeJavaScript`, so every error your page threw reached the client as a generic `DRIVER_ERROR`. It also had no case for `CodeNavigation`.

The switch is now a table, with a spec that reads the engine's own declarations and fails if any code lacks an entry. Adding a code to the engine now breaks the build instead of silently inheriting the default. (Confirmed by deleting an entry and watching it fail.)

Two codes came out of this with their own identity:

**`NAVIGATION`** for a page that loaded with a status you didn't ask for. This isn't `TARGET_NOT_READY`, because the page loaded fine and waiting will never change the answer.

**`engine.CodeInvalidArgument`** for a cookie with no domain and no navigated origin. That's a caller mistake. It had been reporting as an action the target refused, which tells the client to retry something that can never succeed.

`TARGET_NOT_READY` also gains the doc comment it never had, stating that it means "not yet" and is not a bucket for page-caused errors that will never clear. That missing definition is what both miscategorizations grew out of.

## A TypeScript ergonomics fix

Input option bags now declare optional members as `?: T | undefined`.

This project compiles with `exactOptionalPropertyTypes`, where a plain `?: T` rejects an explicit `undefined`. So this didn't compile:

```ts
connect({daemonExecutable: process.env.BILOBA_DAEMON_EXECUTABLE})
```

`connect` advertises an environment-variable fallback, but the obvious way to pass a value that might be unset was a type error. Anyone threading a maybe-value through had to write a conditional spread.

Returned types such as `AssertionResult` and `BilobaError` keep the strict form, where telling "absent" from "present but undefined" is worth having.

This surfaced while typechecking the documentation examples in #10.

## Verification

Biloba 1040/1040 · Engine 25/25 · Protocol 35/35 · Bilobad 24/24. All three `make driver-*` targets exit 0, including 5 parity tests. `go vet` and `gofmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)