### PR TITLE
11/17 feat: add lifecycle, frame, and launch foundations

### DIFF
--- a/cmd/bilobad/engine_adapter.go
+++ b/cmd/bilobad/engine_adapter.go
@@ -285,18 +285,33 @@ func (s *engineSession) lifecycle(ctx context.Context, operation protocol.Operat
 		}
 		return pollResult(result, true), nil
 	case protocol.LifecycleURL:
+		if lifecycle.Expectation.Kind != 0 {
+			return s.poll(ctx, operation, s.lifecycleValueAssertion(lifecycle, func(readCtx context.Context) (any, error) {
+				value, err := s.session.URL(readCtx)
+				return value.Value, err
+			}))
+		}
 		value, err := s.session.URL(ctx)
 		if err != nil {
 			return protocol.Result{}, engineRPCError(err)
 		}
 		return observedResult(started, value.Value), nil
 	case protocol.LifecycleTitle:
+		if lifecycle.Expectation.Kind != 0 {
+			return s.poll(ctx, operation, s.lifecycleValueAssertion(lifecycle, func(readCtx context.Context) (any, error) { return s.session.Title(readCtx) }))
+		}
 		value, err := s.session.Title(ctx)
 		if err != nil {
 			return protocol.Result{}, engineRPCError(err)
 		}
 		return observedResult(started, value), nil
 	case protocol.LifecycleWindowSize:
+		if lifecycle.Expectation.Kind != 0 {
+			return s.poll(ctx, operation, s.lifecycleValueAssertion(lifecycle, func(readCtx context.Context) (any, error) {
+				width, height, err := s.session.WindowSize(readCtx)
+				return map[string]int{"width": width, "height": height}, err
+			}))
+		}
 		width, height, err := s.session.WindowSize(ctx)
 		if err != nil {
 			return protocol.Result{}, engineRPCError(err)
@@ -315,7 +330,28 @@ func (s *engineSession) lifecycle(ctx context.Context, operation protocol.Operat
 		}
 		return observedResult(started, value), nil
 	case protocol.LifecycleConsoleMessages:
-		return observedResult(started, s.session.ConsoleMessages()), nil
+		if lifecycle.Expectation.Kind != 0 {
+			return s.poll(ctx, operation, func(context.Context) (engine.Observation, bool, error) {
+				expected, convertErr := expectationFromProtocol(lifecycle.Expectation)
+				if convertErr != nil {
+					return engine.Observation{}, false, engine.Fatal(convertErr)
+				}
+				for _, message := range s.session.ConsoleMessages() {
+					if lifecycle.Key != "" && lifecycle.Key != message.Type {
+						continue
+					}
+					matched, matchErr := engine.MatchExpectation(message.Text, expected)
+					if matchErr != nil {
+						return engine.Observation{}, false, engine.Fatal(matchErr)
+					}
+					if matched {
+						return engine.Observation{Value: consoleMessageToWire(message)}, true, nil
+					}
+				}
+				return engine.Observation{Value: nil}, false, nil
+			})
+		}
+		return observedResult(started, consoleMessagesToWire(s.session.ConsoleMessages())), nil
 	case protocol.LifecycleSetDeviceMetrics:
 		return oneAttempt(started, s.session.SetDeviceMetrics(ctx, engine.DeviceMetrics{Width: lifecycle.Width, Height: lifecycle.Height, DeviceScaleFactor: lifecycle.DeviceScaleFactor, Mobile: lifecycle.Mobile}))
 	case protocol.LifecycleClearDeviceMetrics:
@@ -349,10 +385,37 @@ func (s *engineSession) lifecycle(ctx context.Context, operation protocol.Operat
 	}
 }
 
+func consoleMessageToWire(message engine.ConsoleMessage) map[string]any {
+	return map[string]any{"type": message.Type, "text": message.Text, "args": message.Args, "timestamp": message.Timestamp}
+}
+
+func consoleMessagesToWire(messages []engine.ConsoleMessage) []map[string]any {
+	result := make([]map[string]any, len(messages))
+	for index, message := range messages {
+		result[index] = consoleMessageToWire(message)
+	}
+	return result
+}
+
+func (s *engineSession) lifecycleValueAssertion(operation protocol.LifecycleOperation, read func(context.Context) (any, error)) engine.Assertion {
+	return func(ctx context.Context) (engine.Observation, bool, error) {
+		value, err := read(ctx)
+		if err != nil {
+			return engine.Observation{}, false, err
+		}
+		expected, convertErr := expectationFromProtocol(operation.Expectation)
+		if convertErr != nil {
+			return engine.Observation{}, false, engine.Fatal(convertErr)
+		}
+		matched, matchErr := engine.MatchExpectation(value, expected)
+		return engine.Observation{Value: value}, matched, matchErr
+	}
+}
+
 func cookiesToWire(cookies []engine.Cookie) []protocol.WireCookie {
 	result := make([]protocol.WireCookie, len(cookies))
 	for index, cookie := range cookies {
-		result[index] = protocol.WireCookie{Name: cookie.Name, Value: cookie.Value, Domain: cookie.Domain, Path: cookie.Path, Secure: cookie.Secure, HTTPOnly: cookie.HTTPOnly, SameSite: cookie.SameSite}
+		result[index] = protocol.WireCookie{Name: cookie.Name, Value: cookie.Value, Domain: cookie.Domain, Path: cookie.Path, Secure: cookie.Secure, HTTPOnly: cookie.HTTPOnly, SameSite: cookie.SameSite, Session: cookie.Session}
 		if !cookie.Session && !cookie.Expires.IsZero() {
 			result[index].ExpiresUnix = float64(cookie.Expires.UnixMilli()) / 1000
 		}

--- a/cmd/bilobad/engine_adapter.go
+++ b/cmd/bilobad/engine_adapter.go
@@ -25,7 +25,62 @@ func (b *engineBackend) OpenSession(ctx context.Context) (protocol.Session, erro
 
 func (b *engineBackend) Close() error { return b.browser.Close() }
 
-type engineSession struct{ session *engine.Session }
+type engineSession struct {
+	session  *engine.Session
+	frameURL string
+}
+
+func (s *engineSession) Metadata() protocol.SessionMetadata {
+	return protocol.SessionMetadata{ContextID: string(s.session.ContextID()), TargetID: string(s.session.TargetID()), OpenerID: string(s.session.OpenerID()), OwnsContext: s.session.OwnsContext(), Frame: s.frameURL != "", URL: s.frameURL}
+}
+
+func (s *engineSession) Tabs(ctx context.Context) ([]protocol.Session, error) {
+	tabs, err := s.session.Tabs(ctx)
+	if err != nil {
+		return nil, engineRPCError(err)
+	}
+	result := make([]protocol.Session, len(tabs))
+	for index, tab := range tabs {
+		result[index] = &engineSession{session: tab}
+	}
+	return result, nil
+}
+
+func (s *engineSession) WaitForTab(ctx context.Context, query protocol.TabQuery, policy protocol.PollPolicy) (protocol.Session, error) {
+	converted, err := tabQueryFromProtocol(query)
+	if err != nil {
+		return nil, err
+	}
+	tab, waitErr := s.session.WaitForTab(ctx, converted, pollPolicyFromProtocol(policy))
+	if waitErr != nil {
+		return nil, engineRPCError(waitErr)
+	}
+	return &engineSession{session: tab}, nil
+}
+
+func (s *engineSession) Frames(ctx context.Context) ([]protocol.Session, error) {
+	frames, err := s.session.Frames(ctx)
+	if err != nil {
+		return nil, engineRPCError(err)
+	}
+	result := make([]protocol.Session, len(frames))
+	for index, frame := range frames {
+		result[index] = &engineSession{session: frame.Session, frameURL: frame.URL()}
+	}
+	return result, nil
+}
+
+func (s *engineSession) WaitForFrame(ctx context.Context, query protocol.FrameQuery, policy protocol.PollPolicy) (protocol.Session, error) {
+	tabQuery, err := tabQueryFromProtocol(protocol.TabQuery{Title: query.Title, URL: query.URL, HasElement: query.HasElement})
+	if err != nil {
+		return nil, err
+	}
+	frame, waitErr := s.session.WaitForFrame(ctx, engine.FrameQuery{Title: tabQuery.Title, URL: tabQuery.URL, HasElement: tabQuery.HasElement}, pollPolicyFromProtocol(policy))
+	if waitErr != nil {
+		return nil, engineRPCError(waitErr)
+	}
+	return &engineSession{session: frame.Session, frameURL: frame.URL()}, nil
+}
 
 const defaultPollTimeout = 10 * time.Second
 const assertionAttemptTimeout = time.Second
@@ -174,9 +229,258 @@ func (s *engineSession) Execute(ctx context.Context, operation protocol.Operatio
 			return protocol.Result{}, err
 		}
 		return s.poll(ctx, operation, assertion)
+	case protocol.OperationLifecycle:
+		return s.lifecycle(ctx, operation)
 	default:
 		return protocol.Result{}, protocol.NewError(protocol.CodeInvalidArgument, "unsupported operation")
 	}
+}
+
+func tabQueryFromProtocol(query protocol.TabQuery) (engine.TabQuery, error) {
+	result := engine.TabQuery{SpawnedOnly: query.SpawnedOnly}
+	if query.Title != nil {
+		value, err := expectationFromProtocol(*query.Title)
+		if err != nil {
+			return engine.TabQuery{}, err
+		}
+		result.Title = &value
+	}
+	if query.URL != nil {
+		value, err := expectationFromProtocol(*query.URL)
+		if err != nil {
+			return engine.TabQuery{}, err
+		}
+		result.URL = &value
+	}
+	if query.HasElement != nil {
+		value, err := selectorFromProtocol(*query.HasElement)
+		if err != nil {
+			return engine.TabQuery{}, err
+		}
+		result.HasElement = &value
+	}
+	return result, nil
+}
+
+func (s *engineSession) lifecycle(ctx context.Context, operation protocol.Operation) (protocol.Result, error) {
+	started := time.Now()
+	lifecycle := operation.Lifecycle
+	switch lifecycle.Kind {
+	case protocol.LifecycleGetCookies:
+		cookies, err := s.session.GetCookies(ctx)
+		if err != nil {
+			return protocol.Result{}, engineRPCError(err)
+		}
+		return observedResult(started, cookiesToWire(cookies)), nil
+	case protocol.LifecycleClearCookies:
+		return oneAttempt(started, s.session.ClearCookies(ctx))
+	case protocol.LifecycleCookieQuery:
+		return s.poll(ctx, operation, s.cookieAssertion(lifecycle))
+	case protocol.LifecycleStorageSet, protocol.LifecycleStorageGet, protocol.LifecycleStorageGetAll, protocol.LifecycleStorageRemove, protocol.LifecycleStorageClear, protocol.LifecycleStorageLength:
+		return s.storageOperation(ctx, operation, started)
+	case protocol.LifecycleWaitForDefined:
+		result, err := s.session.WaitForDefined(ctx, lifecycle.Expression, withDefaultPollTimeout(pollPolicyFromProtocol(operation.Poll)))
+		if err != nil {
+			return pollResult(result, false), engineRPCError(err)
+		}
+		return pollResult(result, true), nil
+	case protocol.LifecycleURL:
+		value, err := s.session.URL(ctx)
+		if err != nil {
+			return protocol.Result{}, engineRPCError(err)
+		}
+		return observedResult(started, value.Value), nil
+	case protocol.LifecycleTitle:
+		value, err := s.session.Title(ctx)
+		if err != nil {
+			return protocol.Result{}, engineRPCError(err)
+		}
+		return observedResult(started, value), nil
+	case protocol.LifecycleWindowSize:
+		width, height, err := s.session.WindowSize(ctx)
+		if err != nil {
+			return protocol.Result{}, engineRPCError(err)
+		}
+		return observedResult(started, map[string]int{"width": width, "height": height}), nil
+	case protocol.LifecycleOutline:
+		value, err := s.session.Outline(ctx)
+		if err != nil {
+			return protocol.Result{}, engineRPCError(err)
+		}
+		return observedResult(started, value), nil
+	case protocol.LifecycleAccessibilityOutline:
+		value, err := s.session.AccessibilityOutline(ctx)
+		if err != nil {
+			return protocol.Result{}, engineRPCError(err)
+		}
+		return observedResult(started, value), nil
+	case protocol.LifecycleConsoleMessages:
+		return observedResult(started, s.session.ConsoleMessages()), nil
+	case protocol.LifecycleSetDeviceMetrics:
+		return oneAttempt(started, s.session.SetDeviceMetrics(ctx, engine.DeviceMetrics{Width: lifecycle.Width, Height: lifecycle.Height, DeviceScaleFactor: lifecycle.DeviceScaleFactor, Mobile: lifecycle.Mobile}))
+	case protocol.LifecycleClearDeviceMetrics:
+		return oneAttempt(started, s.session.ClearDeviceMetrics(ctx))
+	case protocol.LifecycleSetGeolocation:
+		return oneAttempt(started, s.session.SetGeolocation(ctx, engine.Geolocation{Latitude: lifecycle.Latitude, Longitude: lifecycle.Longitude, Accuracy: lifecycle.Accuracy}))
+	case protocol.LifecycleClearGeolocation:
+		return oneAttempt(started, s.session.ClearGeolocation(ctx))
+	case protocol.LifecycleSetPermissions:
+		permissions := map[engine.Permission]engine.PermissionState{}
+		for name, state := range lifecycle.Permissions {
+			permissions[engine.Permission(name)] = engine.PermissionState(state)
+		}
+		return oneAttempt(started, s.session.SetPermissions(ctx, lifecycle.Origin, permissions))
+	case protocol.LifecycleResetPermissions:
+		return oneAttempt(started, s.session.ResetPermissions(ctx))
+	case protocol.LifecycleSetLocale:
+		return oneAttempt(started, s.session.SetLocale(ctx, lifecycle.Locale))
+	case protocol.LifecycleClearLocale:
+		return oneAttempt(started, s.session.ClearLocale(ctx))
+	case protocol.LifecycleSetTimezone:
+		return oneAttempt(started, s.session.SetTimezone(ctx, lifecycle.Timezone))
+	case protocol.LifecycleClearTimezone:
+		return oneAttempt(started, s.session.ClearTimezone(ctx))
+	case protocol.LifecycleSetMedia:
+		return oneAttempt(started, s.session.SetMedia(ctx, engine.Media{Type: lifecycle.MediaType, ColorScheme: lifecycle.ColorScheme, ReducedMotion: lifecycle.ReducedMotion}))
+	case protocol.LifecycleClearMedia:
+		return oneAttempt(started, s.session.ClearMedia(ctx))
+	default:
+		return protocol.Result{}, protocol.NewError(protocol.CodeInvalidArgument, "unsupported lifecycle operation")
+	}
+}
+
+func cookiesToWire(cookies []engine.Cookie) []protocol.WireCookie {
+	result := make([]protocol.WireCookie, len(cookies))
+	for index, cookie := range cookies {
+		result[index] = protocol.WireCookie{Name: cookie.Name, Value: cookie.Value, Domain: cookie.Domain, Path: cookie.Path, Secure: cookie.Secure, HTTPOnly: cookie.HTTPOnly, SameSite: cookie.SameSite}
+		if !cookie.Session && !cookie.Expires.IsZero() {
+			result[index].ExpiresUnix = float64(cookie.Expires.UnixMilli()) / 1000
+		}
+	}
+	return result
+}
+
+func (s *engineSession) cookieAssertion(operation protocol.LifecycleOperation) engine.Assertion {
+	return func(ctx context.Context) (engine.Observation, bool, error) {
+		cookies, err := s.session.GetCookies(ctx)
+		if err != nil {
+			return engine.Observation{}, false, err
+		}
+		matched := make([]engine.Cookie, 0)
+		for _, cookie := range cookies {
+			ok, matchErr := cookieMatches(cookie, operation.Cookie)
+			if matchErr != nil {
+				return engine.Observation{}, false, engine.Fatal(matchErr)
+			}
+			if ok {
+				matched = append(matched, cookie)
+			}
+		}
+		if operation.Count {
+			ok, matchErr := engine.MatchExpectation(len(matched), mustEngineExpectation(operation.Expectation))
+			return engine.Observation{Value: len(matched)}, ok, matchErr
+		}
+		if len(matched) == 0 {
+			return engine.Observation{Value: nil}, false, nil
+		}
+		return engine.Observation{Value: cookiesToWire(matched[:1])[0]}, true, nil
+	}
+}
+
+func cookieMatches(cookie engine.Cookie, query protocol.CookieQuery) (bool, error) {
+	for expectation, value := range map[*protocol.Expectation]any{query.Name: cookie.Name, query.Value: cookie.Value, query.Domain: cookie.Domain, query.Path: cookie.Path, query.SameSite: cookie.SameSite} {
+		if expectation == nil {
+			continue
+		}
+		converted, err := expectationFromProtocol(*expectation)
+		if err != nil {
+			return false, err
+		}
+		matched, err := engine.MatchExpectation(value, converted)
+		if err != nil || !matched {
+			return false, err
+		}
+	}
+	if query.Secure != nil && cookie.Secure != *query.Secure {
+		return false, nil
+	}
+	if query.HTTPOnly != nil && cookie.HTTPOnly != *query.HTTPOnly {
+		return false, nil
+	}
+	return true, nil
+}
+
+func mustEngineExpectation(expectation protocol.Expectation) engine.Expectation {
+	converted, _ := expectationFromProtocol(expectation)
+	return converted
+}
+
+func (s *engineSession) storageOperation(ctx context.Context, operation protocol.Operation, started time.Time) (protocol.Result, error) {
+	state := operation.Lifecycle
+	area := engine.StorageArea(state.Area)
+	storage := s.session.Storage(area)
+	switch state.Kind {
+	case protocol.LifecycleStorageSet:
+		var value any
+		if err := json.Unmarshal([]byte(state.ValueJSON), &value); err != nil {
+			return protocol.Result{}, protocol.NewError(protocol.CodeInvalidArgument, err.Error())
+		}
+		return oneAttempt(started, storage.Set(ctx, state.Key, value))
+	case protocol.LifecycleStorageRemove:
+		return oneAttempt(started, storage.Remove(ctx, state.Key))
+	case protocol.LifecycleStorageClear:
+		return oneAttempt(started, storage.Clear(ctx))
+	case protocol.LifecycleStorageGetAll:
+		value, err := storage.GetAll(ctx)
+		if err != nil {
+			return protocol.Result{}, engineRPCError(err)
+		}
+		return observedResult(started, value), nil
+	case protocol.LifecycleStorageLength:
+		if state.Expectation.Kind != 0 {
+			return s.poll(ctx, operation, func(attemptCtx context.Context) (engine.Observation, bool, error) {
+				value, err := storage.Length(attemptCtx)
+				if err != nil {
+					return engine.Observation{}, false, err
+				}
+				expected, convertErr := expectationFromProtocol(state.Expectation)
+				if convertErr != nil {
+					return engine.Observation{}, false, engine.Fatal(convertErr)
+				}
+				matched, matchErr := engine.MatchExpectation(value, expected)
+				return engine.Observation{Value: value}, matched, matchErr
+			})
+		}
+		value, err := storage.Length(ctx)
+		if err != nil {
+			return protocol.Result{}, engineRPCError(err)
+		}
+		return observedResult(started, value), nil
+	case protocol.LifecycleStorageGet:
+		if state.Expectation.Kind != 0 {
+			return s.poll(ctx, operation, func(attemptCtx context.Context) (engine.Observation, bool, error) {
+				value, found, err := storage.Get(attemptCtx, state.Key)
+				if err != nil {
+					return engine.Observation{}, false, err
+				}
+				if !found {
+					return engine.Observation{Value: nil}, false, nil
+				}
+				expected, convertErr := expectationFromProtocol(state.Expectation)
+				if convertErr != nil {
+					return engine.Observation{}, false, engine.Fatal(convertErr)
+				}
+				matched, matchErr := engine.MatchExpectation(value, expected)
+				return engine.Observation{Value: value}, matched, matchErr
+			})
+		}
+		value, found, err := storage.Get(ctx, state.Key)
+		if err != nil {
+			return protocol.Result{}, engineRPCError(err)
+		}
+		return observedResult(started, map[string]any{"value": value, "found": found}), nil
+	}
+	return protocol.Result{}, protocol.NewError(protocol.CodeInvalidArgument, "unsupported storage operation")
 }
 
 func (s *engineSession) domAssertion(operation protocol.DOMOperation) (engine.Assertion, error) {

--- a/engine/browser.go
+++ b/engine/browser.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -27,6 +28,19 @@ type BrowserConfig struct {
 	WindowWidth    int
 	WindowHeight   int
 	ArtifactDir    string
+	AutoInstall    bool
+}
+
+// LaunchMetadata is the resolved process configuration used by a Browser. Attached browsers set
+// Attached but leave launch-only fields empty because they did not observe the shared process start.
+type LaunchMetadata struct {
+	Mode           ChromeMode
+	ExecutablePath string
+	Arguments      []string
+	WindowWidth    int
+	WindowHeight   int
+	Attached       bool
+	AutoInstalled  bool
 }
 
 // ChromeMode selects the Chrome process variant without coupling callers to chromedp flags.
@@ -37,6 +51,8 @@ const (
 	ChromeModeHeadlessShell ChromeMode = "headless-shell"
 	// ChromeModeHeadless launches a full Chrome executable in modern headless mode.
 	ChromeModeHeadless ChromeMode = "headless"
+	// ChromeModeHeadful launches a visible full Chrome executable.
+	ChromeModeHeadful ChromeMode = "headful"
 )
 
 // Browser owns one supplied Chrome process and opens isolated runner-neutral sessions within it.
@@ -44,6 +60,10 @@ type Browser struct {
 	ctx          context.Context
 	cancel       context.CancelFunc
 	artifactDir  string
+	mode         ChromeMode
+	windowWidth  int
+	windowHeight int
+	launch       LaunchMetadata
 	mu           sync.Mutex
 	sessions     map[*Session]struct{}
 	closed       bool
@@ -55,11 +75,12 @@ func StartBrowser(ctx context.Context, config BrowserConfig) (*Browser, error) {
 	if config.WebSocketURL != "" {
 		return connectBrowser(ctx, config)
 	}
-	if config.ExecutablePath == "" {
-		return nil, &Error{Code: CodeBrowserStart, Operation: "start browser", Message: "ExecutablePath is required"}
+	mode := config.Mode
+	if mode == "" {
+		mode = ChromeModeHeadlessShell
 	}
-	if config.Mode != "" && config.Mode != ChromeModeHeadlessShell && config.Mode != ChromeModeHeadless {
-		return nil, &Error{Code: CodeInvalidArgument, Operation: "start browser", Message: "mode must be headless-shell or headless", Observed: config.Mode}
+	if mode != ChromeModeHeadlessShell && mode != ChromeModeHeadless && mode != ChromeModeHeadful {
+		return nil, &Error{Code: CodeInvalidArgument, Operation: "start browser", Message: "mode must be headless-shell, headless, or headful", Observed: config.Mode}
 	}
 	type chromeArgument struct {
 		name  string
@@ -73,27 +94,43 @@ func StartBrowser(ctx context.Context, config BrowserConfig) (*Browser, error) {
 		}
 		arguments = append(arguments, chromeArgument{name: name, value: value})
 	}
+	executablePath := config.ExecutablePath
+	autoInstalled := false
+	if mode == ChromeModeHeadlessShell {
+		var resolveErr error
+		executablePath, autoInstalled, resolveErr = ResolveHeadlessShell(ctx, executablePath, config.AutoInstall)
+		if resolveErr != nil {
+			return nil, &Error{Code: CodeBrowserStart, Operation: "start browser", Message: resolveErr.Error(), Cause: resolveErr}
+		}
+	} else {
+		executablePath = LocateFullChrome(executablePath)
+	}
+	if executablePath == "" {
+		return nil, &Error{Code: CodeBrowserStart, Operation: "start browser", Message: "could not find a full Chrome executable; provide ExecutablePath"}
+	}
 	width, height := config.WindowWidth, config.WindowHeight
 	if width <= 0 {
-		width = 1920
+		width = 1024
 	}
 	if height <= 0 {
-		height = 1080
+		height = 768
 	}
 	profile, err := os.MkdirTemp("", "biloba-engine-profile-")
 	if err != nil {
 		return nil, typedError(CodeIO, "start browser", err)
 	}
 	opts := append(chromedp.DefaultExecAllocatorOptions[:],
-		chromedp.ExecPath(config.ExecutablePath),
+		chromedp.ExecPath(executablePath),
 		chromedp.WindowSize(width, height),
 		chromedp.UserDataDir(profile),
 		chromedp.WSURLReadTimeout(60*time.Second),
 	)
-	switch config.Mode {
-	case "", ChromeModeHeadlessShell:
+	switch mode {
+	case ChromeModeHeadlessShell:
 	case ChromeModeHeadless:
 		opts = append(opts, chromedp.Flag("headless", "new"))
+	case ChromeModeHeadful:
+		opts = append(opts, chromedp.Flag("headless", false))
 	}
 	for _, argument := range arguments {
 		opts = append(opts, chromedp.Flag(argument.name, argument.value))
@@ -117,6 +154,8 @@ func StartBrowser(ctx context.Context, config BrowserConfig) (*Browser, error) {
 	return &Browser{
 		ctx: browserCtx, cancel: cancel, artifactDir: config.ArtifactDir,
 		sessions: map[*Session]struct{}{}, webSocketURL: wsURL,
+		mode: mode, windowWidth: width, windowHeight: height,
+		launch: LaunchMetadata{Mode: mode, ExecutablePath: executablePath, Arguments: append([]string(nil), config.Arguments...), WindowWidth: width, WindowHeight: height, AutoInstalled: autoInstalled},
 	}, nil
 }
 
@@ -125,14 +164,19 @@ func parseChromeArgument(argument string) (string, any, error) {
 		return "", nil, &Error{Code: CodeInvalidArgument, Operation: "start browser", Message: "Chrome arguments must use --name or --name=value", Observed: argument}
 	}
 	parts := strings.SplitN(strings.TrimPrefix(argument, "--"), "=", 2)
-	if len(parts) == 1 {
-		return parts[0], true, nil
-	}
 	if parts[0] == "" {
 		return "", nil, &Error{Code: CodeInvalidArgument, Operation: "start browser", Message: "Chrome argument name cannot be empty", Observed: argument}
 	}
+	if !validChromeArgumentName.MatchString(parts[0]) {
+		return "", nil, &Error{Code: CodeInvalidArgument, Operation: "start browser", Message: "Chrome argument name must contain only letters, digits, and hyphens", Observed: argument}
+	}
+	if len(parts) == 1 {
+		return parts[0], true, nil
+	}
 	return parts[0], parts[1], nil
 }
+
+var validChromeArgumentName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]*$`)
 
 func connectBrowser(ctx context.Context, config BrowserConfig) (*Browser, error) {
 	allocCtx, cancelAllocator := chromedp.NewRemoteAllocator(ctx, config.WebSocketURL, chromedp.NoModifyURL)
@@ -145,12 +189,21 @@ func connectBrowser(ctx context.Context, config BrowserConfig) (*Browser, error)
 	return &Browser{
 		ctx: browserCtx, cancel: cancel, artifactDir: config.ArtifactDir,
 		sessions: map[*Session]struct{}{}, webSocketURL: config.WebSocketURL,
+		mode: config.Mode, windowWidth: config.WindowWidth, windowHeight: config.WindowHeight,
+		launch: LaunchMetadata{Attached: true},
 	}, nil
 }
 
 // WebSocketURL is the browser-level DevTools endpoint. It can be passed to
 // other Browser instances so independent workers share one Chrome process.
 func (b *Browser) WebSocketURL() string { return b.webSocketURL }
+
+// LaunchMetadata returns a defensive snapshot of this browser's resolved launch configuration.
+func (b *Browser) LaunchMetadata() LaunchMetadata {
+	metadata := b.launch
+	metadata.Arguments = append([]string(nil), metadata.Arguments...)
+	return metadata
+}
 
 func readWebSocketURL(profile string) (string, error) {
 	contents, err := os.ReadFile(filepath.Join(profile, "DevToolsActivePort"))
@@ -275,6 +328,20 @@ func (b *Browser) openTabLocked(ctx context.Context, browserContextID cdp.Browse
 	session := &Session{
 		browser: b, ctx: tabCtx, cancel: cancelTab, browserContextID: browserContextID,
 		targetID: targetID, ownsContext: ownsContext, artifactDir: b.artifactDir, root: root,
+		initialWidth: b.windowWidth, initialHeight: b.windowHeight,
+		highFidelity: b.mode == ChromeModeHeadless,
+	}
+	if session.initialWidth <= 0 || session.initialHeight <= 0 {
+		width, height, sizeErr := ViewportDimensionsContext(tabCtx)
+		if sizeErr != nil {
+			cancelTab()
+			return nil, contextError("read initial window size", sizeErr)
+		}
+		session.initialWidth, session.initialHeight = int(width), int(height)
+	}
+	if err := session.applyViewport(tabCtx, session.initialWidth, session.initialHeight); err != nil {
+		cancelTab()
+		return nil, contextError("apply initial viewport", err)
 	}
 	if ownsContext {
 		session.root = session

--- a/engine/browser.go
+++ b/engine/browser.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chromedp/cdproto/fetch"
 	"github.com/chromedp/cdproto/inspector"
 	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
 	"github.com/chromedp/chromedp"
 )
@@ -21,10 +22,22 @@ import (
 type BrowserConfig struct {
 	ExecutablePath string
 	WebSocketURL   string
+	Mode           ChromeMode
+	Arguments      []string
 	WindowWidth    int
 	WindowHeight   int
 	ArtifactDir    string
 }
+
+// ChromeMode selects the Chrome process variant without coupling callers to chromedp flags.
+type ChromeMode string
+
+const (
+	// ChromeModeHeadlessShell uses the lightweight chrome-headless-shell defaults.
+	ChromeModeHeadlessShell ChromeMode = "headless-shell"
+	// ChromeModeHeadless launches a full Chrome executable in modern headless mode.
+	ChromeModeHeadless ChromeMode = "headless"
+)
 
 // Browser owns one supplied Chrome process and opens isolated runner-neutral sessions within it.
 type Browser struct {
@@ -45,6 +58,21 @@ func StartBrowser(ctx context.Context, config BrowserConfig) (*Browser, error) {
 	if config.ExecutablePath == "" {
 		return nil, &Error{Code: CodeBrowserStart, Operation: "start browser", Message: "ExecutablePath is required"}
 	}
+	if config.Mode != "" && config.Mode != ChromeModeHeadlessShell && config.Mode != ChromeModeHeadless {
+		return nil, &Error{Code: CodeInvalidArgument, Operation: "start browser", Message: "mode must be headless-shell or headless", Observed: config.Mode}
+	}
+	type chromeArgument struct {
+		name  string
+		value any
+	}
+	arguments := make([]chromeArgument, 0, len(config.Arguments))
+	for _, argument := range config.Arguments {
+		name, value, parseErr := parseChromeArgument(argument)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		arguments = append(arguments, chromeArgument{name: name, value: value})
+	}
 	width, height := config.WindowWidth, config.WindowHeight
 	if width <= 0 {
 		width = 1920
@@ -62,6 +90,14 @@ func StartBrowser(ctx context.Context, config BrowserConfig) (*Browser, error) {
 		chromedp.UserDataDir(profile),
 		chromedp.WSURLReadTimeout(60*time.Second),
 	)
+	switch config.Mode {
+	case "", ChromeModeHeadlessShell:
+	case ChromeModeHeadless:
+		opts = append(opts, chromedp.Flag("headless", "new"))
+	}
+	for _, argument := range arguments {
+		opts = append(opts, chromedp.Flag(argument.name, argument.value))
+	}
 	allocCtx, cancelAllocator := chromedp.NewExecAllocator(ctx, opts...)
 	browserCtx, cancelBrowser := chromedp.NewContext(allocCtx)
 	cancel := func() {
@@ -82,6 +118,20 @@ func StartBrowser(ctx context.Context, config BrowserConfig) (*Browser, error) {
 		ctx: browserCtx, cancel: cancel, artifactDir: config.ArtifactDir,
 		sessions: map[*Session]struct{}{}, webSocketURL: wsURL,
 	}, nil
+}
+
+func parseChromeArgument(argument string) (string, any, error) {
+	if !strings.HasPrefix(argument, "--") || len(argument) <= 2 {
+		return "", nil, &Error{Code: CodeInvalidArgument, Operation: "start browser", Message: "Chrome arguments must use --name or --name=value", Observed: argument}
+	}
+	parts := strings.SplitN(strings.TrimPrefix(argument, "--"), "=", 2)
+	if len(parts) == 1 {
+		return parts[0], true, nil
+	}
+	if parts[0] == "" {
+		return "", nil, &Error{Code: CodeInvalidArgument, Operation: "start browser", Message: "Chrome argument name cannot be empty", Observed: argument}
+	}
+	return parts[0], parts[1], nil
 }
 
 func connectBrowser(ctx context.Context, config BrowserConfig) (*Browser, error) {
@@ -177,7 +227,7 @@ func (b *Browser) OpenSession(ctx context.Context) (*Session, error) {
 		cleanupExecutor := cdp.WithExecutor(cleanupCtx, chromedp.FromContext(b.ctx).Browser)
 		_ = target.DisposeBrowserContext(browserContextID).Do(cleanupExecutor)
 	}()
-	session, err := b.openTabLocked(ctx, browserContextID, true, browserExecutor)
+	session, err := b.openTabLocked(ctx, browserContextID, true, nil, browserExecutor)
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +235,7 @@ func (b *Browser) OpenSession(ctx context.Context) (*Session, error) {
 	return session, nil
 }
 
-func (b *Browser) openTab(ctx context.Context, browserContextID cdp.BrowserContextID, ownsContext bool) (*Session, error) {
+func (b *Browser) openTab(ctx context.Context, browserContextID cdp.BrowserContextID, ownsContext bool, root *Session) (*Session, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.closed {
@@ -194,10 +244,10 @@ func (b *Browser) openTab(ctx context.Context, browserContextID cdp.BrowserConte
 	opCtx, cancel := executorContext(b.ctx, ctx)
 	defer cancel()
 	chrome := chromedp.FromContext(opCtx)
-	return b.openTabLocked(ctx, browserContextID, ownsContext, cdp.WithExecutor(opCtx, chrome.Browser))
+	return b.openTabLocked(ctx, browserContextID, ownsContext, root, cdp.WithExecutor(opCtx, chrome.Browser))
 }
 
-func (b *Browser) openTabLocked(ctx context.Context, browserContextID cdp.BrowserContextID, ownsContext bool, browserExecutor context.Context) (*Session, error) {
+func (b *Browser) openTabLocked(ctx context.Context, browserContextID cdp.BrowserContextID, ownsContext bool, root *Session, browserExecutor context.Context) (*Session, error) {
 	targetID, err := target.CreateTarget("about:blank").
 		WithBrowserContextID(browserContextID).
 		WithNewWindow(true).
@@ -224,12 +274,21 @@ func (b *Browser) openTabLocked(ctx context.Context, browserContextID cdp.Browse
 	}
 	session := &Session{
 		browser: b, ctx: tabCtx, cancel: cancelTab, browserContextID: browserContextID,
-		targetID: targetID, ownsContext: ownsContext, artifactDir: b.artifactDir,
+		targetID: targetID, ownsContext: ownsContext, artifactDir: b.artifactDir, root: root,
 	}
+	if ownsContext {
+		session.root = session
+	}
+	b.listenToSession(session)
+	b.sessions[session] = struct{}{}
+	return session, nil
+}
+
+func (b *Browser) listenToSession(session *Session) {
 	// Chrome announces a dead renderer once, on this target, and then goes quiet: subsequent CDP
 	// calls neither succeed nor fail, they simply never answer.  Catching the announcement is the
 	// only way to tell a crashed page from a slow one.
-	chromedp.ListenTarget(tabCtx, func(event any) {
+	chromedp.ListenTarget(session.ctx, func(event any) {
 		if _, ok := event.(*inspector.EventTargetCrashed); ok {
 			session.markCrashed()
 		}
@@ -239,9 +298,43 @@ func (b *Browser) openTabLocked(ctx context.Context, browserContextID cdp.Browse
 		if paused, ok := event.(*fetch.EventRequestPaused); ok {
 			session.handlePausedResponse(paused)
 		}
+		if console, ok := event.(*runtime.EventConsoleAPICalled); ok {
+			session.recordConsoleMessage(console)
+		}
 	})
-	b.sessions[session] = struct{}{}
-	return session, nil
+}
+
+// Sessions returns a stable snapshot of the targets this Browser currently owns or has discovered.
+func (b *Browser) Sessions() []*Session {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]*Session, 0, len(b.sessions))
+	for session := range b.sessions {
+		out = append(out, session)
+	}
+	return out
+}
+
+func (b *Browser) closeContextDescendants(ctx context.Context, root *Session) error {
+	// Discover browser-opened descendants before taking the snapshot, so Prepare invalidates handles
+	// for explicit siblings and popups alike.
+	b.mu.Lock()
+	closed := b.closed
+	b.mu.Unlock()
+	if !closed {
+		_, _ = root.Tabs(ctx)
+	}
+	var firstErr error
+	for _, session := range b.Sessions() {
+		if session != root && session.browserContextID == root.browserContextID {
+			if err := session.Close(); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+			}
+		}
+	}
+	return firstErr
 }
 
 func (b *Browser) Close() error {

--- a/engine/chrome.go
+++ b/engine/chrome.go
@@ -1,6 +1,8 @@
 package engine
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +13,24 @@ import (
 // ChromeEnvVar lets you point Biloba at a chrome-headless-shell binary without code changes.
 // It is honored by the Ginkgo adapter, by the engine's own suite, and by the bilobad daemon.
 const ChromeEnvVar = "BILOBA_CHROME_HEADLESS_SHELL"
+
+var headlessShellInstaller = InstallHeadlessShell
+
+// ResolveHeadlessShell finds a local chrome-headless-shell and, only when autoInstall is true,
+// installs Chrome for Testing's stable shell into Biloba's cache as a fallback.
+func ResolveHeadlessShell(ctx context.Context, explicit string, autoInstall bool) (string, bool, error) {
+	if path := LocateChrome(explicit); path != "" {
+		return path, false, nil
+	}
+	if !autoInstall {
+		return "", false, fmt.Errorf("could not find chrome-headless-shell; install it, set %s, provide an explicit path, or opt in to auto-install", ChromeEnvVar)
+	}
+	path, err := headlessShellInstaller(ctx)
+	if err != nil {
+		return "", false, fmt.Errorf("auto-install chrome-headless-shell: %w", err)
+	}
+	return path, true, nil
+}
 
 // LocateChrome returns the path to a chrome-headless-shell binary, searching (in order): an
 // explicit path, ChromeEnvVar, $PATH, and the puppeteer / Biloba download caches.  It returns ""
@@ -35,6 +55,37 @@ func LocateChrome(explicit string) string {
 		if len(matches) > 0 {
 			sort.Strings(matches) // prefer the lexically-last (typically newest) version
 			return matches[len(matches)-1]
+		}
+	}
+	return ""
+}
+
+// LocateFullChrome returns a full Chrome/Chromium executable for high-fidelity or headful mode.
+func LocateFullChrome(explicit string) string {
+	if explicit != "" && IsExecutableFile(explicit) {
+		return explicit
+	}
+	var candidates []string
+	switch runtime.GOOS {
+	case "darwin":
+		candidates = []string{
+			"/Applications/Chromium.app/Contents/MacOS/Chromium",
+			"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+		}
+	case "windows":
+		candidates = []string{
+			"chrome", "chrome.exe",
+			`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`,
+			`C:\Program Files\Google\Chrome\Application\chrome.exe`,
+			filepath.Join(os.Getenv("USERPROFILE"), `AppData\Local\Google\Chrome\Application\chrome.exe`),
+			filepath.Join(os.Getenv("USERPROFILE"), `AppData\Local\Chromium\Application\chrome.exe`),
+		}
+	default:
+		candidates = []string{"chromium", "chromium-browser", "google-chrome", "google-chrome-stable", "google-chrome-beta", "google-chrome-unstable", "/usr/bin/google-chrome", "/usr/local/bin/chrome", "/snap/bin/chromium", "chrome"}
+	}
+	for _, candidate := range candidates {
+		if path, err := exec.LookPath(candidate); err == nil && IsExecutableFile(path) {
+			return path
 		}
 	}
 	return ""

--- a/engine/chrome_install.go
+++ b/engine/chrome_install.go
@@ -1,0 +1,257 @@
+package engine
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+const chromeForTestingVersionsURL = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
+
+const (
+	maxChromeManifestBytes = 8 << 20
+	maxShellArchiveBytes   = 512 << 20
+	maxShellExtractedBytes = 1 << 30
+	maxShellArchiveEntries = 10_000
+)
+
+// InstallHeadlessShell downloads Chrome for Testing's stable chrome-headless-shell into Biloba's
+// user cache. Callers must opt in; normal browser resolution never calls this function.
+func InstallHeadlessShell(ctx context.Context) (string, error) {
+	platform, err := chromeForTestingPlatform()
+	if err != nil {
+		return "", err
+	}
+	downloadURL, version, err := stableHeadlessShellDownload(ctx, platform)
+	if err != nil {
+		return "", err
+	}
+	cacheRoot, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("determine user cache directory: %w", err)
+	}
+	destination := filepath.Join(cacheRoot, "biloba", "chrome-headless-shell", version)
+	binaryPath := filepath.Join(destination, "chrome-headless-shell-"+platform, ChromeBinaryName())
+	if IsExecutableFile(binaryPath) {
+		return binaryPath, nil
+	}
+	archivePath, cleanup, err := downloadHeadlessShellArchive(ctx, downloadURL)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+	if err := installHeadlessShellArchive(archivePath, destination, platform); err != nil {
+		return "", err
+	}
+	return binaryPath, nil
+}
+
+func chromeForTestingPlatform() (string, error) {
+	switch runtime.GOOS + "/" + runtime.GOARCH {
+	case "darwin/arm64":
+		return "mac-arm64", nil
+	case "darwin/amd64":
+		return "mac-x64", nil
+	case "linux/amd64":
+		return "linux64", nil
+	case "windows/amd64":
+		return "win64", nil
+	case "windows/386":
+		return "win32", nil
+	default:
+		return "", fmt.Errorf("chrome-headless-shell auto-install is unavailable for %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+}
+
+func stableHeadlessShellDownload(ctx context.Context, platform string) (string, string, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, chromeForTestingVersionsURL, nil)
+	if err != nil {
+		return "", "", err
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	response, err := client.Do(request)
+	if err != nil {
+		return "", "", fmt.Errorf("query Chrome for Testing: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("Chrome for Testing returned status %d", response.StatusCode)
+	}
+	var data struct {
+		Channels map[string]struct {
+			Version   string `json:"version"`
+			Downloads struct {
+				HeadlessShell []struct {
+					Platform string `json:"platform"`
+					URL      string `json:"url"`
+				} `json:"chrome-headless-shell"`
+			} `json:"downloads"`
+		} `json:"channels"`
+	}
+	if response.ContentLength > maxChromeManifestBytes {
+		return "", "", fmt.Errorf("Chrome for Testing manifest exceeds %d bytes", maxChromeManifestBytes)
+	}
+	manifest, err := io.ReadAll(io.LimitReader(response.Body, maxChromeManifestBytes+1))
+	if err != nil {
+		return "", "", fmt.Errorf("read Chrome for Testing response: %w", err)
+	}
+	if len(manifest) > maxChromeManifestBytes {
+		return "", "", fmt.Errorf("Chrome for Testing manifest exceeds %d bytes", maxChromeManifestBytes)
+	}
+	if err := json.Unmarshal(manifest, &data); err != nil {
+		return "", "", fmt.Errorf("decode Chrome for Testing response: %w", err)
+	}
+	stable, ok := data.Channels["Stable"]
+	if !ok {
+		return "", "", fmt.Errorf("Chrome for Testing response has no Stable channel")
+	}
+	for _, download := range stable.Downloads.HeadlessShell {
+		if download.Platform == platform {
+			return download.URL, stable.Version, nil
+		}
+	}
+	return "", "", fmt.Errorf("Chrome for Testing has no chrome-headless-shell download for %s", platform)
+}
+
+func downloadHeadlessShellArchive(ctx context.Context, downloadURL string) (string, func(), error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return "", func() {}, err
+	}
+	client := &http.Client{Timeout: 5 * time.Minute}
+	response, err := client.Do(request)
+	if err != nil {
+		return "", func() {}, fmt.Errorf("download %s: %w", downloadURL, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return "", func() {}, fmt.Errorf("download %s returned status %d", downloadURL, response.StatusCode)
+	}
+	if response.ContentLength > maxShellArchiveBytes {
+		return "", func() {}, fmt.Errorf("chrome-headless-shell archive exceeds %d bytes", maxShellArchiveBytes)
+	}
+	temporary, err := os.CreateTemp("", "chrome-headless-shell-*.zip")
+	if err != nil {
+		return "", func() {}, err
+	}
+	temporaryPath := temporary.Name()
+	cleanup := func() { _ = os.Remove(temporaryPath) }
+	written, copyErr := io.Copy(temporary, io.LimitReader(response.Body, maxShellArchiveBytes+1))
+	if copyErr != nil {
+		temporary.Close()
+		cleanup()
+		return "", func() {}, copyErr
+	}
+	if written > maxShellArchiveBytes {
+		temporary.Close()
+		cleanup()
+		return "", func() {}, fmt.Errorf("chrome-headless-shell archive exceeds %d bytes", maxShellArchiveBytes)
+	}
+	if err := temporary.Close(); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	return temporaryPath, cleanup, nil
+}
+
+func installHeadlessShellArchive(archivePath, destination, platform string) error {
+	finalBinary := filepath.Join(destination, "chrome-headless-shell-"+platform, ChromeBinaryName())
+	if IsExecutableFile(finalBinary) {
+		return nil
+	}
+	parent := filepath.Dir(destination)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return err
+	}
+	staging, err := os.MkdirTemp(parent, filepath.Base(destination)+".partial-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(staging)
+	if err := unzipHeadlessShell(archivePath, staging); err != nil {
+		return err
+	}
+	stagedBinary := filepath.Join(staging, "chrome-headless-shell-"+platform, ChromeBinaryName())
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(stagedBinary, 0o755); err != nil {
+			return fmt.Errorf("make chrome-headless-shell executable: %w", err)
+		}
+	}
+	if !IsExecutableFile(stagedBinary) {
+		return fmt.Errorf("downloaded chrome-headless-shell but no binary was found at %s", stagedBinary)
+	}
+	if err := os.Rename(staging, destination); err != nil {
+		if IsExecutableFile(finalBinary) {
+			return nil
+		}
+		return fmt.Errorf("publish chrome-headless-shell cache entry: %w", err)
+	}
+	return nil
+}
+
+func unzipHeadlessShell(archivePath, destination string) error {
+	archive, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+	defer archive.Close()
+	if len(archive.File) > maxShellArchiveEntries {
+		return fmt.Errorf("chrome-headless-shell archive has more than %d entries", maxShellArchiveEntries)
+	}
+	var extracted uint64
+	for _, entry := range archive.File {
+		if entry.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("chrome-headless-shell archive contains a symbolic link: %s", entry.Name)
+		}
+		if entry.UncompressedSize64 > maxShellExtractedBytes-extracted {
+			return fmt.Errorf("chrome-headless-shell archive expands beyond %d bytes", maxShellExtractedBytes)
+		}
+		extracted += entry.UncompressedSize64
+		path := filepath.Join(destination, entry.Name)
+		relative, relativeErr := filepath.Rel(destination, path)
+		if relativeErr != nil || relative == ".." || filepath.IsAbs(relative) || (len(relative) >= 3 && relative[:3] == ".."+string(os.PathSeparator)) {
+			return fmt.Errorf("illegal file path in zip archive: %s", entry.Name)
+		}
+		if entry.FileInfo().IsDir() {
+			if err := os.MkdirAll(path, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return err
+		}
+		reader, err := entry.Open()
+		if err != nil {
+			return err
+		}
+		writer, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, entry.Mode())
+		if err != nil {
+			reader.Close()
+			return err
+		}
+		written, copyErr := io.Copy(writer, io.LimitReader(reader, int64(entry.UncompressedSize64)+1))
+		closeWriterErr := writer.Close()
+		closeReaderErr := reader.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		if uint64(written) != entry.UncompressedSize64 {
+			return fmt.Errorf("archive entry %s size mismatch", entry.Name)
+		}
+		if closeWriterErr != nil {
+			return closeWriterErr
+		}
+		if closeReaderErr != nil {
+			return closeReaderErr
+		}
+	}
+	return nil
+}

--- a/engine/chrome_install_test.go
+++ b/engine/chrome_install_test.go
@@ -1,0 +1,52 @@
+package engine_test
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/biloba/engine"
+)
+
+var _ = Describe("runner-neutral chrome-headless-shell installation", func() {
+	It("atomically publishes one complete cache entry under concurrent installers", func() {
+		platform := "test-platform"
+		archivePath := filepath.Join(GinkgoT().TempDir(), "shell.zip")
+		file, err := os.Create(archivePath)
+		Expect(err).NotTo(HaveOccurred())
+		writer := zip.NewWriter(file)
+		binary, err := writer.Create(filepath.Join("chrome-headless-shell-"+platform, engine.ChromeBinaryName()))
+		Expect(err).NotTo(HaveOccurred())
+		_, err = binary.Write([]byte("complete-binary"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(writer.Close()).To(Succeed())
+		Expect(file.Close()).To(Succeed())
+
+		destination := filepath.Join(GinkgoT().TempDir(), "stable-version")
+		errors := make(chan error, 2)
+		var installers sync.WaitGroup
+		for range 2 {
+			installers.Add(1)
+			go func() {
+				defer installers.Done()
+				errors <- engine.InstallHeadlessShellArchiveForTest(archivePath, destination, platform)
+			}()
+		}
+		installers.Wait()
+		close(errors)
+		for installErr := range errors {
+			Expect(installErr).NotTo(HaveOccurred())
+		}
+
+		contents, err := os.ReadFile(filepath.Join(destination, "chrome-headless-shell-"+platform, engine.ChromeBinaryName()))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(contents).To(Equal([]byte("complete-binary")))
+		partials, err := filepath.Glob(destination + ".partial-*")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(partials).To(BeEmpty())
+	})
+})

--- a/engine/console.go
+++ b/engine/console.go
@@ -1,0 +1,52 @@
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/chromedp/cdproto/runtime"
+)
+
+type ConsoleMessage struct {
+	Type      string
+	Text      string
+	Args      []any
+	Timestamp time.Time
+}
+
+func (s *Session) ConsoleMessages() []ConsoleMessage {
+	s.consoleMu.Lock()
+	defer s.consoleMu.Unlock()
+	return append([]ConsoleMessage(nil), s.consoleMessages...)
+}
+
+func (s *Session) recordConsoleMessage(event *runtime.EventConsoleAPICalled) {
+	message := ConsoleMessage{Type: string(event.Type)}
+	if event.Timestamp != nil {
+		message.Timestamp = event.Timestamp.Time()
+	}
+	parts := make([]string, 0, len(event.Args))
+	for _, object := range event.Args {
+		var value any
+		if len(object.Value) > 0 && json.Unmarshal(object.Value, &value) == nil {
+			message.Args = append(message.Args, value)
+			parts = append(parts, fmt.Sprint(value))
+		} else {
+			value = object.Description
+			message.Args = append(message.Args, value)
+			parts = append(parts, fmt.Sprint(value))
+		}
+	}
+	message.Text = strings.Join(parts, " ")
+	s.consoleMu.Lock()
+	s.consoleMessages = append(s.consoleMessages, message)
+	s.consoleMu.Unlock()
+}
+
+func (s *Session) clearConsoleMessages() {
+	s.consoleMu.Lock()
+	s.consoleMessages = nil
+	s.consoleMu.Unlock()
+}

--- a/engine/emulation.go
+++ b/engine/emulation.go
@@ -1,0 +1,150 @@
+package engine
+
+import (
+	"context"
+
+	cdpbrowser "github.com/chromedp/cdproto/browser"
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/emulation"
+	"github.com/chromedp/chromedp"
+)
+
+type DeviceMetrics struct {
+	Width             int
+	Height            int
+	DeviceScaleFactor float64
+	Mobile            bool
+}
+
+type Geolocation struct{ Latitude, Longitude, Accuracy float64 }
+
+type Permission string
+
+const (
+	PermissionGeolocation   Permission = "geolocation"
+	PermissionNotifications Permission = "notifications"
+	PermissionCamera        Permission = "videoCapture"
+	PermissionMicrophone    Permission = "audioCapture"
+)
+
+type PermissionState string
+
+const (
+	PermissionGranted PermissionState = "granted"
+	PermissionDenied  PermissionState = "denied"
+	PermissionPrompt  PermissionState = "prompt"
+)
+
+type Media struct {
+	Type          string
+	ColorScheme   string
+	ReducedMotion string
+}
+
+func (s *Session) SetDeviceMetrics(ctx context.Context, metrics DeviceMetrics) error {
+	if metrics.Width <= 0 || metrics.Height <= 0 || metrics.DeviceScaleFactor <= 0 {
+		return &Error{Code: CodeInvalidArgument, Operation: "set device metrics", Message: "width, height, and device scale factor must be positive"}
+	}
+	return s.serial(ctx, "set device metrics", func(opCtx context.Context) error {
+		return chromedp.Run(opCtx, emulation.SetDeviceMetricsOverride(int64(metrics.Width), int64(metrics.Height), metrics.DeviceScaleFactor, metrics.Mobile))
+	})
+}
+
+func (s *Session) ClearDeviceMetrics(ctx context.Context) error {
+	return s.serial(ctx, "clear device metrics", clearDeviceMetrics)
+}
+func clearDeviceMetrics(ctx context.Context) error {
+	return chromedp.Run(ctx, emulation.ClearDeviceMetricsOverride())
+}
+
+func (s *Session) SetGeolocation(ctx context.Context, location Geolocation) error {
+	if location.Latitude < -90 || location.Latitude > 90 || location.Longitude < -180 || location.Longitude > 180 || location.Accuracy < 0 {
+		return &Error{Code: CodeInvalidArgument, Operation: "set geolocation", Message: "latitude, longitude, or accuracy is outside its valid range"}
+	}
+	return s.serial(ctx, "set geolocation", func(opCtx context.Context) error {
+		return chromedp.Run(opCtx, chromedp.ActionFunc(func(runCtx context.Context) error {
+			// Pointers preserve valid zero coordinates. The generated CDP params use omitzero and would
+			// otherwise turn latitude/longitude 0 into "position unavailable".
+			params := struct {
+				Latitude  *float64 `json:"latitude"`
+				Longitude *float64 `json:"longitude"`
+				Accuracy  *float64 `json:"accuracy"`
+			}{Latitude: &location.Latitude, Longitude: &location.Longitude, Accuracy: &location.Accuracy}
+			return cdp.Execute(runCtx, emulation.CommandSetGeolocationOverride, &params, nil)
+		}))
+	})
+}
+
+func (s *Session) ClearGeolocation(ctx context.Context) error {
+	return s.serial(ctx, "clear geolocation", clearGeolocation)
+}
+func clearGeolocation(ctx context.Context) error {
+	return chromedp.Run(ctx, emulation.ClearGeolocationOverride())
+}
+
+func (s *Session) SetPermissions(ctx context.Context, origin string, permissions map[Permission]PermissionState) error {
+	return s.serial(ctx, "set permissions", func(opCtx context.Context) error {
+		return s.withBrowserExecutor(opCtx, func(browserCtx context.Context) error {
+			for permission, state := range permissions {
+				setting := cdpbrowser.PermissionSetting(state)
+				if setting != cdpbrowser.PermissionSettingGranted && setting != cdpbrowser.PermissionSettingDenied && setting != cdpbrowser.PermissionSettingPrompt {
+					return &Error{Code: CodeInvalidArgument, Operation: "set permissions", Message: "permission state must be granted, denied, or prompt", Observed: state}
+				}
+				descriptor := &cdpbrowser.PermissionDescriptor{Name: string(permission)}
+				if err := cdpbrowser.SetPermission(descriptor, setting).WithOrigin(origin).WithBrowserContextID(s.browserContextID).Do(browserCtx); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	})
+}
+
+func (s *Session) ResetPermissions(ctx context.Context) error {
+	return s.serial(ctx, "reset permissions", s.resetPermissions)
+}
+func (s *Session) resetPermissions(ctx context.Context) error {
+	return s.withBrowserExecutor(ctx, func(browserCtx context.Context) error {
+		return cdpbrowser.ResetPermissions().WithBrowserContextID(s.browserContextID).Do(browserCtx)
+	})
+}
+
+func (s *Session) SetLocale(ctx context.Context, locale string) error {
+	return s.serial(ctx, "set locale", func(opCtx context.Context) error { return setLocale(opCtx, locale) })
+}
+func (s *Session) ClearLocale(ctx context.Context) error { return s.SetLocale(ctx, "") }
+func setLocale(ctx context.Context, locale string) error {
+	return chromedp.Run(ctx, emulation.SetLocaleOverride().WithLocale(locale))
+}
+
+func (s *Session) SetTimezone(ctx context.Context, timezone string) error {
+	return s.serial(ctx, "set timezone", func(opCtx context.Context) error { return setTimezone(opCtx, timezone) })
+}
+func (s *Session) ClearTimezone(ctx context.Context) error { return s.SetTimezone(ctx, "") }
+func setTimezone(ctx context.Context, timezone string) error {
+	return chromedp.Run(ctx, emulation.SetTimezoneOverride(timezone))
+}
+
+func (s *Session) SetMedia(ctx context.Context, media Media) error {
+	return s.serial(ctx, "set media", func(opCtx context.Context) error { return setMedia(opCtx, media) })
+}
+func (s *Session) ClearMedia(ctx context.Context) error { return s.SetMedia(ctx, Media{}) }
+func setMedia(ctx context.Context, media Media) error {
+	features := []*emulation.MediaFeature{}
+	if media.ColorScheme != "" {
+		features = append(features, &emulation.MediaFeature{Name: "prefers-color-scheme", Value: media.ColorScheme})
+	}
+	if media.ReducedMotion != "" {
+		features = append(features, &emulation.MediaFeature{Name: "prefers-reduced-motion", Value: media.ReducedMotion})
+	}
+	return chromedp.Run(ctx, emulation.SetEmulatedMedia().WithMedia(media.Type).WithFeatures(features))
+}
+
+func (s *Session) resetEmulation(ctx context.Context) error {
+	for _, reset := range []func(context.Context) error{clearDeviceMetrics, clearGeolocation, func(c context.Context) error { return setLocale(c, "") }, func(c context.Context) error { return setTimezone(c, "") }, func(c context.Context) error { return setMedia(c, Media{}) }, s.resetPermissions} {
+		if err := reset(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/engine/export_test.go
+++ b/engine/export_test.go
@@ -9,7 +9,7 @@ func SessionContextForTest(session *Session) context.Context {
 }
 
 // HTTPStatusFailureForTest exposes the classifier NavigateContext uses to tell Chrome's
-// loading failure for a 4xx/5xx document from a genuine transport/target failure.  Which
+// loading failure for a 4xx/5xx document from a genuine transport/target failure. Which
 // responses Chrome reports that way varies by Chrome version, so the classification is pinned
 // here rather than by racing a browser that may or may not produce the error.
 func HTTPStatusFailureForTest(err error) bool {
@@ -20,4 +20,16 @@ func HTTPStatusFailureForTest(err error) bool {
 // recovery state machine to be tested without disturbing other specs sharing the test browser.
 func MarkSessionCrashedForTest(session *Session) {
 	session.markCrashed()
+}
+
+// SetHeadlessShellInstallerForTest replaces the network installer for deterministic acquisition specs.
+func SetHeadlessShellInstallerForTest(installer func(context.Context) (string, error)) func() {
+	previous := headlessShellInstaller
+	headlessShellInstaller = installer
+	return func() { headlessShellInstaller = previous }
+}
+
+// InstallHeadlessShellArchiveForTest exercises atomic cache publication without network access.
+func InstallHeadlessShellArchiveForTest(archivePath, destination, platform string) error {
+	return installHeadlessShellArchive(archivePath, destination, platform)
 }

--- a/engine/frame.go
+++ b/engine/frame.go
@@ -30,9 +30,15 @@ func (f *Frame) URL() string { return f.url }
 func (f *Frame) Close() error {
 	f.closeOnce.Do(func() {
 		f.Session.mu.Lock()
-		f.Session.closed = true
-		f.Session.cancel()
+		if !f.Session.closed {
+			f.Session.closed = true
+			f.Session.cancel()
+		}
+		browser := f.Session.browser
 		f.Session.mu.Unlock()
+		if browser != nil {
+			browser.removeSession(f.Session)
+		}
 	})
 	return nil
 }
@@ -156,6 +162,9 @@ func (s *Session) attachFrame(ctx context.Context, info *target.Info) (*Frame, e
 	if err := ctx.Err(); err != nil {
 		return nil, contextError("attach frame", err)
 	}
+	if existing := s.browser.frameSession(info.TargetID); existing != nil {
+		return &Frame{Session: existing, url: info.URL}, nil
+	}
 	frameCtx, cancelFrame := chromedp.NewContext(s.browser.ctx, chromedp.WithTargetID(info.TargetID))
 	var ready any
 	if err := chromedp.Run(frameCtx, chromedp.Evaluate("1", &ready)); err != nil {
@@ -167,10 +176,47 @@ func (s *Session) attachFrame(ctx context.Context, info *target.Info) (*Frame, e
 	frameSession := &Session{
 		browser: s.browser, ctx: frameCtx, cancel: cancelFrame,
 		browserContextID: s.browserContextID, targetID: info.TargetID,
-		root: s.contextRoot(), artifactDir: s.artifactDir,
+		root: s.contextRoot(), artifactDir: s.artifactDir, frameTarget: true,
+	}
+	registered, err := s.browser.registerFrameSession(frameSession)
+	if err != nil {
+		frameSession.closed = true
+		cancelFrame()
+		return nil, err
+	}
+	if registered != frameSession {
+		frameSession.closed = true
+		cancelFrame()
+		return &Frame{Session: registered, url: info.URL}, nil
 	}
 	s.browser.listenToSession(frameSession)
 	return &Frame{Session: frameSession, url: info.URL}, nil
+}
+
+func (b *Browser) frameSession(targetID target.ID) *Session {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for session := range b.sessions {
+		if session.targetID == targetID {
+			return session
+		}
+	}
+	return nil
+}
+
+func (b *Browser) registerFrameSession(frame *Session) (*Session, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil, &Error{Code: CodeSessionClosed, Operation: "attach frame", Message: "browser is closed"}
+	}
+	for session := range b.sessions {
+		if session.targetID == frame.targetID {
+			return session, nil
+		}
+	}
+	b.sessions[frame] = struct{}{}
+	return frame, nil
 }
 
 func protectFrameTarget(frameCtx context.Context) {

--- a/engine/frame.go
+++ b/engine/frame.go
@@ -1,0 +1,184 @@
+package engine
+
+import (
+	"context"
+	"sync"
+
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/target"
+	"github.com/chromedp/chromedp"
+)
+
+// FrameQuery selects an out-of-process iframe by its target metadata and document state.
+type FrameQuery struct {
+	Title      *Expectation
+	URL        *Expectation
+	HasElement *Selector
+}
+
+// Frame is a DOM-capable handle attached to a cross-origin iframe target.
+type Frame struct {
+	*Session
+	url       string
+	closeOnce sync.Once
+}
+
+// URL returns the target URL observed when the frame was discovered.
+func (f *Frame) URL() string { return f.url }
+
+// Close detaches this handle without removing the iframe from its parent document.
+func (f *Frame) Close() error {
+	f.closeOnce.Do(func() {
+		f.Session.mu.Lock()
+		f.Session.closed = true
+		f.Session.cancel()
+		f.Session.mu.Unlock()
+	})
+	return nil
+}
+
+// Frames returns handles for every out-of-process iframe in this session's browser context.
+func (s *Session) Frames(ctx context.Context) ([]*Frame, error) {
+	infos, err := s.frameTargetInfos(ctx)
+	if err != nil {
+		return nil, err
+	}
+	frames := make([]*Frame, 0, len(infos))
+	for _, info := range infos {
+		frame, attachErr := s.attachFrame(ctx, info)
+		if attachErr != nil {
+			for _, attached := range frames {
+				_ = attached.Close()
+			}
+			return nil, attachErr
+		}
+		frames = append(frames, frame)
+	}
+	return frames, nil
+}
+
+// WaitForFrame discovers a matching cross-origin frame and waits for its document predicate.
+func (s *Session) WaitForFrame(ctx context.Context, query FrameQuery, policy PollPolicy) (*Frame, error) {
+	var candidate *Frame
+	_, err := Poll(ctx, policy, func(attemptCtx context.Context) (Observation, bool, error) {
+		if candidate == nil {
+			infos, listErr := s.frameTargetInfos(attemptCtx)
+			if listErr != nil {
+				return Observation{}, false, listErr
+			}
+			for _, info := range infos {
+				matched, matchErr := frameMetadataMatches(info, query)
+				if matchErr != nil {
+					return Observation{}, false, matchErr
+				}
+				if !matched {
+					continue
+				}
+				candidate, matchErr = s.attachFrame(attemptCtx, info)
+				if matchErr != nil {
+					return Observation{Value: info.URL}, false, matchErr
+				}
+				break
+			}
+		}
+		if candidate == nil {
+			return Observation{Value: "no matching frame target"}, false, nil
+		}
+		if query.HasElement == nil {
+			return Observation{Value: candidate.url}, true, nil
+		}
+		exists, existsErr := candidate.Exists(attemptCtx, *query.HasElement)
+		if existsErr != nil {
+			return exists, false, existsErr
+		}
+		found, _ := exists.Value.(bool)
+		return exists, found, nil
+	})
+	if err != nil {
+		if candidate != nil {
+			_ = candidate.Close()
+		}
+		return nil, err
+	}
+	return candidate, nil
+}
+
+func (s *Session) frameTargetInfos(ctx context.Context) ([]*target.Info, error) {
+	s.mu.Lock()
+	closed := s.closed
+	s.mu.Unlock()
+	if closed {
+		return nil, &Error{Code: CodeSessionClosed, Operation: "list frames", Message: "session is closed"}
+	}
+	if s.browser == nil {
+		return nil, &Error{Code: CodeSessionClosed, Operation: "list frames", Message: "browser is closed"}
+	}
+	opCtx, cancel := executorContext(s.browser.ctx, ctx)
+	defer cancel()
+	chrome := chromedp.FromContext(opCtx)
+	infos, err := target.GetTargets().Do(cdp.WithExecutor(opCtx, chrome.Browser))
+	if err != nil {
+		return nil, contextError("list frames", err)
+	}
+	frames := make([]*target.Info, 0)
+	descendants := map[target.ID]bool{s.targetID: true}
+	for added := true; added; {
+		added = false
+		for _, info := range infos {
+			if info.Type != "iframe" || info.BrowserContextID != s.browserContextID || descendants[info.TargetID] || !descendants[info.ParentID] {
+				continue
+			}
+			descendants[info.TargetID] = true
+			frames = append(frames, info)
+			added = true
+		}
+	}
+	return frames, nil
+}
+
+func frameMetadataMatches(info *target.Info, query FrameQuery) (bool, error) {
+	for _, value := range []struct {
+		actual      string
+		expectation *Expectation
+	}{{info.Title, query.Title}, {info.URL, query.URL}} {
+		if value.expectation == nil {
+			continue
+		}
+		matched, err := MatchExpectation(value.actual, *value.expectation)
+		if err != nil || !matched {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func (s *Session) attachFrame(ctx context.Context, info *target.Info) (*Frame, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, contextError("attach frame", err)
+	}
+	frameCtx, cancelFrame := chromedp.NewContext(s.browser.ctx, chromedp.WithTargetID(info.TargetID))
+	var ready any
+	if err := chromedp.Run(frameCtx, chromedp.Evaluate("1", &ready)); err != nil {
+		protectFrameTarget(frameCtx)
+		cancelFrame()
+		return nil, contextError("attach frame", err)
+	}
+	protectFrameTarget(frameCtx)
+	frameSession := &Session{
+		browser: s.browser, ctx: frameCtx, cancel: cancelFrame,
+		browserContextID: s.browserContextID, targetID: info.TargetID,
+		root: s.contextRoot(), artifactDir: s.artifactDir,
+	}
+	s.browser.listenToSession(frameSession)
+	return &Frame{Session: frameSession, url: info.URL}, nil
+}
+
+func protectFrameTarget(frameCtx context.Context) {
+	frameContext := chromedp.FromContext(frameCtx)
+	if frameContext == nil || frameContext.Target == nil {
+		return
+	}
+	// chromedp closes any target it attached when its context is cancelled. This target belongs to
+	// the parent page, so retain the session ID for normal detachment but suppress target closure.
+	frameContext.Target.TargetID = ""
+}

--- a/engine/frame_test.go
+++ b/engine/frame_test.go
@@ -71,5 +71,8 @@ var _ = Describe("cross-origin frame targets", func() {
 		})
 		Expect(rootFrames).To(HaveLen(1), "a sibling tab's frame must not leak into this session")
 		Expect(rootFrames[0].URL()).To(HaveSuffix("/destination"))
+		Expect(root.Prepare(ctx)).To(Succeed())
+		_, err = rootFrames[0].Text(ctx, engine.TestID("destination"))
+		Expect(err).To(MatchError(ContainSubstring("session is closed")))
 	})
 })

--- a/engine/frame_test.go
+++ b/engine/frame_test.go
@@ -1,0 +1,75 @@
+package engine_test
+
+import (
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/biloba/engine"
+)
+
+var _ = Describe("cross-origin frame targets", func() {
+	It("discovers an isolated frame and drives its DOM through a scoped handle", func(ctx SpecContext) {
+		isolatedBrowser, err := engine.StartBrowser(ctx, engine.BrowserConfig{
+			ExecutablePath: chromePath(),
+			Arguments:      []string{"--site-per-process"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(isolatedBrowser.Close)
+		root, err := isolatedBrowser.OpenSession(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(root.Close)
+		Expect(root.Navigate(ctx, server.URL)).To(Succeed())
+
+		frameURL := strings.Replace(server.URL, "127.0.0.1", "localhost", 1) + "/destination"
+		_, err = root.Evaluate(ctx, `(() => { const frame = document.createElement("iframe"); frame.src = `+strconv.Quote(frameURL)+`; document.body.append(frame) })()`)
+		Expect(err).NotTo(HaveOccurred())
+
+		frame, err := root.WaitForFrame(ctx, engine.FrameQuery{
+			URL:        &engine.Expectation{Kind: engine.ExpectSuffix, Expected: "/destination"},
+			HasElement: selectorPtr(engine.TestID("destination")),
+		}, engine.PollPolicy{Timeout: 2 * time.Second, Interval: 5 * time.Millisecond})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(frame.Close)
+
+		parsed, err := url.Parse(frame.URL())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(parsed.Hostname()).To(Equal("localhost"))
+		text, err := frame.Text(ctx, engine.TestID("destination"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(text.Value).To(Equal("arrived"))
+		Expect(frame.Close()).To(Succeed())
+		stillPresent, err := root.Evaluate(ctx, `document.querySelector("iframe") !== null`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stillPresent).To(BeTrue())
+		_, err = frame.Text(ctx, engine.TestID("destination"))
+		Expect(err).To(MatchError(ContainSubstring("session is closed")))
+
+		sibling, err := root.NewTab(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(sibling.Close)
+		Expect(sibling.Navigate(ctx, server.URL)).To(Succeed())
+		siblingFrameURL := strings.Replace(server.URL, "127.0.0.1", "localhost", 1) + "/dom-surface"
+		_, err = sibling.Evaluate(ctx, `(() => { const frame = document.createElement("iframe"); frame.src = `+strconv.Quote(siblingFrameURL)+`; document.body.append(frame) })()`)
+		Expect(err).NotTo(HaveOccurred())
+		siblingFrame, err := sibling.WaitForFrame(ctx, engine.FrameQuery{
+			URL: &engine.Expectation{Kind: engine.ExpectSuffix, Expected: "/dom-surface"},
+		}, engine.PollPolicy{Timeout: 2 * time.Second, Interval: 5 * time.Millisecond})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(siblingFrame.Close()).To(Succeed())
+
+		rootFrames, err := root.Frames(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			for _, discovered := range rootFrames {
+				_ = discovered.Close()
+			}
+		})
+		Expect(rootFrames).To(HaveLen(1), "a sibling tab's frame must not leak into this session")
+		Expect(rootFrames[0].URL()).To(HaveSuffix("/destination"))
+	})
+})

--- a/engine/input.go
+++ b/engine/input.go
@@ -23,6 +23,16 @@ func EmulateViewportContext(ctx context.Context, width, height int, opts ...chro
 	return chromedp.Run(ctx, chromedp.EmulateViewport(int64(width), int64(height), opts...))
 }
 
+// EmulateViewportMatchingScreenContext keeps full headless Chrome's compositor surface aligned
+// with its layout viewport, so trusted input is not clipped to Chrome's default 800x600 screen.
+func EmulateViewportMatchingScreenContext(ctx context.Context, width, height int) error {
+	matchScreen := func(metrics *emulation.SetDeviceMetricsOverrideParams, _ *emulation.SetTouchEmulationEnabledParams) {
+		metrics.ScreenWidth = metrics.Width
+		metrics.ScreenHeight = metrics.Height
+	}
+	return EmulateViewportContext(ctx, width, height, matchScreen)
+}
+
 // KeyEventContext dispatches keys as real keyboard events, so keydown/keypress/keyup all fire.
 func KeyEventContext(ctx context.Context, keys string, opts ...chromedp.KeyOption) error {
 	if keys == "" {

--- a/engine/javascript_state.go
+++ b/engine/javascript_state.go
@@ -1,0 +1,32 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+)
+
+func (s *Session) WaitForDefined(ctx context.Context, expression string, policy PollPolicy) (PollResult, error) {
+	script := "(() => { const value = (" + expression + "); return {defined: value !== undefined, value}; })()"
+	return Poll(ctx, policy, func(attemptCtx context.Context) (Observation, bool, error) {
+		var envelope struct {
+			Defined bool            `json:"defined"`
+			Value   json.RawMessage `json:"value"`
+		}
+		err := s.serial(attemptCtx, "wait for defined JavaScript value", func(opCtx context.Context) error {
+			return EvaluateContext(opCtx, script, false, &envelope)
+		})
+		if err != nil {
+			return Observation{}, false, err
+		}
+		if !envelope.Defined {
+			return Observation{}, false, nil
+		}
+		var value any
+		if len(envelope.Value) > 0 {
+			if err := json.Unmarshal(envelope.Value, &value); err != nil {
+				return Observation{}, false, Fatal(err)
+			}
+		}
+		return Observation{Value: value}, true, nil
+	})
+}

--- a/engine/lifecycle_foundations_test.go
+++ b/engine/lifecycle_foundations_test.go
@@ -1,6 +1,9 @@
 package engine_test
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -189,6 +192,157 @@ var _ = Describe("lifecycle engine foundations", func() {
 		userAgent, err := session.Evaluate(ctx, `navigator.userAgent`)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(userAgent).To(Equal("BilobaLifecycleTest"))
+	})
+
+	It("uses Go's 1024 by 768 starting size when none is configured", func(ctx SpecContext) {
+		launched, err := engine.StartBrowser(ctx, engine.BrowserConfig{ExecutablePath: chromePath()})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(launched.Close)
+		session, err := launched.OpenSession(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(session.Close)
+
+		width, height, err := session.WindowSize(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(width).To(Equal(1024))
+		Expect(height).To(Equal(768))
+
+		metadata := launched.LaunchMetadata()
+		Expect(metadata.Mode).To(Equal(engine.ChromeModeHeadlessShell))
+		Expect(metadata.ExecutablePath).To(Equal(chromePath()))
+		Expect(metadata.WindowWidth).To(Equal(1024))
+		Expect(metadata.WindowHeight).To(Equal(768))
+		Expect(metadata.Attached).To(BeFalse())
+		metadata.Arguments = append(metadata.Arguments, "--mutated")
+		Expect(launched.LaunchMetadata().Arguments).To(BeEmpty(), "metadata snapshots must not mutate browser state")
+	})
+
+	It("rejects malformed raw Chrome arguments before launching", func(ctx SpecContext) {
+		_, err := engine.StartBrowser(ctx, engine.BrowserConfig{
+			ExecutablePath: chromePath(),
+			Arguments:      []string{"--bad name=value"},
+		})
+		Expect(err).To(MatchError(ContainSubstring("Chrome argument name")))
+	})
+
+	It("accepts headful mode as a full-Chrome launch mode", func(ctx SpecContext) {
+		canceled, cancel := context.WithCancel(ctx)
+		cancel()
+		_, err := engine.StartBrowser(canceled, engine.BrowserConfig{
+			ExecutablePath: "/usr/bin/google-chrome",
+			Mode:           engine.ChromeMode("headful"),
+			Arguments:      []string{"--no-sandbox"},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).NotTo(ContainSubstring("mode must"))
+	})
+
+	It("resolves an installed full Chrome for high-fidelity mode", func(ctx SpecContext) {
+		launched, err := engine.StartBrowser(ctx, engine.BrowserConfig{
+			Mode:      engine.ChromeModeHeadless,
+			Arguments: []string{"--no-sandbox"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(launched.Close)
+		Expect(launched.LaunchMetadata().ExecutablePath).NotTo(BeEmpty())
+	})
+
+	It("does not invent launch metadata for an attached browser", func(ctx SpecContext) {
+		attached, err := engine.StartBrowser(ctx, engine.BrowserConfig{
+			WebSocketURL: browser.WebSocketURL(),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(attached.Close)
+
+		metadata := attached.LaunchMetadata()
+		Expect(metadata.Attached).To(BeTrue())
+		Expect(metadata.Mode).To(BeEmpty())
+		Expect(metadata.ExecutablePath).To(BeEmpty())
+		Expect(metadata.WindowWidth).To(BeZero())
+		Expect(metadata.WindowHeight).To(BeZero())
+
+		session, err := attached.OpenSession(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(session.Close)
+		width, height, err := session.WindowSize(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(width).To(Equal(1024))
+		Expect(height).To(Equal(768))
+	})
+
+	It("keeps the default mode compatible with an explicitly supplied full Chrome", func(ctx SpecContext) {
+		launched, err := engine.StartBrowser(ctx, engine.BrowserConfig{
+			ExecutablePath: engine.LocateFullChrome(""),
+			Arguments:      []string{"--no-sandbox"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(launched.Close)
+		Expect(launched.LaunchMetadata().Mode).To(Equal(engine.ChromeModeHeadlessShell))
+		session, err := launched.OpenSession(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(session.Close)
+		value, err := session.Evaluate(ctx, `1 + 1`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(value).To(BeNumerically("==", 2))
+	})
+
+	It("never installs the headless shell unless explicitly opted in", func(ctx SpecContext) {
+		GinkgoT().Setenv(engine.ChromeEnvVar, "")
+		GinkgoT().Setenv("PATH", "")
+		GinkgoT().Setenv("HOME", GinkgoT().TempDir())
+		GinkgoT().Setenv("XDG_CACHE_HOME", GinkgoT().TempDir())
+		installedPath := filepath.Join(GinkgoT().TempDir(), engine.ChromeBinaryName())
+		Expect(os.WriteFile(installedPath, []byte("binary"), 0o755)).To(Succeed())
+		calls := 0
+		restore := engine.SetHeadlessShellInstallerForTest(func(context.Context) (string, error) {
+			calls++
+			return installedPath, nil
+		})
+		DeferCleanup(restore)
+
+		_, _, err := engine.ResolveHeadlessShell(ctx, "", false)
+		Expect(err).To(MatchError(ContainSubstring("could not find chrome-headless-shell")))
+		Expect(calls).To(BeZero())
+
+		path, autoInstalled, err := engine.ResolveHeadlessShell(ctx, "", true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(path).To(Equal(installedPath))
+		Expect(autoInstalled).To(BeTrue())
+		Expect(calls).To(Equal(1))
+	})
+
+	It("reasserts the high-fidelity viewport after navigation and restores it during prepare", func(ctx SpecContext) {
+		launched, err := engine.StartBrowser(ctx, engine.BrowserConfig{
+			ExecutablePath: "/usr/bin/google-chrome",
+			Mode:           engine.ChromeModeHeadless,
+			Arguments:      []string{"--no-sandbox"},
+			WindowWidth:    640,
+			WindowHeight:   480,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(launched.Close)
+		session, err := launched.OpenSession(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(session.Close)
+
+		Expect(session.SetWindowSize(ctx, 700, 650)).To(Succeed())
+		Expect(session.Navigate(ctx, server.URL)).To(Succeed())
+		state, err := session.Evaluate(ctx, `[innerWidth, innerHeight, screen.width, screen.height]`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state).To(Equal([]any{float64(700), float64(650), float64(700), float64(650)}))
+
+		_, err = session.Evaluate(ctx, `void window.open("about:blank", "_blank")`)
+		Expect(err).NotTo(HaveOccurred())
+		spawned, err := session.WaitForTab(ctx, engine.TabQuery{SpawnedOnly: true}, engine.PollPolicy{Timeout: time.Second})
+		Expect(err).NotTo(HaveOccurred())
+		spawnedState, err := spawned.Evaluate(ctx, `[innerWidth, innerHeight, screen.width, screen.height]`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(spawnedState).To(Equal([]any{float64(640), float64(480), float64(640), float64(480)}))
+
+		Expect(session.Prepare(ctx)).To(Succeed())
+		state, err = session.Evaluate(ctx, `[innerWidth, innerHeight, screen.width, screen.height]`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state).To(Equal([]any{float64(640), float64(480), float64(640), float64(480)}))
 	})
 })
 

--- a/engine/lifecycle_foundations_test.go
+++ b/engine/lifecycle_foundations_test.go
@@ -25,12 +25,12 @@ var _ = Describe("lifecycle engine foundations", func() {
 		Expect(root.OwnsContext()).To(BeTrue())
 		Expect(sibling.ContextID()).To(Equal(root.ContextID()))
 		Expect(sibling.OwnsContext()).To(BeFalse())
-		Expect(browser.Sessions()).To(ContainElements(root, sibling))
+		Expect(sessionTargetIDs(browser.Sessions())).To(ContainElements(string(root.TargetID()), string(sibling.TargetID())))
 
 		Expect(root.Prepare(ctx)).To(Succeed())
 		_, err = sibling.Evaluate(ctx, "1")
 		Expect(err).To(MatchError(ContainSubstring("session is closed")))
-		Expect(browser.Sessions()).To(ConsistOf(root))
+		Expect(sessionTargetIDs(browser.Sessions())).To(ConsistOf(string(root.TargetID())))
 	})
 
 	It("invalidates descendant handles when their context owner closes", func(ctx SpecContext) {
@@ -42,7 +42,7 @@ var _ = Describe("lifecycle engine foundations", func() {
 		Expect(root.Close()).To(Succeed())
 		_, err = sibling.Evaluate(ctx, "1")
 		Expect(err).To(MatchError(ContainSubstring("session is closed")))
-		Expect(browser.Sessions()).NotTo(ContainElements(root, sibling))
+		Expect(sessionTargetIDs(browser.Sessions())).NotTo(ContainElements(string(root.TargetID()), string(sibling.TargetID())))
 	})
 
 	It("discovers a spawned tab and can wait for it by typed query", func(ctx SpecContext) {
@@ -347,3 +347,11 @@ var _ = Describe("lifecycle engine foundations", func() {
 })
 
 func selectorPtr(selector engine.Selector) *engine.Selector { return &selector }
+
+func sessionTargetIDs(sessions []*engine.Session) []string {
+	ids := make([]string, 0, len(sessions))
+	for _, session := range sessions {
+		ids = append(ids, string(session.TargetID()))
+	}
+	return ids
+}

--- a/engine/lifecycle_foundations_test.go
+++ b/engine/lifecycle_foundations_test.go
@@ -1,0 +1,195 @@
+package engine_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/biloba/engine"
+)
+
+var _ = Describe("lifecycle engine foundations", func() {
+	It("exposes ownership metadata and closes every context descendant during root prepare", func(ctx SpecContext) {
+		root, err := browser.OpenSession(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(root.Close)
+		sibling, err := root.NewTab(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(root.ContextID()).NotTo(BeEmpty())
+		Expect(root.TargetID()).NotTo(BeEmpty())
+		Expect(root.OwnsContext()).To(BeTrue())
+		Expect(sibling.ContextID()).To(Equal(root.ContextID()))
+		Expect(sibling.OwnsContext()).To(BeFalse())
+		Expect(browser.Sessions()).To(ContainElements(root, sibling))
+
+		Expect(root.Prepare(ctx)).To(Succeed())
+		_, err = sibling.Evaluate(ctx, "1")
+		Expect(err).To(MatchError(ContainSubstring("session is closed")))
+		Expect(browser.Sessions()).To(ConsistOf(root))
+	})
+
+	It("invalidates descendant handles when their context owner closes", func(ctx SpecContext) {
+		root, err := browser.OpenSession(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		sibling, err := root.NewTab(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(root.Close()).To(Succeed())
+		_, err = sibling.Evaluate(ctx, "1")
+		Expect(err).To(MatchError(ContainSubstring("session is closed")))
+		Expect(browser.Sessions()).NotTo(ContainElements(root, sibling))
+	})
+
+	It("discovers a spawned tab and can wait for it by typed query", func(ctx SpecContext) {
+		root, err := browser.OpenSession(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(root.Close)
+		Expect(root.Navigate(ctx, server.URL)).To(Succeed())
+
+		_, err = root.Evaluate(ctx, `void window.open("/destination", "_blank")`)
+		Expect(err).NotTo(HaveOccurred())
+		tab, err := root.WaitForTab(ctx, engine.TabQuery{
+			SpawnedOnly: true,
+			URL:         &engine.Expectation{Kind: engine.ExpectSuffix, Expected: "/destination"},
+			HasElement:  selectorPtr(engine.TestID("destination")),
+		}, engine.PollPolicy{Timeout: time.Second, Interval: 5 * time.Millisecond})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tab).NotTo(BeNil())
+		Expect(tab.ContextID()).To(Equal(root.ContextID()))
+	})
+
+	It("provides typed cookie, storage, page, and defined-JavaScript operations", func(ctx SpecContext) {
+		session, err := browser.OpenSession(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(session.Close)
+		Expect(session.Navigate(ctx, server.URL)).To(Succeed())
+
+		local := session.Storage(engine.StorageLocal)
+		Expect(local.Set(ctx, "count", 3)).To(Succeed())
+		Expect(local.Set(ctx, "raw", "value")).To(Succeed())
+		value, found, err := local.Get(ctx, "count")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(value).To(BeNumerically("==", 3))
+		length, err := local.Length(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(length).To(Equal(2))
+		all, err := local.GetAll(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(all).To(Equal(map[string]any{"count": float64(3), "raw": "value"}))
+		Expect(local.Remove(ctx, "raw")).To(Succeed())
+		Expect(local.Clear(ctx)).To(Succeed())
+
+		_, err = session.Evaluate(ctx, `setTimeout(() => window.__readyValue = {ready: true}, 30)`)
+		Expect(err).NotTo(HaveOccurred())
+		defined, err := session.WaitForDefined(ctx, `window.__readyValue`, engine.PollPolicy{Timeout: time.Second})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(defined.Final.Value).To(Equal(map[string]any{"ready": true}))
+
+		_, err = session.Evaluate(ctx, `document.title = "Lifecycle"`)
+		Expect(err).NotTo(HaveOccurred())
+		title, err := session.Title(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(title).To(Equal("Lifecycle"))
+		width, height, err := session.WindowSize(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(width).To(BeNumerically(">", 0))
+		Expect(height).To(BeNumerically(">", 0))
+		outline, err := session.Outline(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(outline).To(ContainSubstring(`<button aria-label="Save">`))
+		a11y, err := session.AccessibilityOutline(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(a11y).To(ContainSubstring(`button "Save"`))
+
+		Expect(session.SetCookies(ctx, []engine.Cookie{{Name: "clear-me", Value: "yes", Domain: "127.0.0.1", Path: "/"}})).To(Succeed())
+		Expect(session.ClearCookies(ctx)).To(Succeed())
+		cookies, err := session.GetCookies(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cookies).To(BeEmpty())
+	})
+
+	It("records console events and clears their history during prepare", func(ctx SpecContext) {
+		session, err := browser.OpenSession(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(session.Close)
+		Expect(session.Navigate(ctx, server.URL)).To(Succeed())
+		_, err = session.Evaluate(ctx, `console.warn("careful", {count: 2})`)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session.ConsoleMessages).Should(ContainElement(SatisfyAll(
+			HaveField("Type", Equal("warning")),
+			HaveField("Text", ContainSubstring("careful")),
+		)))
+		Expect(session.Prepare(ctx)).To(Succeed())
+		Expect(session.ConsoleMessages()).To(BeEmpty())
+	})
+
+	It("removes registered init scripts during prepare", func(ctx SpecContext) {
+		session, err := browser.OpenSession(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(session.Close)
+		Expect(session.AddInitScript(ctx, `window.__leakedInit = true`)).To(Succeed())
+		Expect(session.Navigate(ctx, server.URL)).To(Succeed())
+		value, err := session.Evaluate(ctx, `window.__leakedInit`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(value).To(BeTrue())
+
+		Expect(session.Prepare(ctx)).To(Succeed())
+		Expect(session.Navigate(ctx, server.URL)).To(Succeed())
+		value, err = session.Evaluate(ctx, `typeof window.__leakedInit`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(value).To(Equal("undefined"))
+	})
+
+	It("applies typed emulation and restores every override during prepare", func(ctx SpecContext) {
+		session, err := browser.OpenSession(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(session.Close)
+		Expect(session.Navigate(ctx, server.URL)).To(Succeed())
+
+		Expect(session.SetDeviceMetrics(ctx, engine.DeviceMetrics{Width: 390, Height: 844, DeviceScaleFactor: 2, Mobile: true})).To(Succeed())
+		Expect(session.SetLocale(ctx, "fr-FR")).To(Succeed())
+		Expect(session.SetTimezone(ctx, "America/New_York")).To(Succeed())
+		Expect(session.SetMedia(ctx, engine.Media{ColorScheme: "dark", ReducedMotion: "reduce"})).To(Succeed())
+		state, err := session.Evaluate(ctx, `[screen.width, screen.height, devicePixelRatio, matchMedia("(prefers-color-scheme: dark)").matches, matchMedia("(prefers-reduced-motion: reduce)").matches, Intl.DateTimeFormat().resolvedOptions().timeZone]`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(state).To(Equal([]any{float64(390), float64(844), float64(2), true, true, "America/New_York"}))
+
+		Expect(session.SetPermissions(ctx, server.URL, map[engine.Permission]engine.PermissionState{engine.PermissionGeolocation: engine.PermissionGranted})).To(Succeed())
+		Expect(session.SetGeolocation(ctx, engine.Geolocation{Latitude: 40.7, Longitude: -74, Accuracy: 10})).To(Succeed())
+
+		Expect(session.Prepare(ctx)).To(Succeed())
+		Expect(session.Navigate(ctx, server.URL)).To(Succeed())
+		reset, err := session.Evaluate(ctx, `[innerWidth === 390, devicePixelRatio === 2, matchMedia("(prefers-color-scheme: dark)").matches, matchMedia("(prefers-reduced-motion: reduce)").matches, Intl.DateTimeFormat().resolvedOptions().timeZone === "America/New_York"]`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(reset).To(Equal([]any{false, false, false, false, false}))
+	})
+
+	It("honors runner-neutral Chrome mode, arguments, and starting size", func(ctx SpecContext) {
+		launched, err := engine.StartBrowser(ctx, engine.BrowserConfig{
+			ExecutablePath: chromePath(),
+			Mode:           engine.ChromeModeHeadless,
+			Arguments:      []string{"--user-agent=BilobaLifecycleTest"},
+			WindowWidth:    640,
+			WindowHeight:   480,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(launched.Close)
+		session, err := launched.OpenSession(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(session.Close)
+		Expect(session.Navigate(ctx, server.URL)).To(Succeed())
+
+		width, height, err := session.WindowSize(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(width).To(Equal(640))
+		Expect(height).To(Equal(480))
+		userAgent, err := session.Evaluate(ctx, `navigator.userAgent`)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(userAgent).To(Equal("BilobaLifecycleTest"))
+	})
+})
+
+func selectorPtr(selector engine.Selector) *engine.Selector { return &selector }

--- a/engine/page_state.go
+++ b/engine/page_state.go
@@ -1,0 +1,109 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/chromedp/cdproto/accessibility"
+)
+
+func (s *Session) Title(ctx context.Context) (string, error) {
+	var title string
+	err := s.serial(ctx, "read title", func(opCtx context.Context) error {
+		var readErr error
+		title, readErr = TitleContext(opCtx)
+		return readErr
+	})
+	return title, err
+}
+
+func (s *Session) WindowSize(ctx context.Context) (int, int, error) {
+	var width, height int64
+	err := s.serial(ctx, "read window size", func(opCtx context.Context) error {
+		var readErr error
+		width, height, readErr = ViewportDimensionsContext(opCtx)
+		return readErr
+	})
+	return int(width), int(height), err
+}
+
+func (s *Session) Outline(ctx context.Context) (string, error) {
+	var outline string
+	err := s.serial(ctx, "capture DOM outline", func(opCtx context.Context) error {
+		response, runErr := s.runHandler(opCtx, "outline", Selector{})
+		if runErr != nil {
+			return runErr
+		}
+		outline, _ = response.Result.(string)
+		return nil
+	})
+	return capOutline(outline), err
+}
+
+func (s *Session) AccessibilityOutline(ctx context.Context) (string, error) {
+	var nodes []*accessibility.Node
+	err := s.serial(ctx, "capture accessibility outline", func(opCtx context.Context) error {
+		var readErr error
+		nodes, readErr = AccessibilityTreeContext(opCtx)
+		return readErr
+	})
+	if err != nil {
+		return "", err
+	}
+	return capOutline(renderAccessibilityTree(nodes)), nil
+}
+
+func renderAccessibilityTree(nodes []*accessibility.Node) string {
+	if len(nodes) == 0 {
+		return ""
+	}
+	byID := make(map[accessibility.NodeID]*accessibility.Node, len(nodes))
+	for _, node := range nodes {
+		byID[node.NodeID] = node
+	}
+	root := nodes[0]
+	for _, node := range nodes {
+		if node.ParentID == "" || byID[node.ParentID] == nil {
+			root = node
+			break
+		}
+	}
+	out := &strings.Builder{}
+	var walk func(*accessibility.Node, int)
+	walk = func(node *accessibility.Node, depth int) {
+		nextDepth := depth
+		role := accessibilityValue(node.Role)
+		if !node.Ignored && role != "InlineTextBox" {
+			if role == "" {
+				role = "none"
+			}
+			fmt.Fprintf(out, "%s%s", strings.Repeat("  ", depth), role)
+			if name := accessibilityValue(node.Name); name != "" {
+				fmt.Fprintf(out, " %q", name)
+			}
+			if value := accessibilityValue(node.Value); value != "" {
+				fmt.Fprintf(out, " (value: %q)", value)
+			}
+			out.WriteByte('\n')
+			nextDepth++
+		}
+		for _, id := range node.ChildIDs {
+			if child := byID[id]; child != nil {
+				walk(child, nextDepth)
+			}
+		}
+	}
+	walk(root, 0)
+	return out.String()
+}
+
+func accessibilityValue(value *accessibility.Value) string {
+	if value == nil {
+		return ""
+	}
+	var text string
+	_ = json.Unmarshal(value.Value, &text)
+	return text
+}

--- a/engine/session.go
+++ b/engine/session.go
@@ -51,6 +51,7 @@ type Session struct {
 	targetID         target.ID
 	openerID         target.ID
 	ownsContext      bool
+	frameTarget      bool
 	artifactDir      string
 	mu               sync.Mutex
 	requestMu        sync.Mutex
@@ -145,7 +146,7 @@ func (s *Session) Close() error {
 			return target.DisposeBrowserContext(s.browserContextID).Do(browserCtx)
 		})
 		cancel()
-	} else if s.browser != nil {
+	} else if s.browser != nil && !s.frameTarget {
 		ctx, cancel := context.WithTimeout(s.browser.ctx, 5*time.Second)
 		disposeErr = s.withBrowserExecutor(ctx, func(browserCtx context.Context) error {
 			return target.CloseTarget(s.targetID).Do(browserCtx)

--- a/engine/session.go
+++ b/engine/session.go
@@ -49,11 +49,14 @@ type Session struct {
 	cancel           context.CancelFunc
 	browserContextID cdp.BrowserContextID
 	targetID         target.ID
+	openerID         target.ID
 	ownsContext      bool
 	artifactDir      string
 	mu               sync.Mutex
 	requestMu        sync.Mutex
 	requests         []Request
+	consoleMu        sync.Mutex
+	consoleMessages  []ConsoleMessage
 	holdMu           sync.Mutex
 	holds            map[string]*responseHold
 	holdOrder        []string
@@ -61,6 +64,8 @@ type Session struct {
 	fetchEnabled     bool
 	closed           bool
 	installed        bool
+	root             *Session
+	initScriptIDs    []page.ScriptIdentifier
 	// crashed is closed by Chrome's Inspector.targetCrashed listener, which runs on chromedp's event
 	// goroutine rather than under mu - hence its own lock.  A channel rather than a bool because an
 	// operation already in flight has to be interrupted, not merely refused next time: CDP does not
@@ -69,6 +74,18 @@ type Session struct {
 	crashMu sync.Mutex
 	crashed chan struct{}
 }
+
+// ContextID identifies the isolated browser context shared by this session and its descendants.
+func (s *Session) ContextID() cdp.BrowserContextID { return s.browserContextID }
+
+// TargetID identifies this session's page target.
+func (s *Session) TargetID() target.ID { return s.targetID }
+
+// OpenerID identifies the target that opened this tab, or is empty for explicitly-created tabs.
+func (s *Session) OpenerID() target.ID { return s.openerID }
+
+// OwnsContext reports whether closing this session disposes its isolated browser context.
+func (s *Session) OwnsContext() bool { return s.ownsContext }
 
 // crashSignal is closed once this session's renderer dies, and replaced when a navigation recovers.
 func (s *Session) crashSignal() <-chan struct{} {
@@ -109,6 +126,11 @@ func (s *Session) hasCrashed() bool {
 }
 
 func (s *Session) Close() error {
+	if s.ownsContext && s.browser != nil {
+		ctx, cancel := context.WithTimeout(s.browser.ctx, 5*time.Second)
+		_ = s.browser.closeContextDescendants(ctx, s)
+		cancel()
+	}
 	s.mu.Lock()
 	if s.closed {
 		s.mu.Unlock()
@@ -154,14 +176,24 @@ func (s *Session) NewTab(ctx context.Context) (*Session, error) {
 	if browser == nil {
 		return nil, &Error{Code: CodeSessionClosed, Operation: "new tab", Message: "browser is closed"}
 	}
-	return browser.openTab(ctx, browserContextID, false)
+	return browser.openTab(ctx, browserContextID, false, s.contextRoot())
+}
+
+func (s *Session) contextRoot() *Session {
+	if s.root != nil {
+		return s.root
+	}
+	return s
 }
 
 // AddInitScript installs JavaScript that runs before every future document in this tab.
 func (s *Session) AddInitScript(ctx context.Context, script string) error {
 	return s.serial(ctx, "add init script", func(opCtx context.Context) error {
 		return chromedp.Run(opCtx, chromedp.ActionFunc(func(runCtx context.Context) error {
-			_, err := page.AddScriptToEvaluateOnNewDocument(script).Do(runCtx)
+			identifier, err := page.AddScriptToEvaluateOnNewDocument(script).Do(runCtx)
+			if err == nil {
+				s.initScriptIDs = append(s.initScriptIDs, identifier)
+			}
 			return err
 		}))
 	})
@@ -177,11 +209,23 @@ func (s *Session) Activate(ctx context.Context) error {
 }
 
 func (s *Session) Prepare(ctx context.Context) error {
+	if s.ownsContext && s.browser != nil {
+		if err := s.browser.closeContextDescendants(ctx, s); err != nil {
+			return err
+		}
+	}
 	return s.serial(ctx, "prepare", func(opCtx context.Context) error {
 		if err := s.resetResponseHolds(opCtx); err != nil {
 			return err
 		}
 		s.clearRequests()
+		s.clearConsoleMessages()
+		for _, identifier := range s.initScriptIDs {
+			if err := chromedp.Run(opCtx, page.RemoveScriptToEvaluateOnNewDocument(identifier)); err != nil {
+				return err
+			}
+		}
+		s.initScriptIDs = nil
 		// Clear storage while the tab still has its current origin. about:blank has an opaque
 		// origin, so navigating first would leave localStorage behind for the next spec. A crashed
 		// renderer has already lost that storage and no longer answers evaluation requests, so skip
@@ -190,6 +234,9 @@ func (s *Session) Prepare(ctx context.Context) error {
 			_ = EvaluateContext(opCtx, `try { window.localStorage.clear(); window.sessionStorage.clear(); } catch (e) {}`, false, nil)
 		}
 		if err := ClearCookiesContext(opCtx, s.browserContextID); err != nil {
+			return err
+		}
+		if err := s.resetEmulation(opCtx); err != nil {
 			return err
 		}
 		navigateBlank := func() error {
@@ -272,6 +319,13 @@ func (s *Session) GetCookies(ctx context.Context) ([]Cookie, error) {
 		return readErr
 	})
 	return cookies, err
+}
+
+// ClearCookies clears every cookie in this session's isolated browser context.
+func (s *Session) ClearCookies(ctx context.Context) error {
+	return s.serial(ctx, "clear cookies", func(opCtx context.Context) error {
+		return ClearCookiesContext(opCtx, s.browserContextID)
+	})
 }
 
 func (s *Session) Evaluate(ctx context.Context, script string) (any, error) {

--- a/engine/session.go
+++ b/engine/session.go
@@ -66,6 +66,9 @@ type Session struct {
 	closed           bool
 	installed        bool
 	root             *Session
+	initialWidth     int
+	initialHeight    int
+	highFidelity     bool
 	initScriptIDs    []page.ScriptIdentifier
 	// crashed is closed by Chrome's Inspector.targetCrashed listener, which runs on chromedp's event
 	// goroutine rather than under mu - hence its own lock.  A channel rather than a bool because an
@@ -253,6 +256,9 @@ func (s *Session) Prepare(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
+		if err := s.applyViewport(opCtx, s.initialWidth, s.initialHeight); err != nil {
+			return err
+		}
 		s.installed = false
 		s.clearCrashed()
 		return nil
@@ -272,6 +278,14 @@ func (s *Session) Navigate(ctx context.Context, destination string) error {
 // downstream failure instead of at the navigation that caused it.
 func (s *Session) NavigateWithStatus(ctx context.Context, destination string, expectedStatus int) error {
 	return s.serial(ctx, "navigate", func(opCtx context.Context) error {
+		width, height := int64(s.initialWidth), int64(s.initialHeight)
+		if s.highFidelity && !s.hasCrashed() {
+			var sizeErr error
+			width, height, sizeErr = ViewportDimensionsContext(opCtx)
+			if sizeErr != nil {
+				return sizeErr
+			}
+		}
 		result, err := NavigateContext(opCtx, destination)
 		// A navigation gives the target a fresh renderer, which is how a crashed page recovers - but
 		// Chrome needs a beat to spawn one, and a navigation issued before it exists comes back
@@ -283,6 +297,11 @@ func (s *Session) NavigateWithStatus(ctx context.Context, destination string, ex
 		s.installed = false
 		if err == nil {
 			s.clearCrashed()
+		}
+		if (err == nil || result.HTTPFailure) && s.highFidelity {
+			if viewportErr := s.applyViewport(opCtx, int(width), int(height)); viewportErr != nil {
+				return viewportErr
+			}
 		}
 		// Chrome reports a 4xx/5xx document as a loading failure, so that particular error is not
 		// a navigation failure - the status we observed is what decides.  Any other error is.
@@ -352,8 +371,15 @@ func (s *Session) SetWindowSize(ctx context.Context, width, height int) error {
 		return &Error{Code: CodeInvalidArgument, Operation: "set window size", Message: "width and height must be positive"}
 	}
 	return s.serial(ctx, "set window size", func(opCtx context.Context) error {
-		return EmulateViewportContext(opCtx, width, height)
+		return s.applyViewport(opCtx, width, height)
 	})
+}
+
+func (s *Session) applyViewport(ctx context.Context, width, height int) error {
+	if s.highFidelity {
+		return EmulateViewportMatchingScreenContext(ctx, width, height)
+	}
+	return EmulateViewportContext(ctx, width, height)
 }
 
 // SetUpload attaches paths to the first file input matching selector.

--- a/engine/storage.go
+++ b/engine/storage.go
@@ -1,0 +1,113 @@
+package engine
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+type StorageArea string
+
+const (
+	StorageLocal   StorageArea = "localStorage"
+	StorageSession StorageArea = "sessionStorage"
+)
+
+type Storage struct {
+	session *Session
+	area    StorageArea
+}
+
+func (s *Session) Storage(area StorageArea) *Storage { return &Storage{session: s, area: area} }
+
+func (s *Storage) valid() error {
+	if s == nil || s.session == nil || (s.area != StorageLocal && s.area != StorageSession) {
+		return &Error{Code: CodeInvalidArgument, Operation: "storage", Message: "area must be localStorage or sessionStorage"}
+	}
+	return nil
+}
+
+func (s *Storage) Set(ctx context.Context, key string, value any) error {
+	if err := s.valid(); err != nil {
+		return err
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return &Error{Code: CodeInvalidArgument, Operation: "storage set", Message: err.Error(), Cause: err}
+	}
+	args, _ := EncodeArgs(key, string(encoded))
+	return s.session.serial(ctx, "storage set", func(opCtx context.Context) error {
+		return EvaluateContext(opCtx, fmt.Sprintf("window.%s.setItem(...%s)", s.area, args), false, nil)
+	})
+}
+
+func (s *Storage) Get(ctx context.Context, key string) (any, bool, error) {
+	if err := s.valid(); err != nil {
+		return nil, false, err
+	}
+	args, _ := EncodeArgs(key)
+	var raw *string
+	err := s.session.serial(ctx, "storage get", func(opCtx context.Context) error {
+		return EvaluateContext(opCtx, fmt.Sprintf("window.%s.getItem(...%s)", s.area, args), false, &raw)
+	})
+	if err != nil || raw == nil {
+		return nil, false, err
+	}
+	return decodeStoredValue(*raw), true, nil
+}
+
+func (s *Storage) GetAll(ctx context.Context) (map[string]any, error) {
+	if err := s.valid(); err != nil {
+		return nil, err
+	}
+	var raw map[string]string
+	err := s.session.serial(ctx, "storage get all", func(opCtx context.Context) error {
+		return EvaluateContext(opCtx, fmt.Sprintf("({...window.%s})", s.area), false, &raw)
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]any, len(raw))
+	for key, value := range raw {
+		out[key] = decodeStoredValue(value)
+	}
+	return out, nil
+}
+
+func (s *Storage) Remove(ctx context.Context, key string) error {
+	if err := s.valid(); err != nil {
+		return err
+	}
+	args, _ := EncodeArgs(key)
+	return s.session.serial(ctx, "storage remove", func(opCtx context.Context) error {
+		return EvaluateContext(opCtx, fmt.Sprintf("window.%s.removeItem(...%s)", s.area, args), false, nil)
+	})
+}
+
+func (s *Storage) Clear(ctx context.Context) error {
+	if err := s.valid(); err != nil {
+		return err
+	}
+	return s.session.serial(ctx, "storage clear", func(opCtx context.Context) error {
+		return EvaluateContext(opCtx, fmt.Sprintf("window.%s.clear()", s.area), false, nil)
+	})
+}
+
+func (s *Storage) Length(ctx context.Context) (int, error) {
+	if err := s.valid(); err != nil {
+		return 0, err
+	}
+	var length int
+	err := s.session.serial(ctx, "storage length", func(opCtx context.Context) error {
+		return EvaluateContext(opCtx, fmt.Sprintf("window.%s.length", s.area), false, &length)
+	})
+	return length, err
+}
+
+func decodeStoredValue(raw string) any {
+	var value any
+	if err := json.Unmarshal([]byte(raw), &value); err != nil {
+		return raw
+	}
+	return value
+}

--- a/engine/tabs.go
+++ b/engine/tabs.go
@@ -1,0 +1,139 @@
+package engine
+
+import (
+	"context"
+
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/target"
+	"github.com/chromedp/chromedp"
+)
+
+type TabQuery struct {
+	SpawnedOnly bool
+	Title       *Expectation
+	URL         *Expectation
+	HasElement  *Selector
+}
+
+// Tabs discovers and returns every page target in this session's isolated browser context.
+func (s *Session) Tabs(ctx context.Context) ([]*Session, error) {
+	s.mu.Lock()
+	closed := s.closed
+	s.mu.Unlock()
+	if closed {
+		return nil, &Error{Code: CodeSessionClosed, Operation: "list tabs", Message: "session is closed"}
+	}
+	if s.browser == nil {
+		return nil, &Error{Code: CodeSessionClosed, Operation: "list tabs", Message: "browser is closed"}
+	}
+	opCtx, cancel := executorContext(s.browser.ctx, ctx)
+	defer cancel()
+	chrome := chromedp.FromContext(opCtx)
+	infos, err := target.GetTargets().Do(cdp.WithExecutor(opCtx, chrome.Browser))
+	if err != nil {
+		return nil, contextError("list tabs", err)
+	}
+	out := []*Session{}
+	for _, info := range infos {
+		if info.Type != "page" || info.BrowserContextID != s.browserContextID {
+			continue
+		}
+		tab, attachErr := s.browser.sessionForTarget(ctx, info.TargetID, info.OpenerID, s.contextRoot())
+		if attachErr != nil {
+			return nil, attachErr
+		}
+		out = append(out, tab)
+	}
+	return out, nil
+}
+
+func (b *Browser) sessionForTarget(ctx context.Context, targetID, openerID target.ID, root *Session) (*Session, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil, &Error{Code: CodeSessionClosed, Operation: "attach tab", Message: "browser is closed"}
+	}
+	for session := range b.sessions {
+		if session.targetID == targetID {
+			if session.openerID == "" {
+				session.openerID = openerID
+			}
+			return session, nil
+		}
+	}
+	tabCtx, cancelTab := chromedp.NewContext(b.ctx, chromedp.WithTargetID(targetID))
+	done := make(chan error, 1)
+	go func() { done <- chromedp.Run(tabCtx, chromedp.Evaluate("1", nil)) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			cancelTab()
+			return nil, contextError("attach tab", err)
+		}
+	case <-ctx.Done():
+		cancelTab()
+		return nil, contextError("attach tab", ctx.Err())
+	}
+	session := &Session{browser: b, ctx: tabCtx, cancel: cancelTab, browserContextID: root.browserContextID, targetID: targetID, openerID: openerID, root: root, artifactDir: b.artifactDir}
+	b.listenToSession(session)
+	b.sessions[session] = struct{}{}
+	return session, nil
+}
+
+func (s *Session) WaitForTab(ctx context.Context, query TabQuery, policy PollPolicy) (*Session, error) {
+	var matched *Session
+	_, err := Poll(ctx, policy, func(attemptCtx context.Context) (Observation, bool, error) {
+		tabs, listErr := s.Tabs(attemptCtx)
+		if listErr != nil {
+			return Observation{}, false, listErr
+		}
+		for _, tab := range tabs {
+			if query.SpawnedOnly && tab.openerID != s.targetID {
+				continue
+			}
+			ok, matchErr := tab.matchesTabQuery(attemptCtx, query)
+			if matchErr != nil {
+				return Observation{}, false, matchErr
+			}
+			if ok {
+				matched = tab
+				return Observation{Value: tab.targetID}, true, nil
+			}
+		}
+		return Observation{Value: len(tabs)}, false, nil
+	})
+	return matched, err
+}
+
+func (s *Session) matchesTabQuery(ctx context.Context, query TabQuery) (bool, error) {
+	if query.Title != nil {
+		value, err := s.Title(ctx)
+		if err != nil {
+			return false, err
+		}
+		matched, err := MatchExpectation(value, *query.Title)
+		if err != nil || !matched {
+			return false, err
+		}
+	}
+	if query.URL != nil {
+		value, err := s.URL(ctx)
+		if err != nil {
+			return false, err
+		}
+		matched, err := MatchExpectation(value.Value, *query.URL)
+		if err != nil || !matched {
+			return false, err
+		}
+	}
+	if query.HasElement != nil {
+		value, err := s.Exists(ctx, *query.HasElement)
+		if err != nil {
+			return false, err
+		}
+		if found, ok := value.Value.(bool); !ok || !found {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/engine/tabs.go
+++ b/engine/tabs.go
@@ -74,7 +74,24 @@ func (b *Browser) sessionForTarget(ctx context.Context, targetID, openerID targe
 		cancelTab()
 		return nil, contextError("attach tab", ctx.Err())
 	}
-	session := &Session{browser: b, ctx: tabCtx, cancel: cancelTab, browserContextID: root.browserContextID, targetID: targetID, openerID: openerID, root: root, artifactDir: b.artifactDir}
+	session := &Session{
+		browser: b, ctx: tabCtx, cancel: cancelTab, browserContextID: root.browserContextID,
+		targetID: targetID, openerID: openerID, root: root, artifactDir: b.artifactDir,
+		initialWidth: b.windowWidth, initialHeight: b.windowHeight,
+		highFidelity: b.mode == ChromeModeHeadless,
+	}
+	if session.initialWidth <= 0 || session.initialHeight <= 0 {
+		width, height, sizeErr := ViewportDimensionsContext(tabCtx)
+		if sizeErr != nil {
+			cancelTab()
+			return nil, contextError("read initial window size", sizeErr)
+		}
+		session.initialWidth, session.initialHeight = int(width), int(height)
+	}
+	if err := session.applyViewport(tabCtx, session.initialWidth, session.initialHeight); err != nil {
+		cancelTab()
+		return nil, contextError("apply initial viewport", err)
+	}
 	b.listenToSession(session)
 	b.sessions[session] = struct{}{}
 	return session, nil

--- a/export_test.go
+++ b/export_test.go
@@ -1,6 +1,9 @@
 package biloba
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // CapOutlineForTest exposes capOutlineWithCap so that outline_test.go can
 // exercise the truncation path with a small byte cap.
@@ -28,6 +31,11 @@ func LocateHeadlessShellForTest(explicit string) string {
 	return locateHeadlessShell(explicit)
 }
 
+// HeadlessShellBinaryNameForTest exposes the shared platform-specific shell name.
+func HeadlessShellBinaryNameForTest() string {
+	return headlessShellBinaryName()
+}
+
 // HeadlessShellInstructionsForTest exposes headlessShellInstructions for headless_shell_test.go.
 func HeadlessShellInstructionsForTest() string {
 	return headlessShellInstructions()
@@ -43,14 +51,21 @@ func MinimumSupportedChromeMajorForTest() int {
 	return minimumSupportedChromeMajor
 }
 
-// ChromeForTestingPlatformForTest exposes chromeForTestingPlatform for headless_shell_test.go.
-func ChromeForTestingPlatformForTest() (string, error) {
-	return chromeForTestingPlatform()
-}
-
 // InstallHeadlessShellForTest exposes installHeadlessShell for headless_shell_test.go.
 func InstallHeadlessShellForTest() (string, error) {
 	return installHeadlessShell()
+}
+
+// SetHeadlessShellResolverForTest replaces the engine resolver for deterministic adapter specs.
+func SetHeadlessShellResolverForTest(resolver func(context.Context, string, bool) (string, bool, error)) func() {
+	previous := resolveHeadlessShell
+	resolveHeadlessShell = resolver
+	return func() { resolveHeadlessShell = previous }
+}
+
+// ResolveHeadlessShellForTest exercises the public Go adapter's error and progress behavior.
+func ResolveHeadlessShellForTest(ginkgoT GinkgoTInterface, explicit string, autoInstall bool) (string, error) {
+	return resolveHeadlessShellPath(ginkgoT, &spinUpConfig{headlessShellPath: explicit, autoInstall: autoInstall})
 }
 
 // SafeAllTabScreenshotsForTest exposes safeAllTabScreenshots for integration tests.

--- a/headless_shell.go
+++ b/headless_shell.go
@@ -1,16 +1,8 @@
 package biloba
 
 import (
-	"archive/zip"
-	"encoding/json"
+	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
-	"time"
 
 	"github.com/onsi/biloba/engine"
 )
@@ -20,22 +12,21 @@ import (
 // bilobad daemon and this suite resolve the same binary.
 const headlessShellEnvVar = engine.ChromeEnvVar
 
-const chromeForTestingVersionsURL = "https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json"
+var resolveHeadlessShell = engine.ResolveHeadlessShell
 
 // resolveHeadlessShellPath finds a chrome-headless-shell binary for the default (pragmatic)
 // headless mode.  It searches local locations first and, only if cfg.autoInstall is set,
 // downloads one via Chrome for Testing.  Otherwise it returns an actionable error.
 func resolveHeadlessShellPath(ginkgoT GinkgoTInterface, cfg *spinUpConfig) (string, error) {
-	if p := locateHeadlessShell(cfg.headlessShellPath); p != "" {
-		return p, nil
+	if cfg.autoInstall && locateHeadlessShell(cfg.headlessShellPath) == "" {
+		ginkgoT.Printf("Biloba: chrome-headless-shell not found locally; downloading it via Chrome for Testing (AutoInstallHeadlessShell)...\n")
+	}
+	path, _, err := resolveHeadlessShell(context.Background(), cfg.headlessShellPath, cfg.autoInstall)
+	if err == nil {
+		return path, nil
 	}
 	if cfg.autoInstall {
-		ginkgoT.Printf("Biloba: chrome-headless-shell not found locally; downloading it via Chrome for Testing (AutoInstallHeadlessShell)...\n")
-		p, err := installHeadlessShell()
-		if err != nil {
-			return "", fmt.Errorf("Biloba could not auto-install chrome-headless-shell:\n%s\n\n%s", err.Error(), headlessShellInstructions())
-		}
-		return p, nil
+		return "", fmt.Errorf("Biloba could not auto-install chrome-headless-shell:\n%s\n\n%s", err.Error(), headlessShellInstructions())
 	}
 	return "", fmt.Errorf("%s", headlessShellInstructions())
 }
@@ -46,8 +37,6 @@ func resolveHeadlessShellPath(ginkgoT GinkgoTInterface, cfg *spinUpConfig) (stri
 func locateHeadlessShell(explicit string) string { return engine.LocateChrome(explicit) }
 
 func headlessShellBinaryName() string { return engine.ChromeBinaryName() }
-
-func isExecutableFile(p string) bool { return engine.IsExecutableFile(p) }
 
 func headlessShellInstructions() string {
 	return fmt.Sprintf(`Biloba defaults to the lightweight chrome-headless-shell for speed, but could not find it.
@@ -66,145 +55,5 @@ Alternatively:
 // Chrome for Testing into Biloba's cache and returns the path to the binary.  It is a no-op if a
 // matching binary is already cached.
 func installHeadlessShell() (string, error) {
-	platform, err := chromeForTestingPlatform()
-	if err != nil {
-		return "", err
-	}
-	url, version, err := stableHeadlessShellDownload(platform)
-	if err != nil {
-		return "", err
-	}
-	cacheRoot, err := os.UserCacheDir()
-	if err != nil {
-		return "", fmt.Errorf("could not determine user cache dir: %w", err)
-	}
-	destDir := filepath.Join(cacheRoot, "biloba", "chrome-headless-shell", version)
-	binPath := filepath.Join(destDir, "chrome-headless-shell-"+platform, headlessShellBinaryName())
-	if isExecutableFile(binPath) {
-		return binPath, nil // already installed
-	}
-	if err := downloadAndUnzip(url, destDir); err != nil {
-		return "", err
-	}
-	if runtime.GOOS != "windows" {
-		os.Chmod(binPath, 0o755)
-	}
-	if !isExecutableFile(binPath) {
-		return "", fmt.Errorf("downloaded chrome-headless-shell but the binary was not found at %s", binPath)
-	}
-	return binPath, nil
-}
-
-func chromeForTestingPlatform() (string, error) {
-	switch runtime.GOOS + "/" + runtime.GOARCH {
-	case "darwin/arm64":
-		return "mac-arm64", nil
-	case "darwin/amd64":
-		return "mac-x64", nil
-	case "linux/amd64":
-		return "linux64", nil
-	case "windows/amd64":
-		return "win64", nil
-	case "windows/386":
-		return "win32", nil
-	default:
-		return "", fmt.Errorf("chrome-headless-shell auto-install is not available for %s/%s via Chrome for Testing - install it manually", runtime.GOOS, runtime.GOARCH)
-	}
-}
-
-func stableHeadlessShellDownload(platform string) (url string, version string, err error) {
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Get(chromeForTestingVersionsURL)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to query Chrome for Testing: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", "", fmt.Errorf("Chrome for Testing returned status %d", resp.StatusCode)
-	}
-	var data struct {
-		Channels map[string]struct {
-			Version   string `json:"version"`
-			Downloads struct {
-				HeadlessShell []struct {
-					Platform string `json:"platform"`
-					URL      string `json:"url"`
-				} `json:"chrome-headless-shell"`
-			} `json:"downloads"`
-		} `json:"channels"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return "", "", fmt.Errorf("failed to decode Chrome for Testing response: %w", err)
-	}
-	stable, ok := data.Channels["Stable"]
-	if !ok {
-		return "", "", fmt.Errorf("Chrome for Testing response did not include a Stable channel")
-	}
-	for _, dl := range stable.Downloads.HeadlessShell {
-		if dl.Platform == platform {
-			return dl.URL, stable.Version, nil
-		}
-	}
-	return "", "", fmt.Errorf("Chrome for Testing has no chrome-headless-shell download for platform %s", platform)
-}
-
-func downloadAndUnzip(url, destDir string) error {
-	client := &http.Client{Timeout: 5 * time.Minute}
-	resp, err := client.Get(url)
-	if err != nil {
-		return fmt.Errorf("failed to download %s: %w", url, err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("download of %s returned status %d", url, resp.StatusCode)
-	}
-	tmpFile, err := os.CreateTemp("", "chrome-headless-shell-*.zip")
-	if err != nil {
-		return err
-	}
-	defer os.Remove(tmpFile.Name())
-	if _, err := io.Copy(tmpFile, resp.Body); err != nil {
-		tmpFile.Close()
-		return err
-	}
-	tmpFile.Close()
-	return unzip(tmpFile.Name(), destDir)
-}
-
-func unzip(zipPath, destDir string) error {
-	r, err := zip.OpenReader(zipPath)
-	if err != nil {
-		return err
-	}
-	defer r.Close()
-	for _, f := range r.File {
-		fpath := filepath.Join(destDir, f.Name)
-		// zip-slip guard
-		if !strings.HasPrefix(fpath, filepath.Clean(destDir)+string(os.PathSeparator)) {
-			return fmt.Errorf("illegal file path in zip archive: %s", f.Name)
-		}
-		if f.FileInfo().IsDir() {
-			os.MkdirAll(fpath, 0o755)
-			continue
-		}
-		if err := os.MkdirAll(filepath.Dir(fpath), 0o755); err != nil {
-			return err
-		}
-		rc, err := f.Open()
-		if err != nil {
-			return err
-		}
-		out, err := os.OpenFile(fpath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, f.Mode())
-		if err != nil {
-			rc.Close()
-			return err
-		}
-		_, copyErr := io.Copy(out, rc)
-		out.Close()
-		rc.Close()
-		if copyErr != nil {
-			return copyErr
-		}
-	}
-	return nil
+	return engine.InstallHeadlessShell(context.Background())
 }

--- a/headless_shell_test.go
+++ b/headless_shell_test.go
@@ -1,11 +1,13 @@
 package biloba_test
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/onsi/biloba"
+	"github.com/onsi/biloba/engine"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -45,19 +47,50 @@ var _ = Describe("locating chrome-headless-shell", Label("no-browser"), func() {
 		os.Setenv("BILOBA_CHROME_HEADLESS_SHELL", fake)
 		Expect(biloba.LocateHeadlessShellForTest("")).To(Equal(fake))
 	})
+
+	It("finds a shell in the current Puppeteer cache layout", func() {
+		os.Unsetenv("BILOBA_CHROME_HEADLESS_SHELL")
+		GinkgoT().Setenv("PATH", "")
+		cacheRoot := filepath.Join(GinkgoT().TempDir(), ".cache", "puppeteer")
+		GinkgoT().Setenv("HOME", filepath.Dir(filepath.Dir(cacheRoot)))
+		fake := filepath.Join(cacheRoot, "chrome-headless-shell", "999.0.0", "chrome-headless-shell-test", biloba.HeadlessShellBinaryNameForTest())
+		Expect(os.MkdirAll(filepath.Dir(fake), 0o755)).To(Succeed())
+		Expect(os.WriteFile(fake, []byte("#!/bin/sh\n"), 0o755)).To(Succeed())
+
+		Expect(biloba.LocateHeadlessShellForTest("")).To(Equal(fake))
+	})
 })
 
 var _ = Describe("chrome-headless-shell acquisition helpers", Label("no-browser"), func() {
-	It("maps common platforms to Chrome for Testing identifiers", func() {
-		platform, err := biloba.ChromeForTestingPlatformForTest()
-		// the test host is one of the supported platforms
-		switch runtime.GOOS {
-		case "darwin", "linux", "windows":
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(platform).ShouldNot(BeEmpty())
-		default:
-			Expect(err).Should(HaveOccurred())
-		}
+	It("delegates local resolution and installation policy to the engine", func() {
+		GinkgoT().Setenv(engine.ChromeEnvVar, "")
+		GinkgoT().Setenv("PATH", "")
+		GinkgoT().Setenv("HOME", GinkgoT().TempDir())
+		GinkgoT().Setenv("XDG_CACHE_HOME", GinkgoT().TempDir())
+		calls := []bool{}
+		restore := biloba.SetHeadlessShellResolverForTest(func(_ context.Context, explicit string, autoInstall bool) (string, bool, error) {
+			Expect(explicit).To(Equal("/configured/shell"))
+			calls = append(calls, autoInstall)
+			if !autoInstall {
+				return "", false, errors.New("engine did not find a shell")
+			}
+			return "/engine/cache/shell", true, nil
+		})
+		DeferCleanup(restore)
+
+		path, err := biloba.ResolveHeadlessShellForTest(gt, "/configured/shell", false)
+		Expect(path).To(BeEmpty())
+		Expect(err).To(MatchError(And(
+			ContainSubstring("AutoInstallHeadlessShell"),
+			Not(ContainSubstring("engine did not find a shell")),
+		)))
+		Expect(string(gt.buffer.Contents())).To(BeEmpty(), "default resolution must not announce a download")
+
+		path, err = biloba.ResolveHeadlessShellForTest(gt, "/configured/shell", true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(path).To(Equal("/engine/cache/shell"))
+		Expect(calls).To(Equal([]bool{false, true}))
+		Expect(string(gt.buffer.Contents())).To(ContainSubstring("downloading it via Chrome for Testing"))
 	})
 
 	It("produces actionable instructions when the shell cannot be found", func() {

--- a/protocol/internal/protocolgen/protocolgen.go
+++ b/protocol/internal/protocolgen/protocolgen.go
@@ -49,6 +49,12 @@ var declarations = []reflect.Type{
 	reflect.TypeFor[protocol.HandshakeResponse](),
 	reflect.TypeFor[protocol.OpenSessionResponse](),
 	reflect.TypeFor[protocol.SessionRequest](),
+	reflect.TypeFor[protocol.TabQueryRequest](),
+	reflect.TypeFor[protocol.ListHandlesRequest](),
+	reflect.TypeFor[protocol.WaitForTabRequest](),
+	reflect.TypeFor[protocol.WaitForFrameRequest](),
+	reflect.TypeFor[protocol.HandleListResponse](),
+	reflect.TypeFor[protocol.InvalidationResponse](),
 	reflect.TypeFor[protocol.NavigateRequest](),
 	reflect.TypeFor[protocol.PollOptions](),
 	reflect.TypeFor[protocol.WireLocator](),
@@ -59,6 +65,13 @@ var declarations = []reflect.Type{
 	reflect.TypeFor[protocol.DOMRequest](),
 	reflect.TypeFor[protocol.WireCookie](),
 	reflect.TypeFor[protocol.SetCookiesRequest](),
+	reflect.TypeFor[protocol.WireCookieQuery](),
+	reflect.TypeFor[protocol.WireDeviceMetrics](),
+	reflect.TypeFor[protocol.WireGeolocation](),
+	reflect.TypeFor[protocol.WireMedia](),
+	reflect.TypeFor[protocol.WireLifecycleOperation](),
+	reflect.TypeFor[protocol.LifecycleRequest](),
+	reflect.TypeFor[protocol.CookieListResponse](),
 	reflect.TypeFor[protocol.LocatorRequest](),
 	reflect.TypeFor[protocol.SetValueRequest](),
 	reflect.TypeFor[protocol.TypeRequest](),
@@ -153,6 +166,9 @@ func tsType(owner reflect.Type, field reflect.StructField) string {
 			return `"EXACT" | "CONTAINS"`
 		}
 	}
+	if owner == reflect.TypeFor[protocol.WireLifecycleOperation]() && field.Name == "Kind" {
+		return `"GET_COOKIES" | "CLEAR_COOKIES" | "COOKIE_QUERY" | "STORAGE_SET" | "STORAGE_GET" | "STORAGE_GET_ALL" | "STORAGE_REMOVE" | "STORAGE_CLEAR" | "STORAGE_LENGTH" | "WAIT_FOR_DEFINED" | "URL" | "TITLE" | "WINDOW_SIZE" | "OUTLINE" | "ACCESSIBILITY_OUTLINE" | "CONSOLE_MESSAGES" | "SET_DEVICE_METRICS" | "CLEAR_DEVICE_METRICS" | "SET_GEOLOCATION" | "CLEAR_GEOLOCATION" | "SET_PERMISSIONS" | "RESET_PERMISSIONS" | "SET_LOCALE" | "CLEAR_LOCALE" | "SET_TIMEZONE" | "CLEAR_TIMEZONE" | "SET_MEDIA" | "CLEAR_MEDIA"`
+	}
 	if owner == reflect.TypeFor[protocol.PollOptions]() && field.Name == "Mode" {
 		return `"EVENTUALLY" | "IMMEDIATE" | "CONSISTENTLY"`
 	}
@@ -186,6 +202,8 @@ func typeName(value reflect.Type) string {
 		return "number"
 	case reflect.Slice:
 		return typeName(value.Elem()) + "[]"
+	case reflect.Map:
+		return "Record<" + typeName(value.Key()) + ", " + typeName(value.Elem()) + ">"
 	case reflect.Struct:
 		return tsName(value)
 	default:

--- a/protocol/server.go
+++ b/protocol/server.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 )
@@ -20,6 +21,7 @@ var Capabilities = []string{
 	"action.set_upload", "viewport.set", "evaluate", "evaluate.async", "assert.visible", "assert.text", "assert.count", "assert.attribute",
 	"assert.value", "assert.url", "assert.evaluate", "poll.server_side", "diagnostics.structured",
 	"dom.typed", "dom.collections", "dom.geometry", "dom.style", "dom.selection", "action.pointer_options", "action.scroll", "action.element_javascript", "keyboard.modifiers",
+	"lifecycle.tabs", "lifecycle.context_identity", "lifecycle.cookies", "lifecycle.storage", "lifecycle.javascript", "lifecycle.page_state", "lifecycle.console", "lifecycle.emulation", "lifecycle.frames",
 }
 
 type ErrorCode string
@@ -81,6 +83,39 @@ type TabSession interface {
 	NewTab(context.Context) (Session, error)
 }
 
+// DiscoverableSession exposes live page and frame handles without leaking the underlying CDP
+// representation across the runner-neutral protocol boundary.
+type DiscoverableSession interface {
+	Session
+	Metadata() SessionMetadata
+	Tabs(context.Context) ([]Session, error)
+	WaitForTab(context.Context, TabQuery, PollPolicy) (Session, error)
+	Frames(context.Context) ([]Session, error)
+	WaitForFrame(context.Context, FrameQuery, PollPolicy) (Session, error)
+}
+
+type SessionMetadata struct {
+	ContextID   string
+	TargetID    string
+	OpenerID    string
+	OwnsContext bool
+	Frame       bool
+	URL         string
+}
+
+type TabQuery struct {
+	SpawnedOnly bool
+	Title       *Expectation
+	URL         *Expectation
+	HasElement  *Locator
+}
+
+type FrameQuery struct {
+	Title      *Expectation
+	URL        *Expectation
+	HasElement *Locator
+}
+
 type OperationKind uint8
 
 const (
@@ -101,6 +136,40 @@ const (
 	OperationAddInitScript
 	OperationActivate
 	OperationDOM
+	OperationLifecycle
+)
+
+type LifecycleOperationKind uint8
+
+const (
+	LifecycleGetCookies LifecycleOperationKind = iota + 1
+	LifecycleClearCookies
+	LifecycleCookieQuery
+	LifecycleStorageSet
+	LifecycleStorageGet
+	LifecycleStorageGetAll
+	LifecycleStorageRemove
+	LifecycleStorageClear
+	LifecycleStorageLength
+	LifecycleWaitForDefined
+	LifecycleURL
+	LifecycleTitle
+	LifecycleWindowSize
+	LifecycleOutline
+	LifecycleAccessibilityOutline
+	LifecycleConsoleMessages
+	LifecycleSetDeviceMetrics
+	LifecycleClearDeviceMetrics
+	LifecycleSetGeolocation
+	LifecycleClearGeolocation
+	LifecycleSetPermissions
+	LifecycleResetPermissions
+	LifecycleSetLocale
+	LifecycleClearLocale
+	LifecycleSetTimezone
+	LifecycleClearTimezone
+	LifecycleSetMedia
+	LifecycleClearMedia
 )
 
 type Operation struct {
@@ -127,6 +196,42 @@ type Operation struct {
 	Expectation    Expectation
 	HoldID         string
 	DOM            DOMOperation
+	Lifecycle      LifecycleOperation
+}
+
+type LifecycleOperation struct {
+	Kind              LifecycleOperationKind
+	Area              string
+	Key               string
+	ValueJSON         string
+	Expression        string
+	Expectation       Expectation
+	Cookie            CookieQuery
+	Count             bool
+	Width             int
+	Height            int
+	DeviceScaleFactor float64
+	Mobile            bool
+	Latitude          float64
+	Longitude         float64
+	Accuracy          float64
+	Origin            string
+	Permissions       map[string]string
+	Locale            string
+	Timezone          string
+	MediaType         string
+	ColorScheme       string
+	ReducedMotion     string
+}
+
+type CookieQuery struct {
+	Name     *Expectation
+	Value    *Expectation
+	Domain   *Expectation
+	Path     *Expectation
+	SameSite *Expectation
+	Secure   *bool
+	HTTPOnly *bool
 }
 
 type LocatorKind uint8
@@ -401,11 +506,48 @@ type HandshakeResponse struct {
 }
 
 type OpenSessionResponse struct {
-	SessionID string `json:"sessionId"`
+	SessionID   string `json:"sessionId"`
+	ContextID   string `json:"contextId,omitempty"`
+	TargetID    string `json:"targetId,omitempty"`
+	OpenerID    string `json:"openerId,omitempty"`
+	OwnsContext bool   `json:"ownsContext,omitempty"`
+	Frame       bool   `json:"frame,omitempty"`
+	URL         string `json:"url,omitempty"`
 }
 
 type SessionRequest struct {
 	SessionID string `json:"sessionId"`
+}
+
+type TabQueryRequest struct {
+	SpawnedOnly bool             `json:"spawnedOnly,omitempty"`
+	Title       *WireExpectation `json:"title,omitempty"`
+	URL         *WireExpectation `json:"url,omitempty"`
+	Has         *WireLocator     `json:"has,omitempty"`
+}
+
+type ListHandlesRequest struct {
+	SessionID   string `json:"sessionId"`
+	SpawnedOnly bool   `json:"spawnedOnly,omitempty"`
+}
+
+type WaitForTabRequest struct {
+	SessionID string          `json:"sessionId"`
+	Query     TabQueryRequest `json:"query"`
+	Poll      PollOptions     `json:"poll,omitempty"`
+}
+
+type WaitForFrameRequest struct {
+	SessionID string          `json:"sessionId"`
+	Query     TabQueryRequest `json:"query"`
+	Poll      PollOptions     `json:"poll,omitempty"`
+}
+
+type HandleListResponse struct {
+	Handles []OpenSessionResponse `json:"handles"`
+}
+type InvalidationResponse struct {
+	InvalidatedSessionIDs []string `json:"invalidatedSessionIds,omitempty"`
 }
 
 type NavigateRequest struct {
@@ -514,6 +656,63 @@ type WireCookie struct {
 type SetCookiesRequest struct {
 	SessionID string       `json:"sessionId"`
 	Cookies   []WireCookie `json:"cookies"`
+}
+
+type WireCookieQuery struct {
+	Name     *WireExpectation `json:"name,omitempty"`
+	Value    *WireExpectation `json:"value,omitempty"`
+	Domain   *WireExpectation `json:"domain,omitempty"`
+	Path     *WireExpectation `json:"path,omitempty"`
+	SameSite *WireExpectation `json:"sameSite,omitempty"`
+	Secure   *bool            `json:"secure,omitempty"`
+	HTTPOnly *bool            `json:"httpOnly,omitempty"`
+}
+
+type WireDeviceMetrics struct {
+	Width             int     `json:"width"`
+	Height            int     `json:"height"`
+	DeviceScaleFactor float64 `json:"deviceScaleFactor"`
+	Mobile            bool    `json:"mobile,omitempty"`
+}
+
+type WireGeolocation struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+	Accuracy  float64 `json:"accuracy,omitempty"`
+}
+
+type WireMedia struct {
+	Type          string `json:"type,omitempty"`
+	ColorScheme   string `json:"colorScheme,omitempty"`
+	ReducedMotion string `json:"reducedMotion,omitempty"`
+}
+
+type WireLifecycleOperation struct {
+	Kind        string             `json:"kind"`
+	Area        string             `json:"area,omitempty"`
+	Key         string             `json:"key,omitempty"`
+	ValueJSON   string             `json:"valueJson,omitempty"`
+	Expression  string             `json:"expression,omitempty"`
+	Cookie      *WireCookieQuery   `json:"cookie,omitempty"`
+	Count       bool               `json:"count,omitempty"`
+	Device      *WireDeviceMetrics `json:"device,omitempty"`
+	Geolocation *WireGeolocation   `json:"geolocation,omitempty"`
+	Origin      string             `json:"origin,omitempty"`
+	Permissions map[string]string  `json:"permissions,omitempty"`
+	Locale      string             `json:"locale,omitempty"`
+	Timezone    string             `json:"timezone,omitempty"`
+	Media       *WireMedia         `json:"media,omitempty"`
+}
+
+type LifecycleRequest struct {
+	SessionID   string                  `json:"sessionId"`
+	Operation   *WireLifecycleOperation `json:"operation"`
+	Expectation *WireExpectation        `json:"expectation,omitempty"`
+	Poll        PollOptions             `json:"poll,omitempty"`
+}
+
+type CookieListResponse struct {
+	Cookies []WireCookie `json:"cookies"`
 }
 
 type LocatorRequest struct {
@@ -681,15 +880,12 @@ func (s *Server) Dispatch(ctx context.Context, method string, params json.RawMes
 		if err != nil {
 			return nil, normalizeError(err)
 		}
-		id, idErr := randomID()
-		if idErr != nil {
+		opened, openErr := s.registerSession(session)
+		if openErr != nil {
 			_ = session.Close()
-			return nil, NewError(CodeDriver, "generate session id")
+			return nil, openErr
 		}
-		s.mu.Lock()
-		s.sessions[id] = &sessionEntry{session: session}
-		s.mu.Unlock()
-		return OpenSessionResponse{SessionID: id}, nil
+		return opened, nil
 	case "newTab":
 		var request SessionRequest
 		if err := decodeParams(params, &request); err != nil {
@@ -709,15 +905,80 @@ func (s *Server) Dispatch(ctx context.Context, method string, params json.RawMes
 		if openErr != nil {
 			return nil, normalizeError(openErr)
 		}
-		id, idErr := randomID()
-		if idErr != nil {
+		opened, registerErr := s.registerSession(sibling)
+		if registerErr != nil {
 			_ = sibling.Close()
-			return nil, NewError(CodeDriver, "generate session id")
+			return nil, registerErr
 		}
-		s.mu.Lock()
-		s.sessions[id] = &sessionEntry{session: sibling}
-		s.mu.Unlock()
-		return OpenSessionResponse{SessionID: id}, nil
+		return opened, nil
+	case "listTabs", "listFrames":
+		var request ListHandlesRequest
+		if err := decodeParams(params, &request); err != nil {
+			return nil, err
+		}
+		entry, err := s.session(request.SessionID)
+		if err != nil {
+			return nil, err
+		}
+		discoverable, ok := entry.session.(DiscoverableSession)
+		if !ok {
+			return nil, NewError(CodeDriver, "session backend does not support handle discovery")
+		}
+		var handles []Session
+		var discoverErr error
+		if method == "listFrames" {
+			handles, discoverErr = discoverable.Frames(ctx)
+		} else {
+			handles, discoverErr = discoverable.Tabs(ctx)
+		}
+		if discoverErr != nil {
+			return nil, normalizeError(discoverErr)
+		}
+		response := HandleListResponse{Handles: []OpenSessionResponse{}}
+		for _, handle := range handles {
+			meta, hasMeta := handle.(DiscoverableSession)
+			if method == "listTabs" && request.SpawnedOnly && (!hasMeta || meta.Metadata().OpenerID == "") {
+				continue
+			}
+			opened, registerErr := s.registerSession(handle)
+			if registerErr != nil {
+				return nil, registerErr
+			}
+			response.Handles = append(response.Handles, opened)
+		}
+		return response, nil
+	case "waitForTab", "waitForFrame":
+		var request WaitForTabRequest
+		if err := decodeParams(params, &request); err != nil {
+			return nil, err
+		}
+		entry, err := s.session(request.SessionID)
+		if err != nil {
+			return nil, err
+		}
+		discoverable, ok := entry.session.(DiscoverableSession)
+		if !ok {
+			return nil, NewError(CodeDriver, "session backend does not support handle discovery")
+		}
+		query, queryErr := tabQueryFromWire(request.Query)
+		if queryErr != nil {
+			return nil, queryErr
+		}
+		policy, policyErr := pollFromWire(request.Poll)
+		if policyErr != nil {
+			return nil, policyErr
+		}
+		var handle Session
+		var waitErr error
+		if method == "waitForFrame" {
+			handle, waitErr = discoverable.WaitForFrame(ctx, FrameQuery{Title: query.Title, URL: query.URL, HasElement: query.HasElement}, policy)
+		} else {
+			handle, waitErr = discoverable.WaitForTab(ctx, query, policy)
+		}
+		if waitErr != nil {
+			return nil, normalizeError(waitErr)
+		}
+		return s.registerSession(handle)
 	case "prepareSession":
 		var request SessionRequest
 		if err := decodeParams(params, &request); err != nil {
@@ -732,7 +993,7 @@ func (s *Server) Dispatch(ctx context.Context, method string, params json.RawMes
 		if prepareErr := entry.session.Prepare(ctx); prepareErr != nil {
 			return nil, normalizeError(prepareErr)
 		}
-		return struct{}{}, nil
+		return InvalidationResponse{InvalidatedSessionIDs: s.invalidateContext(entry.session, request.SessionID, true)}, nil
 	case "closeSession":
 		var request SessionRequest
 		if err := decodeParams(params, &request); err != nil {
@@ -768,6 +1029,46 @@ func (s *Server) Dispatch(ctx context.Context, method string, params json.RawMes
 			cookies[i] = Cookie{Name: cookie.Name, Value: cookie.Value, Domain: cookie.Domain, Path: cookie.Path, Secure: cookie.Secure, HTTPOnly: cookie.HTTPOnly, ExpiresUnix: cookie.ExpiresUnix, SameSite: cookie.SameSite}
 		}
 		return s.execute(ctx, request.SessionID, Operation{Kind: OperationSetCookies, Cookies: cookies})
+	case "getCookies":
+		var request SessionRequest
+		if err := decodeParams(params, &request); err != nil {
+			return nil, err
+		}
+		result, executeErr := s.execute(ctx, request.SessionID, Operation{Kind: OperationLifecycle, Lifecycle: LifecycleOperation{Kind: LifecycleGetCookies}})
+		if executeErr != nil {
+			return nil, executeErr
+		}
+		operationResult := result.(OperationResult)
+		var cookies []WireCookie
+		if operationResult.ObservedJSON != "" {
+			if err := json.Unmarshal([]byte(operationResult.ObservedJSON), &cookies); err != nil {
+				return nil, NewError(CodeDriver, "decode cookie snapshot: "+err.Error())
+			}
+		}
+		if cookies == nil {
+			cookies = []WireCookie{}
+		}
+		return CookieListResponse{Cookies: cookies}, nil
+	case "clearCookies":
+		var request SessionRequest
+		if err := decodeParams(params, &request); err != nil {
+			return nil, err
+		}
+		return s.execute(ctx, request.SessionID, Operation{Kind: OperationLifecycle, Lifecycle: LifecycleOperation{Kind: LifecycleClearCookies}})
+	case "lifecycle":
+		var request LifecycleRequest
+		if err := decodeParams(params, &request); err != nil {
+			return nil, err
+		}
+		operation, operationErr := lifecycleOperationFromWire(request.Operation, request.Expectation)
+		if operationErr != nil {
+			return nil, operationErr
+		}
+		policy, policyErr := pollFromWire(request.Poll)
+		if policyErr != nil {
+			return nil, policyErr
+		}
+		return s.execute(ctx, request.SessionID, Operation{Kind: OperationLifecycle, Lifecycle: operation, Poll: policy})
 	case "click":
 		var request LocatorRequest
 		if err := decodeParams(params, &request); err != nil {
@@ -1155,7 +1456,55 @@ func (s *Server) closeSession(id string) (any, *ProtocolError) {
 	if err := entry.session.Close(); err != nil {
 		return nil, normalizeError(err)
 	}
-	return struct{}{}, nil
+	invalidated := s.invalidateContext(entry.session, id, false)
+	invalidated = append([]string{id}, invalidated...)
+	return InvalidationResponse{InvalidatedSessionIDs: invalidated}, nil
+}
+
+func (s *Server) registerSession(session Session) (OpenSessionResponse, *ProtocolError) {
+	metadata := SessionMetadata{}
+	if discoverable, ok := session.(DiscoverableSession); ok {
+		metadata = discoverable.Metadata()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if metadata.TargetID != "" {
+		for id, entry := range s.sessions {
+			if existing, ok := entry.session.(DiscoverableSession); ok && existing.Metadata().TargetID == metadata.TargetID {
+				return openSessionResponse(id, metadata), nil
+			}
+		}
+	}
+	id, err := randomID()
+	if err != nil {
+		return OpenSessionResponse{}, NewError(CodeDriver, "generate session id")
+	}
+	s.sessions[id] = &sessionEntry{session: session}
+	return openSessionResponse(id, metadata), nil
+}
+
+func openSessionResponse(id string, metadata SessionMetadata) OpenSessionResponse {
+	return OpenSessionResponse{SessionID: id, ContextID: metadata.ContextID, TargetID: metadata.TargetID, OpenerID: metadata.OpenerID, OwnsContext: metadata.OwnsContext, Frame: metadata.Frame, URL: metadata.URL}
+}
+
+func (s *Server) invalidateContext(session Session, keepID string, keepSelf bool) []string {
+	discoverable, ok := session.(DiscoverableSession)
+	if !ok || discoverable.Metadata().ContextID == "" {
+		return nil
+	}
+	metadata := discoverable.Metadata()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	invalidated := []string{}
+	for id, entry := range s.sessions {
+		candidate, ok := entry.session.(DiscoverableSession)
+		if !ok || candidate.Metadata().ContextID != metadata.ContextID || (keepSelf && id == keepID) {
+			continue
+		}
+		delete(s.sessions, id)
+		invalidated = append(invalidated, id)
+	}
+	return invalidated
 }
 
 func (s *Server) Close() error {
@@ -1191,6 +1540,100 @@ func pollFromWire(poll PollOptions) (PollPolicy, *ProtocolError) {
 		return PollPolicy{}, NewError(CodeInvalidArgument, "unsupported poll mode")
 	}
 	return PollPolicy{Timeout: time.Duration(poll.TimeoutMS) * time.Millisecond, Interval: time.Duration(poll.IntervalMS) * time.Millisecond, Mode: mode}, nil
+}
+
+func tabQueryFromWire(query TabQueryRequest) (TabQuery, *ProtocolError) {
+	result := TabQuery{SpawnedOnly: query.SpawnedOnly}
+	var err *ProtocolError
+	if query.Title != nil {
+		value, decodeErr := expectationFromWire(query.Title, 0)
+		if decodeErr != nil {
+			return TabQuery{}, decodeErr
+		}
+		result.Title = &value
+	}
+	if query.URL != nil {
+		value, decodeErr := expectationFromWire(query.URL, 0)
+		if decodeErr != nil {
+			return TabQuery{}, decodeErr
+		}
+		result.URL = &value
+	}
+	if query.Has != nil {
+		value, decodeErr := locatorFromWire(query.Has)
+		if decodeErr != nil {
+			return TabQuery{}, decodeErr
+		}
+		result.HasElement = &value
+	}
+	return result, err
+}
+
+func lifecycleOperationFromWire(operation *WireLifecycleOperation, expected *WireExpectation) (LifecycleOperation, *ProtocolError) {
+	if operation == nil {
+		return LifecycleOperation{}, NewError(CodeInvalidArgument, "lifecycle operation is required")
+	}
+	kinds := map[string]LifecycleOperationKind{
+		"GET_COOKIES": LifecycleGetCookies, "CLEAR_COOKIES": LifecycleClearCookies, "COOKIE_QUERY": LifecycleCookieQuery,
+		"STORAGE_SET": LifecycleStorageSet, "STORAGE_GET": LifecycleStorageGet, "STORAGE_GET_ALL": LifecycleStorageGetAll, "STORAGE_REMOVE": LifecycleStorageRemove, "STORAGE_CLEAR": LifecycleStorageClear, "STORAGE_LENGTH": LifecycleStorageLength,
+		"WAIT_FOR_DEFINED": LifecycleWaitForDefined, "URL": LifecycleURL, "TITLE": LifecycleTitle, "WINDOW_SIZE": LifecycleWindowSize, "OUTLINE": LifecycleOutline, "ACCESSIBILITY_OUTLINE": LifecycleAccessibilityOutline, "CONSOLE_MESSAGES": LifecycleConsoleMessages,
+		"SET_DEVICE_METRICS": LifecycleSetDeviceMetrics, "CLEAR_DEVICE_METRICS": LifecycleClearDeviceMetrics, "SET_GEOLOCATION": LifecycleSetGeolocation, "CLEAR_GEOLOCATION": LifecycleClearGeolocation,
+		"SET_PERMISSIONS": LifecycleSetPermissions, "RESET_PERMISSIONS": LifecycleResetPermissions, "SET_LOCALE": LifecycleSetLocale, "CLEAR_LOCALE": LifecycleClearLocale, "SET_TIMEZONE": LifecycleSetTimezone, "CLEAR_TIMEZONE": LifecycleClearTimezone, "SET_MEDIA": LifecycleSetMedia, "CLEAR_MEDIA": LifecycleClearMedia,
+	}
+	kind, ok := kinds[operation.Kind]
+	if !ok {
+		return LifecycleOperation{}, NewError(CodeInvalidArgument, "unsupported lifecycle operation")
+	}
+	result := LifecycleOperation{Kind: kind, Area: operation.Area, Key: operation.Key, ValueJSON: operation.ValueJSON, Expression: operation.Expression, Count: operation.Count, Origin: operation.Origin, Permissions: operation.Permissions, Locale: operation.Locale, Timezone: operation.Timezone}
+	if operation.Device != nil {
+		result.Width = operation.Device.Width
+		result.Height = operation.Device.Height
+		result.DeviceScaleFactor = operation.Device.DeviceScaleFactor
+		result.Mobile = operation.Device.Mobile
+	}
+	if operation.Geolocation != nil {
+		result.Latitude = operation.Geolocation.Latitude
+		result.Longitude = operation.Geolocation.Longitude
+		result.Accuracy = operation.Geolocation.Accuracy
+	}
+	if operation.Media != nil {
+		result.MediaType = operation.Media.Type
+		result.ColorScheme = operation.Media.ColorScheme
+		result.ReducedMotion = operation.Media.ReducedMotion
+	}
+	if expected != nil {
+		expectation, err := expectationFromWire(expected, 0)
+		if err != nil {
+			return LifecycleOperation{}, err
+		}
+		result.Expectation = expectation
+	}
+	if operation.Cookie != nil {
+		result.Cookie.Secure, result.Cookie.HTTPOnly = operation.Cookie.Secure, operation.Cookie.HTTPOnly
+		for source, destination := range map[*WireExpectation]**Expectation{operation.Cookie.Name: &result.Cookie.Name, operation.Cookie.Value: &result.Cookie.Value, operation.Cookie.Domain: &result.Cookie.Domain, operation.Cookie.Path: &result.Cookie.Path, operation.Cookie.SameSite: &result.Cookie.SameSite} {
+			if source == nil {
+				continue
+			}
+			value, err := expectationFromWire(source, 0)
+			if err != nil {
+				return LifecycleOperation{}, err
+			}
+			*destination = &value
+		}
+	}
+	if strings.HasPrefix(operation.Kind, "STORAGE_") && operation.Area != "localStorage" && operation.Area != "sessionStorage" {
+		return LifecycleOperation{}, NewError(CodeInvalidArgument, "storage area must be localStorage or sessionStorage")
+	}
+	if operation.Kind == "STORAGE_SET" && operation.ValueJSON == "" {
+		return LifecycleOperation{}, NewError(CodeInvalidArgument, "storage set requires valueJson")
+	}
+	if operation.ValueJSON != "" {
+		var value any
+		if err := json.Unmarshal([]byte(operation.ValueJSON), &value); err != nil {
+			return LifecycleOperation{}, NewError(CodeInvalidArgument, "invalid lifecycle valueJson: "+err.Error())
+		}
+	}
+	return result, nil
 }
 
 func locatorFromWire(locator *WireLocator) (Locator, *ProtocolError) {

--- a/protocol/server.go
+++ b/protocol/server.go
@@ -651,6 +651,7 @@ type WireCookie struct {
 	Secure      bool    `json:"secure,omitempty"`
 	HTTPOnly    bool    `json:"httpOnly,omitempty"`
 	SameSite    string  `json:"sameSite,omitempty"`
+	Session     bool    `json:"session,omitempty"`
 }
 
 type SetCookiesRequest struct {
@@ -987,6 +988,9 @@ func (s *Server) Dispatch(ctx context.Context, method string, params json.RawMes
 		entry, err := s.session(request.SessionID)
 		if err != nil {
 			return nil, err
+		}
+		if discoverable, ok := entry.session.(DiscoverableSession); ok && !discoverable.Metadata().OwnsContext {
+			return nil, NewError(CodeInvalidArgument, "prepare requires an owning root session")
 		}
 		entry.mu.Lock()
 		defer entry.mu.Unlock()
@@ -1456,7 +1460,10 @@ func (s *Server) closeSession(id string) (any, *ProtocolError) {
 	if err := entry.session.Close(); err != nil {
 		return nil, normalizeError(err)
 	}
-	invalidated := s.invalidateContext(entry.session, id, false)
+	invalidated := []string{}
+	if discoverable, ok := entry.session.(DiscoverableSession); ok && discoverable.Metadata().OwnsContext {
+		invalidated = s.invalidateContext(entry.session, id, false)
+	}
 	invalidated = append([]string{id}, invalidated...)
 	return InvalidationResponse{InvalidatedSessionIDs: invalidated}, nil
 }
@@ -1626,6 +1633,17 @@ func lifecycleOperationFromWire(operation *WireLifecycleOperation, expected *Wir
 	}
 	if operation.Kind == "STORAGE_SET" && operation.ValueJSON == "" {
 		return LifecycleOperation{}, NewError(CodeInvalidArgument, "storage set requires valueJson")
+	}
+	if operation.Kind == "SET_PERMISSIONS" {
+		validPermissions := map[string]bool{"ar": true, "audioCapture": true, "automaticFullscreen": true, "backgroundFetch": true, "backgroundSync": true, "cameraPanTiltZoom": true, "capturedSurfaceControl": true, "clipboardReadWrite": true, "clipboardSanitizedWrite": true, "displayCapture": true, "durableStorage": true, "geolocation": true, "handTracking": true, "idleDetection": true, "keyboardLock": true, "localFonts": true, "localNetwork": true, "localNetworkAccess": true, "loopbackNetwork": true, "midi": true, "midiSysex": true, "nfc": true, "notifications": true, "paymentHandler": true, "periodicBackgroundSync": true, "pointerLock": true, "protectedMediaIdentifier": true, "sensors": true, "smartCard": true, "speakerSelection": true, "storageAccess": true, "topLevelStorageAccess": true, "videoCapture": true, "vr": true, "wakeLockScreen": true, "wakeLockSystem": true, "webAppInstallation": true, "webPrinting": true, "windowManagement": true}
+		for permission, state := range operation.Permissions {
+			if !validPermissions[permission] {
+				return LifecycleOperation{}, NewError(CodeInvalidArgument, "unsupported permission "+permission)
+			}
+			if state != "granted" && state != "denied" && state != "prompt" {
+				return LifecycleOperation{}, NewError(CodeInvalidArgument, "permission state must be granted, denied, or prompt")
+			}
+		}
 	}
 	if operation.ValueJSON != "" {
 		var value any

--- a/protocol/server_test.go
+++ b/protocol/server_test.go
@@ -3,6 +3,7 @@ package protocol_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -28,6 +29,7 @@ var _ = Describe("driver protocol", func() {
 		Expect(client.call("handshake", protocol.HandshakeRequest{ProtocolVersion: protocol.Version}, &response)).To(Succeed())
 		Expect(response.ProtocolVersion).To(Equal(protocol.Version))
 		Expect(response.Capabilities).NotTo(BeEmpty())
+		Expect(response.Capabilities).To(ContainElements("lifecycle.tabs", "lifecycle.cookies", "lifecycle.storage", "lifecycle.emulation", "lifecycle.frames"))
 
 		err := client.call("handshake", protocol.HandshakeRequest{ProtocolVersion: "999"}, nil)
 		Expect(err).To(MatchError(ContainSubstring("protocol version mismatch")))
@@ -49,6 +51,64 @@ var _ = Describe("driver protocol", func() {
 		Expect(backend.opened).To(Equal(1))
 		Expect(backend.session.prepared).To(Equal(1))
 		Expect(backend.session.closed).To(Equal(1))
+	})
+
+	It("serves typed lifecycle state operations", func() {
+		client, cleanup := startTestServer(&fakeBackend{session: &fakeSession{result: protocol.Result{Matched: true, Attempts: 1, ObservedJSON: `[]`}}})
+		DeferCleanup(cleanup)
+
+		var opened protocol.OpenSessionResponse
+		Expect(client.call("openSession", struct{}{}, &opened)).To(Succeed())
+		var cookies struct {
+			Cookies []protocol.WireCookie `json:"cookies"`
+		}
+		Expect(client.call("getCookies", protocol.SessionRequest{SessionID: opened.SessionID}, &cookies)).To(Succeed())
+		Expect(cookies.Cookies).To(BeEmpty())
+	})
+
+	It("validates and carries lifecycle operation categories", func() {
+		recorder := &recordingSession{}
+		client, cleanup := startTestServer(&fakeBackend{custom: recorder})
+		DeferCleanup(cleanup)
+		var opened protocol.OpenSessionResponse
+		Expect(client.call("openSession", struct{}{}, &opened)).To(Succeed())
+
+		Expect(client.call("lifecycle", protocol.LifecycleRequest{
+			SessionID:   opened.SessionID,
+			Operation:   &protocol.WireLifecycleOperation{Kind: "STORAGE_GET", Area: "localStorage", Key: "ready"},
+			Expectation: &protocol.WireExpectation{Kind: "EQUAL", ExpectedJSON: `true`},
+			Poll:        protocol.PollOptions{Mode: "EVENTUALLY", TimeoutMS: 250},
+		}, nil)).To(Succeed())
+		Expect(recorder.lastOperation().Lifecycle.Kind).To(Equal(protocol.LifecycleStorageGet))
+		Expect(recorder.lastOperation().Lifecycle.Key).To(Equal("ready"))
+		Expect(recorder.lastOperation().Poll.Timeout).To(Equal(250 * time.Millisecond))
+
+		err := client.call("lifecycle", protocol.LifecycleRequest{SessionID: opened.SessionID, Operation: &protocol.WireLifecycleOperation{Kind: "STORAGE_GET", Area: "indexedDB"}}, nil)
+		Expect(err.Code).To(Equal(protocol.CodeInvalidArgument))
+		err = client.call("lifecycle", protocol.LifecycleRequest{SessionID: opened.SessionID, Operation: &protocol.WireLifecycleOperation{Kind: "RAW_CDP"}}, nil)
+		Expect(err.Code).To(Equal(protocol.CodeInvalidArgument))
+	})
+
+	It("registers discovered handles once and invalidates context siblings on prepare", func() {
+		child := &discoverableSession{metadata: protocol.SessionMetadata{ContextID: "context-a", TargetID: "child", OpenerID: "root"}}
+		root := &discoverableSession{metadata: protocol.SessionMetadata{ContextID: "context-a", TargetID: "root", OwnsContext: true}, tabs: []protocol.Session{child}}
+		client, cleanup := startTestServer(&fakeBackend{custom: root})
+		DeferCleanup(cleanup)
+
+		var opened protocol.OpenSessionResponse
+		Expect(client.call("openSession", struct{}{}, &opened)).To(Succeed())
+		Expect(opened.ContextID).To(Equal("context-a"))
+		var first, second protocol.HandleListResponse
+		Expect(client.call("listTabs", protocol.ListHandlesRequest{SessionID: opened.SessionID}, &first)).To(Succeed())
+		Expect(client.call("listTabs", protocol.ListHandlesRequest{SessionID: opened.SessionID}, &second)).To(Succeed())
+		Expect(first.Handles).To(HaveLen(1))
+		Expect(second.Handles[0].SessionID).To(Equal(first.Handles[0].SessionID))
+
+		var prepared protocol.InvalidationResponse
+		Expect(client.call("prepareSession", protocol.SessionRequest{SessionID: opened.SessionID}, &prepared)).To(Succeed())
+		Expect(prepared.InvalidatedSessionIDs).To(ConsistOf(first.Handles[0].SessionID))
+		err := client.call("prepareSession", protocol.SessionRequest{SessionID: first.Handles[0].SessionID}, nil)
+		Expect(err.Code).To(Equal(protocol.CodeTargetNotFound))
 	})
 
 	// `invoke` is what makes an expression's meaning explicit on the wire: without it the daemon has
@@ -515,6 +575,37 @@ type blockingSession struct {
 	active, maxActive int
 	entered           chan string
 	release           chan struct{}
+}
+
+type discoverableSession struct {
+	metadata protocol.SessionMetadata
+	tabs     []protocol.Session
+	frames   []protocol.Session
+}
+
+func (s *discoverableSession) Metadata() protocol.SessionMetadata { return s.metadata }
+func (s *discoverableSession) Prepare(context.Context) error      { return nil }
+func (s *discoverableSession) Close() error                       { return nil }
+func (s *discoverableSession) Execute(context.Context, protocol.Operation) (protocol.Result, error) {
+	return protocol.Result{Matched: true, Attempts: 1}, nil
+}
+func (s *discoverableSession) Tabs(context.Context) ([]protocol.Session, error) {
+	return s.tabs, nil
+}
+func (s *discoverableSession) Frames(context.Context) ([]protocol.Session, error) {
+	return s.frames, nil
+}
+func (s *discoverableSession) WaitForTab(context.Context, protocol.TabQuery, protocol.PollPolicy) (protocol.Session, error) {
+	if len(s.tabs) == 0 {
+		return nil, errors.New("no tab")
+	}
+	return s.tabs[0], nil
+}
+func (s *discoverableSession) WaitForFrame(context.Context, protocol.FrameQuery, protocol.PollPolicy) (protocol.Session, error) {
+	if len(s.frames) == 0 {
+		return nil, errors.New("no frame")
+	}
+	return s.frames[0], nil
 }
 
 func (*blockingSession) Prepare(context.Context) error { return nil }

--- a/protocol/server_test.go
+++ b/protocol/server_test.go
@@ -87,6 +87,10 @@ var _ = Describe("driver protocol", func() {
 		Expect(err.Code).To(Equal(protocol.CodeInvalidArgument))
 		err = client.call("lifecycle", protocol.LifecycleRequest{SessionID: opened.SessionID, Operation: &protocol.WireLifecycleOperation{Kind: "RAW_CDP"}}, nil)
 		Expect(err.Code).To(Equal(protocol.CodeInvalidArgument))
+		err = client.call("lifecycle", protocol.LifecycleRequest{SessionID: opened.SessionID, Operation: &protocol.WireLifecycleOperation{Kind: "SET_PERMISSIONS", Permissions: map[string]string{"not-a-cdp-permission": "granted"}}}, nil)
+		Expect(err.Code).To(Equal(protocol.CodeInvalidArgument))
+		err = client.call("lifecycle", protocol.LifecycleRequest{SessionID: opened.SessionID, Operation: &protocol.WireLifecycleOperation{Kind: "SET_PERMISSIONS", Permissions: map[string]string{"clipboardReadWrite": "sometimes"}}}, nil)
+		Expect(err.Code).To(Equal(protocol.CodeInvalidArgument))
 	})
 
 	It("registers discovered handles once and invalidates context siblings on prepare", func() {
@@ -109,6 +113,25 @@ var _ = Describe("driver protocol", func() {
 		Expect(prepared.InvalidatedSessionIDs).To(ConsistOf(first.Handles[0].SessionID))
 		err := client.call("prepareSession", protocol.SessionRequest{SessionID: first.Handles[0].SessionID}, nil)
 		Expect(err.Code).To(Equal(protocol.CodeTargetNotFound))
+	})
+
+	It("keeps an owning session live when a discovered child closes and rejects prepare on the child", func() {
+		child := &discoverableSession{metadata: protocol.SessionMetadata{ContextID: "context-a", TargetID: "child", OpenerID: "root"}}
+		root := &discoverableSession{metadata: protocol.SessionMetadata{ContextID: "context-a", TargetID: "root", OwnsContext: true}, tabs: []protocol.Session{child}}
+		client, cleanup := startTestServer(&fakeBackend{custom: root})
+		DeferCleanup(cleanup)
+
+		var opened protocol.OpenSessionResponse
+		Expect(client.call("openSession", struct{}{}, &opened)).To(Succeed())
+		var handles protocol.HandleListResponse
+		Expect(client.call("listTabs", protocol.ListHandlesRequest{SessionID: opened.SessionID}, &handles)).To(Succeed())
+		Expect(handles.Handles).To(HaveLen(1))
+
+		err := client.call("prepareSession", protocol.SessionRequest{SessionID: handles.Handles[0].SessionID}, nil)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Code).To(Equal(protocol.CodeInvalidArgument))
+		Expect(client.call("closeSession", protocol.SessionRequest{SessionID: handles.Handles[0].SessionID}, nil)).To(Succeed())
+		Expect(client.call("prepareSession", protocol.SessionRequest{SessionID: opened.SessionID}, nil)).To(Succeed())
 	})
 
 	// `invoke` is what makes an expression's meaning explicit on the wire: without it the daemon has

--- a/typescript/src/generated/protocol.ts
+++ b/typescript/src/generated/protocol.ts
@@ -190,6 +190,7 @@ export interface Cookie {
   secure?: boolean;
   httpOnly?: boolean;
   sameSite?: string;
+  session?: boolean;
 }
 
 export interface SetCookiesRequest {

--- a/typescript/src/generated/protocol.ts
+++ b/typescript/src/generated/protocol.ts
@@ -47,10 +47,48 @@ export interface HandshakeResponse {
 
 export interface OpenSessionResponse {
   sessionId: string;
+  contextId?: string;
+  targetId?: string;
+  openerId?: string;
+  ownsContext?: boolean;
+  frame?: boolean;
+  url?: string;
 }
 
 export interface SessionRequest {
   sessionId: string;
+}
+
+export interface TabQueryRequest {
+  spawnedOnly?: boolean;
+  title?: Expectation;
+  url?: Expectation;
+  has?: Locator;
+}
+
+export interface ListHandlesRequest {
+  sessionId: string;
+  spawnedOnly?: boolean;
+}
+
+export interface WaitForTabRequest {
+  sessionId: string;
+  query: TabQueryRequest;
+  poll?: PollOptions;
+}
+
+export interface WaitForFrameRequest {
+  sessionId: string;
+  query: TabQueryRequest;
+  poll?: PollOptions;
+}
+
+export interface HandleListResponse {
+  handles: OpenSessionResponse[];
+}
+
+export interface InvalidationResponse {
+  invalidatedSessionIds?: string[];
 }
 
 export interface NavigateRequest {
@@ -156,6 +194,63 @@ export interface Cookie {
 
 export interface SetCookiesRequest {
   sessionId: string;
+  cookies: Cookie[];
+}
+
+export interface CookieQuery {
+  name?: Expectation;
+  value?: Expectation;
+  domain?: Expectation;
+  path?: Expectation;
+  sameSite?: Expectation;
+  secure?: boolean;
+  httpOnly?: boolean;
+}
+
+export interface DeviceMetrics {
+  width: number;
+  height: number;
+  deviceScaleFactor: number;
+  mobile?: boolean;
+}
+
+export interface Geolocation {
+  latitude: number;
+  longitude: number;
+  accuracy?: number;
+}
+
+export interface Media {
+  type?: string;
+  colorScheme?: string;
+  reducedMotion?: string;
+}
+
+export interface LifecycleOperation {
+  kind: "GET_COOKIES" | "CLEAR_COOKIES" | "COOKIE_QUERY" | "STORAGE_SET" | "STORAGE_GET" | "STORAGE_GET_ALL" | "STORAGE_REMOVE" | "STORAGE_CLEAR" | "STORAGE_LENGTH" | "WAIT_FOR_DEFINED" | "URL" | "TITLE" | "WINDOW_SIZE" | "OUTLINE" | "ACCESSIBILITY_OUTLINE" | "CONSOLE_MESSAGES" | "SET_DEVICE_METRICS" | "CLEAR_DEVICE_METRICS" | "SET_GEOLOCATION" | "CLEAR_GEOLOCATION" | "SET_PERMISSIONS" | "RESET_PERMISSIONS" | "SET_LOCALE" | "CLEAR_LOCALE" | "SET_TIMEZONE" | "CLEAR_TIMEZONE" | "SET_MEDIA" | "CLEAR_MEDIA";
+  area?: string;
+  key?: string;
+  valueJson?: string;
+  expression?: string;
+  cookie?: CookieQuery;
+  count?: boolean;
+  device?: DeviceMetrics;
+  geolocation?: Geolocation;
+  origin?: string;
+  permissions?: Record<string, string>;
+  locale?: string;
+  timezone?: string;
+  media?: Media;
+}
+
+export interface LifecycleRequest {
+  sessionId: string;
+  operation?: LifecycleOperation;
+  expectation?: Expectation;
+  poll?: PollOptions;
+}
+
+export interface CookieListResponse {
   cookies: Cookie[];
 }
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -174,10 +174,14 @@ export interface WaitOptions {
   signal?: AbortSignal | undefined;
   mode?: "eventually" | "immediate" | "consistently" | undefined;
 }
+export type PollOptions = WaitOptions;
 
 export interface CancellationOptions {
   signal?: AbortSignal | undefined;
 }
+
+export interface WaitingCommandOptions extends CancellationOptions {timeoutMs?: number | undefined}
+export type CommandOptions = CancellationOptions;
 
 export type Modifier = "Shift" | "Control" | "Alt" | "Meta";
 export type TextMode = "innerText" | "textContent" | "normalizedText";
@@ -256,7 +260,52 @@ export interface Cookie {
   secure?: boolean | undefined;
   httpOnly?: boolean | undefined;
   sameSite?: string | undefined;
+	readonly session?: boolean | undefined;
 }
+
+export interface CookieQuery {
+	name?: ExpectedValue | undefined;
+	value?: ExpectedValue | undefined;
+	domain?: ExpectedValue | undefined;
+	path?: ExpectedValue | undefined;
+	sameSite?: ExpectedValue | undefined;
+	secure?: boolean | undefined;
+	httpOnly?: boolean | undefined;
+}
+
+export type StorageArea = "localStorage" | "sessionStorage";
+export type StorageItem<T = unknown> = {readonly found: true; readonly value: T} | {readonly found: false};
+export interface BrowserStorage {
+	set(key: string, value: SerializableValue, options?: CommandOptions): Promise<void>;
+	get<T = unknown>(key: string, options?: CommandOptions): Promise<StorageItem<T>>;
+	getAll(options?: CommandOptions): Promise<Readonly<Record<string, unknown>>>;
+	remove(key: string, options?: CommandOptions): Promise<void>;
+	clear(options?: CommandOptions): Promise<void>;
+	length(options?: CommandOptions): Promise<number>;
+	expectItem<T = unknown>(key: string, expected?: ExpectedValue, options?: PollOptions): Promise<T>;
+	expectLength(expected: number | Expectation, options?: PollOptions): Promise<AssertionResult>;
+}
+
+export interface TabQuery {
+	title?: ExpectedValue | undefined;
+	url?: ExpectedValue | undefined;
+	has?: Locator | string | undefined;
+}
+export interface WindowSize {readonly width: number; readonly height: number}
+export interface ConsoleMessage {readonly type: string; readonly text: string; readonly args: readonly unknown[]; readonly timestamp: string}
+export interface DeviceMetrics {readonly width: number; readonly height: number; readonly deviceScaleFactor?: number | undefined; readonly mobile?: boolean | undefined}
+export interface Geolocation {readonly latitude: number; readonly longitude: number; readonly accuracy?: number | undefined}
+export type Permission =
+	| "ar" | "audioCapture" | "automaticFullscreen" | "backgroundFetch" | "backgroundSync"
+	| "cameraPanTiltZoom" | "capturedSurfaceControl" | "clipboardReadWrite" | "clipboardSanitizedWrite"
+	| "displayCapture" | "durableStorage" | "geolocation" | "handTracking" | "idleDetection"
+	| "keyboardLock" | "localFonts" | "localNetwork" | "localNetworkAccess" | "loopbackNetwork"
+	| "midi" | "midiSysex" | "nfc" | "notifications" | "paymentHandler" | "periodicBackgroundSync"
+	| "pointerLock" | "protectedMediaIdentifier" | "sensors" | "smartCard" | "speakerSelection"
+	| "storageAccess" | "topLevelStorageAccess" | "videoCapture" | "vr" | "wakeLockScreen"
+	| "wakeLockSystem" | "webAppInstallation" | "webPrinting" | "windowManagement";
+export type PermissionState = "granted" | "denied" | "prompt";
+export interface MediaEmulation {readonly type?: "screen" | "print" | "" | undefined; readonly colorScheme?: "light" | "dark" | "no-preference" | undefined; readonly reducedMotion?: "reduce" | "no-preference" | undefined}
 
 export interface PollObservation {
   readonly attempt: number;
@@ -473,16 +522,55 @@ export interface Locator {
 
 export interface Session {
   readonly id: string;
-  newTab(): Promise<Session>;
-  addInitScript(script: string, options?: WaitOptions): Promise<void>;
-  activate(options?: WaitOptions): Promise<void>;
-  prepare(): Promise<void>;
-  navigate(url: string, options?: WaitOptions): Promise<void>;
-  navigateWithStatus(url: string, expectedStatus: number, options?: WaitOptions): Promise<void>;
-  setCookies(cookies: readonly Cookie[]): Promise<void>;
-  evaluate<T = unknown>(expression: string, args?: readonly SerializableValue[], options?: WaitOptions): Promise<T>;
-  evaluateAsync<T = unknown>(expression: string, args?: readonly SerializableValue[], options?: WaitOptions): Promise<T>;
-  setWindowSize(width: number, height: number, options?: WaitOptions): Promise<void>;
+	readonly contextId: string;
+	readonly targetId: string;
+	readonly openerId?: string;
+	readonly ownsContext: boolean;
+	readonly isFrame: boolean;
+	readonly frameUrl?: string;
+	newTab(options?: WaitingCommandOptions): Promise<Session>;
+	tabs(options?: CommandOptions): Promise<readonly Session[]>;
+	spawnedTabs(options?: CommandOptions): Promise<readonly Session[]>;
+	findTab(query: TabQuery, options?: CommandOptions): Promise<Session | undefined>;
+	waitForTab(query: TabQuery, options?: PollOptions): Promise<Session>;
+	frames(options?: CommandOptions): Promise<readonly Session[]>;
+	waitForFrame(query: TabQuery, options?: PollOptions): Promise<Session>;
+  addInitScript(script: string, options?: CommandOptions): Promise<void>;
+  activate(options?: CommandOptions): Promise<void>;
+  prepare(options?: WaitingCommandOptions): Promise<{readonly invalidatedSessionIds: readonly string[]}>;
+  navigate(url: string, options?: WaitingCommandOptions): Promise<void>;
+  navigateWithStatus(url: string, expectedStatus: number, options?: WaitingCommandOptions): Promise<void>;
+  setCookies(cookies: readonly Cookie[], options?: CommandOptions): Promise<void>;
+	getCookies(options?: CommandOptions): Promise<readonly Cookie[]>;
+	clearCookies(options?: CommandOptions): Promise<void>;
+	findCookie(query: CookieQuery, options?: CommandOptions): Promise<Cookie | undefined>;
+	expectCookie(query: CookieQuery, options?: PollOptions): Promise<Cookie>;
+	expectCookieCount(expected: number | Expectation, query?: CookieQuery, options?: PollOptions): Promise<AssertionResult>;
+	localStorage(): BrowserStorage;
+	sessionStorage(): BrowserStorage;
+  evaluate<T = unknown>(expression: string, args?: readonly SerializableValue[], options?: CommandOptions): Promise<T>;
+  evaluateAsync<T = unknown>(expression: string, args?: readonly SerializableValue[], options?: WaitingCommandOptions): Promise<T>;
+	waitForDefined<T = unknown>(expression: string, options?: PollOptions): Promise<T>;
+  setWindowSize(width: number, height: number, options?: CommandOptions): Promise<void>;
+	windowSize(options?: CommandOptions): Promise<WindowSize>;
+	title(options?: CommandOptions): Promise<string>;
+	expectTitle(expected: ExpectedValue, options?: PollOptions): Promise<AssertionResult>;
+	outline(options?: CommandOptions): Promise<string>;
+	accessibilityOutline(options?: CommandOptions): Promise<string>;
+	consoleMessages(options?: CommandOptions): Promise<readonly ConsoleMessage[]>;
+	expectConsoleMessage(expected: ExpectedValue, options?: PollOptions & {type?: string | undefined}): Promise<ConsoleMessage>;
+	setDeviceMetrics(metrics: DeviceMetrics, options?: CommandOptions): Promise<void>;
+	clearDeviceMetrics(options?: CommandOptions): Promise<void>;
+	setGeolocation(location: Geolocation, options?: CommandOptions): Promise<void>;
+	clearGeolocation(options?: CommandOptions): Promise<void>;
+	setPermissions(origin: string, permissions: Readonly<Partial<Record<Permission, PermissionState>>>, options?: CommandOptions): Promise<void>;
+	resetPermissions(options?: CommandOptions): Promise<void>;
+	setLocale(locale: string, options?: CommandOptions): Promise<void>;
+	clearLocale(options?: CommandOptions): Promise<void>;
+	setTimezone(timezone: string, options?: CommandOptions): Promise<void>;
+	clearTimezone(options?: CommandOptions): Promise<void>;
+	setMedia(media: MediaEmulation, options?: CommandOptions): Promise<void>;
+	clearMedia(options?: CommandOptions): Promise<void>;
   sendKeys(keys: string, options?: WindowKeyboardOptions): Promise<void>;
   clearSelection(options?: CancellationOptions): Promise<void>;
   normalizeColor(color: string, options?: CancellationOptions): Promise<string>;
@@ -496,11 +584,13 @@ export interface Session {
   getByPlaceholder(value: string, options?: {exact?: boolean | undefined}): Locator;
   getByAltText(value: string, options?: {exact?: boolean | undefined}): Locator;
   getByTitle(value: string, options?: {exact?: boolean | undefined}): Locator;
+  // One URL assertion, as Go has one HaveURL.  expectUrl is the superset: exact tightens the match,
+  // pathname compares window.location.pathname instead of the whole URL.
   expectUrl(expected: ExpectedValue, options?: WaitOptions & {exact?: boolean | undefined; pathname?: boolean | undefined}): Promise<AssertionResult>;
-  url(): Promise<string>;
+  url(options?: CommandOptions): Promise<string>;
   expectEvaluation(expression: string, expected: ExpectedValue, options?: WaitOptions): Promise<AssertionResult>;
   expectRequest(expectedUrl: ExpectedValue, options?: WaitOptions & {method?: string | undefined}): Promise<AssertionResult>;
-  holdResponse(expectedUrl: ExpectedValue, options?: WaitOptions): Promise<ResponseHold>;
+  holdResponse(expectedUrl: ExpectedValue, options?: CommandOptions): Promise<ResponseHold>;
 }
 
 export interface HeldResponse {
@@ -509,8 +599,8 @@ export interface HeldResponse {
 }
 
 export interface ResponseHold {
-  await(options?: WaitOptions): Promise<HeldResponse>;
-  release(options?: WaitOptions): Promise<void>;
+  await(options?: WaitingCommandOptions): Promise<HeldResponse>;
+  release(options?: CommandOptions): Promise<void>;
 }
 
 export interface Browser {

--- a/typescript/src/internal/client.ts
+++ b/typescript/src/internal/client.ts
@@ -5,6 +5,7 @@ import type {
   DOMRequest,
   Expectation as WireExpectation,
   Locator as WireLocator,
+	LifecycleOperation as WireLifecycleOperation,
   LocatorRequest,
   OperationResult as StdioOperationResult,
   SetValueRequest,
@@ -18,6 +19,21 @@ import {
   type ConnectOptions,
   type Cookie,
   type ClickOptions,
+	type CommandOptions,
+	type WaitingCommandOptions,
+	type PollOptions,
+	type CookieQuery,
+	type BrowserStorage,
+	type StorageArea,
+	type StorageItem,
+	type TabQuery,
+	type WindowSize,
+	type ConsoleMessage,
+	type DeviceMetrics,
+	type Geolocation,
+	type Permission,
+	type PermissionState,
+	type MediaEmulation,
   type CancellationOptions,
   type KeyboardOptions,
   type PointerOptions,
@@ -74,7 +90,7 @@ class ClientBrowser implements Browser {
   async openSession(): Promise<Session> {
     this.#assertOpen();
     const response = await this.#transport.openSession({});
-    return this.#trackSession(response.sessionId ?? "");
+    return this.#trackSession(response);
   }
 
   async close(): Promise<void> {
@@ -90,71 +106,116 @@ class ClientBrowser implements Browser {
     if (this.#closed) throw new BilobaError({code: "DRIVER_CLOSED", message: "Biloba browser is closed"});
   }
 
-  #trackSession(id: string): ClientSession {
+  #trackSession(response: import("../generated/protocol.js").OpenSessionResponse): ClientSession {
+		const existing = [...this.#sessions].find((candidate) => candidate.id === response.sessionId);
+		if (existing) return existing;
     let session: ClientSession;
     session = new ClientSession(
-      id,
+      response,
       this.#transport,
       () => this.#sessions.delete(session),
-      (siblingId) => this.#trackSession(siblingId),
+      (sibling) => this.#trackSession(sibling),
+			(ids) => this.#invalidateSessions(ids),
     );
     this.#sessions.add(session);
     return session;
   }
+
+	#invalidateSessions(ids: readonly string[]): void {
+		for (const session of this.#sessions) {
+			if (ids.includes(session.id)) session.invalidate();
+		}
+	}
 }
 
 class ClientSession implements Session {
   readonly id: string;
+	readonly contextId: string;
+	readonly targetId: string;
+	readonly openerId?: string;
+	readonly ownsContext: boolean;
+	readonly isFrame: boolean;
+	readonly frameUrl?: string;
   readonly #transport: DriverTransport;
   readonly #onClose: () => void;
-  readonly #registerSibling: (id: string) => ClientSession;
+  readonly #registerSibling: (response: import("../generated/protocol.js").OpenSessionResponse) => ClientSession;
+	readonly #invalidateSessions: (ids: readonly string[]) => void;
   closed = false;
 
   constructor(
-    id: string,
+    response: import("../generated/protocol.js").OpenSessionResponse,
     transport: DriverTransport,
     onClose: () => void,
-    registerSibling: (id: string) => ClientSession,
+    registerSibling: (response: import("../generated/protocol.js").OpenSessionResponse) => ClientSession,
+		invalidateSessions: (ids: readonly string[]) => void,
   ) {
-    this.id = id;
+		this.id = response.sessionId;
+		this.contextId = response.contextId ?? "";
+		this.targetId = response.targetId ?? "";
+		if (response.openerId !== undefined) this.openerId = response.openerId;
+		this.ownsContext = response.ownsContext ?? false;
+		this.isFrame = response.frame ?? false;
+		if (response.url !== undefined) this.frameUrl = response.url;
     this.#transport = transport;
     this.#onClose = onClose;
     this.#registerSibling = registerSibling;
+		this.#invalidateSessions = invalidateSessions;
   }
 
-  async newTab(): Promise<Session> {
+  async newTab(options: WaitingCommandOptions = {}): Promise<Session> {
     this.#assertOpen();
-    const response = await this.#transport.newTab({sessionId: this.id});
-    return this.#registerSibling(response.sessionId ?? "");
+    assertWaitingCommandOptions(options, "newTab");
+    const response = await this.#transport.newTab({sessionId: this.id}, options);
+    return this.#registerSibling(response);
   }
 
-  async addInitScript(script: string, options: WaitOptions = {}): Promise<void> {
+	async tabs(options: CommandOptions = {}): Promise<readonly Session[]> { return await this.#listHandles("tabs", false, options); }
+	async spawnedTabs(options: CommandOptions = {}): Promise<readonly Session[]> { return await this.#listHandles("tabs", true, options); }
+	async frames(options: CommandOptions = {}): Promise<readonly Session[]> { return await this.#listHandles("frames", false, options); }
+	async findTab(query: TabQuery, options: CommandOptions = {}): Promise<Session | undefined> {
+		const tabs = await this.tabs(options);
+		if (Object.keys(query).length === 0) return tabs[0];
+		// A zero-time server poll keeps all predicates on the same candidate observation.
+		try { return await this.waitForTab(query, {...options, mode: "immediate"}); } catch (error) { if (error instanceof BilobaError && error.code === "TIMEOUT") return undefined; throw error; }
+	}
+	async waitForTab(query: TabQuery, options: PollOptions = {}): Promise<Session> { return await this.#waitForHandle("tab", query, options); }
+	async waitForFrame(query: TabQuery, options: PollOptions = {}): Promise<Session> { return await this.#waitForHandle("frame", query, options); }
+
+  async addInitScript(script: string, options: CommandOptions = {}): Promise<void> {
     this.#assertOpen();
+    assertCancellationOptions(options, "addInitScript");
     const response = await this.#transport.addInitScript({sessionId: this.id, script}, options);
     operationResult(response, "add init script operation", new Error().stack);
   }
 
-  async activate(options: WaitOptions = {}): Promise<void> {
+  async activate(options: CommandOptions = {}): Promise<void> {
     this.#assertOpen();
+    assertCancellationOptions(options, "activate");
     const response = await this.#transport.activate({sessionId: this.id}, options);
     operationResult(response, "activate tab operation", new Error().stack);
   }
 
-  async prepare(): Promise<void> {
+  async prepare(options: WaitingCommandOptions = {}): Promise<{readonly invalidatedSessionIds: readonly string[]}> {
     this.#assertOpen();
-    await this.#transport.prepareSession({sessionId: this.id});
+		assertWaitingCommandOptions(options, "prepare");
+		const response = await this.#transport.prepareSession({sessionId: this.id}, options);
+		const ids = response.invalidatedSessionIds ?? [];
+		this.#invalidateSessions(ids);
+		return {invalidatedSessionIds: ids};
   }
 
-  async navigate(url: string, options: WaitOptions = {}): Promise<void> {
+  async navigate(url: string, options: WaitingCommandOptions = {}): Promise<void> {
     this.#assertOpen();
+    assertWaitingCommandOptions(options, "navigate");
     await this.#transport.navigate({sessionId: this.id, url}, options);
   }
 
   // Mirrors the Go runner's NavigateWithStatus.  navigate() asserting 200 is what makes a broken
   // fixture fail at the navigation rather than as a baffling assertion three lines later; this is
   // the way to say the 4xx/5xx page is the page you meant to load.
-  async navigateWithStatus(url: string, expectedStatus: number, options: WaitOptions = {}): Promise<void> {
+  async navigateWithStatus(url: string, expectedStatus: number, options: WaitingCommandOptions = {}): Promise<void> {
     this.#assertOpen();
+    assertWaitingCommandOptions(options, "navigateWithStatus");
     await this.#transport.navigate({sessionId: this.id, url, expectedStatus}, options);
   }
 
@@ -179,8 +240,9 @@ class ClientSession implements Session {
     return parseJson(response.observedJson) as string;
   }
 
-  async setCookies(cookies: readonly Cookie[]): Promise<void> {
+  async setCookies(cookies: readonly Cookie[], options: CommandOptions = {}): Promise<void> {
     this.#assertOpen();
+    assertCancellationOptions(options, "setCookies");
     await this.#transport.setCookies({
       sessionId: this.id,
       // The public Cookie lets a caller pass an explicit undefined for any optional member; the
@@ -199,8 +261,34 @@ class ClientSession implements Session {
           expiresUnix: typeof expires === "number" ? expires : expires.getTime() / 1_000,
         }),
       })),
-    });
+    }, options);
   }
+
+	async getCookies(options: CommandOptions = {}): Promise<readonly Cookie[]> {
+		this.#assertOpen();
+		assertCancellationOptions(options, "getCookies");
+		const response = await this.#transport.getCookies({sessionId: this.id}, options);
+		return response.cookies.map(cookieFromWire);
+	}
+	async clearCookies(options: CommandOptions = {}): Promise<void> {
+		this.#assertOpen();
+		assertCancellationOptions(options, "clearCookies");
+		operationResult(await this.#transport.clearCookies({sessionId: this.id}, options), "clear cookies operation", new Error().stack);
+	}
+	async findCookie(query: CookieQuery, options: CommandOptions = {}): Promise<Cookie | undefined> {
+		return (await this.getCookies(options)).find((cookie) => currentCookieMatches(cookie, query));
+	}
+	async expectCookie(query: CookieQuery, options: PollOptions = {}): Promise<Cookie> {
+		const response = await this.lifecycleOperation({kind: "COOKIE_QUERY", cookie: wireCookieQuery(query)}, options);
+		operationResult(response, "cookie assertion", new Error().stack);
+		return cookieFromWire(parseJson(response.observedJson) as import("../generated/protocol.js").Cookie);
+	}
+	async expectCookieCount(expected: number | Expectation, query: CookieQuery = {}, options: PollOptions = {}): Promise<AssertionResult> {
+		const response = await this.lifecycleOperation({kind: "COOKIE_QUERY", cookie: wireCookieQuery(query), count: true}, options, wireExpectation(expected));
+		return assertionResult(response, new Error().stack);
+	}
+	localStorage(): BrowserStorage { return new ClientStorage(this, "localStorage"); }
+	sessionStorage(): BrowserStorage { return new ClientStorage(this, "sessionStorage"); }
 
   // invoke tells the daemon what expression means instead of letting it infer that from the
   // argument count: passing an args array - even an empty one - is the caller saying "call this",
@@ -210,9 +298,10 @@ class ClientSession implements Session {
   async evaluate<T = unknown>(
     expression: string,
     args?: readonly SerializableValue[],
-    options: WaitOptions = {},
+    options: CommandOptions = {},
   ): Promise<T> {
     this.#assertOpen();
+    assertCancellationOptions(options, "evaluate");
     const response = await this.#transport.evaluate({
       sessionId: this.id,
       expression,
@@ -225,9 +314,10 @@ class ClientSession implements Session {
   async evaluateAsync<T = unknown>(
     expression: string,
     args?: readonly SerializableValue[],
-    options: WaitOptions = {},
+    options: WaitingCommandOptions = {},
   ): Promise<T> {
     this.#assertOpen();
+    assertWaitingCommandOptions(options, "evaluateAsync");
     const response = await this.#transport.evaluate({
       sessionId: this.id,
       expression,
@@ -238,17 +328,87 @@ class ClientSession implements Session {
     return parseJson(response.observedJson) as T;
   }
 
-  async setWindowSize(width: number, height: number, options: WaitOptions = {}): Promise<void> {
+  async waitForDefined<T = unknown>(expression: string, options: PollOptions = {}): Promise<T> {
+		const response = await this.lifecycleOperation({kind: "WAIT_FOR_DEFINED", expression}, options);
+		operationResult(response, "wait for defined JavaScript value", new Error().stack);
+		return parseJson(response.observedJson) as T;
+	}
+
+  async setWindowSize(width: number, height: number, options: CommandOptions = {}): Promise<void> {
     this.#assertOpen();
+    assertCancellationOptions(options, "setWindowSize");
     const response = await this.#transport.setWindowSize({sessionId: this.id, width, height}, options);
     operationResult(response, "set window size operation", new Error().stack);
   }
+
+	async windowSize(options: CommandOptions = {}): Promise<WindowSize> { return await this.#lifecycleValue<WindowSize>({kind: "WINDOW_SIZE"}, options); }
+	async title(options: CommandOptions = {}): Promise<string> { return await this.#lifecycleValue<string>({kind: "TITLE"}, options); }
+	async expectTitle(expected: ExpectedValue, options: PollOptions = {}): Promise<AssertionResult> { return assertionResult(await this.lifecycleOperation({kind: "TITLE"}, options, wireExpectation(expected)), new Error().stack); }
+	async outline(options: CommandOptions = {}): Promise<string> { return await this.#lifecycleValue<string>({kind: "OUTLINE"}, options); }
+	async accessibilityOutline(options: CommandOptions = {}): Promise<string> { return await this.#lifecycleValue<string>({kind: "ACCESSIBILITY_OUTLINE"}, options); }
+	async consoleMessages(options: CommandOptions = {}): Promise<readonly ConsoleMessage[]> { return await this.#lifecycleValue<readonly ConsoleMessage[]>({kind: "CONSOLE_MESSAGES"}, options); }
+	async expectConsoleMessage(expected: ExpectedValue, options: PollOptions & {type?: string} = {}): Promise<ConsoleMessage> {
+		const {type, ...poll} = options;
+		const response = await this.lifecycleOperation({kind: "CONSOLE_MESSAGES", ...(type !== undefined && {key: type})}, poll, wireExpectation(expected));
+		operationResult(response, "console message assertion", new Error().stack);
+		return parseJson(response.observedJson) as ConsoleMessage;
+	}
+	async setDeviceMetrics(metrics: DeviceMetrics, options: CommandOptions = {}): Promise<void> { await this.#lifecycleCommand({kind: "SET_DEVICE_METRICS", device: {width: metrics.width, height: metrics.height, deviceScaleFactor: metrics.deviceScaleFactor ?? 1, ...(metrics.mobile !== undefined && {mobile: metrics.mobile})}}, options); }
+	async clearDeviceMetrics(options: CommandOptions = {}): Promise<void> { await this.#lifecycleCommand({kind: "CLEAR_DEVICE_METRICS"}, options); }
+	async setGeolocation(location: Geolocation, options: CommandOptions = {}): Promise<void> { await this.#lifecycleCommand({kind: "SET_GEOLOCATION", geolocation: {latitude: location.latitude, longitude: location.longitude, ...(location.accuracy !== undefined && {accuracy: location.accuracy})}}, options); }
+	async clearGeolocation(options: CommandOptions = {}): Promise<void> { await this.#lifecycleCommand({kind: "CLEAR_GEOLOCATION"}, options); }
+	async setPermissions(origin: string, permissions: Readonly<Partial<Record<Permission, PermissionState>>>, options: CommandOptions = {}): Promise<void> { await this.#lifecycleCommand({kind: "SET_PERMISSIONS", origin, permissions: {...permissions} as Record<string, string>}, options); }
+	async resetPermissions(options: CommandOptions = {}): Promise<void> { await this.#lifecycleCommand({kind: "RESET_PERMISSIONS"}, options); }
+	async setLocale(locale: string, options: CommandOptions = {}): Promise<void> { await this.#lifecycleCommand({kind: "SET_LOCALE", locale}, options); }
+	async clearLocale(options: CommandOptions = {}): Promise<void> { await this.#lifecycleCommand({kind: "CLEAR_LOCALE"}, options); }
+	async setTimezone(timezone: string, options: CommandOptions = {}): Promise<void> { await this.#lifecycleCommand({kind: "SET_TIMEZONE", timezone}, options); }
+	async clearTimezone(options: CommandOptions = {}): Promise<void> { await this.#lifecycleCommand({kind: "CLEAR_TIMEZONE"}, options); }
+	async setMedia(media: MediaEmulation, options: CommandOptions = {}): Promise<void> { await this.#lifecycleCommand({kind: "SET_MEDIA", media: {...(media.type !== undefined && {type: media.type}), ...(media.colorScheme !== undefined && {colorScheme: media.colorScheme}), ...(media.reducedMotion !== undefined && {reducedMotion: media.reducedMotion})}}, options); }
+  async clearMedia(options: CommandOptions = {}): Promise<void> { await this.#lifecycleCommand({kind: "CLEAR_MEDIA"}, options); }
+
+	async #listHandles(kind: "tabs" | "frames", spawnedOnly: boolean, options: CommandOptions): Promise<readonly Session[]> {
+		this.#assertOpen();
+		assertCancellationOptions(options, kind);
+		const request = {sessionId: this.id, ...(spawnedOnly && {spawnedOnly: true})};
+		const response = kind === "tabs" ? await this.#transport.listTabs(request, options) : await this.#transport.listFrames(request, options);
+		return response.handles.map(this.#registerSibling);
+	}
+	async #waitForHandle(kind: "tab" | "frame", query: TabQuery, options: PollOptions): Promise<Session> {
+		this.#assertOpen();
+		assertPollOptions(options, `waitFor${kind === "tab" ? "Tab" : "Frame"}`);
+		const request = {sessionId: this.id, query: wireTabQuery(query), poll: pollPolicy(options)};
+		const transportOptions = {...options, ...(options.timeoutMs !== undefined && {deadlineMs: options.timeoutMs + 2_100})};
+		const response = kind === "tab" ? await this.#transport.waitForTab(request, transportOptions) : await this.#transport.waitForFrame(request, transportOptions);
+		return this.#registerSibling(response);
+	}
+	async lifecycleOperation(operation: WireLifecycleOperation, options: WaitOptions, expectation?: WireExpectation): Promise<DriverOperationResult> {
+		this.#assertOpen();
+		assertPollOptions(options, "lifecycle operation");
+		return await this.#transport.lifecycle({sessionId: this.id, operation, ...(expectation && {expectation}), poll: pollPolicy(options)}, {...options, ...(options.timeoutMs !== undefined && {deadlineMs: options.timeoutMs + 2_100})});
+	}
+	async #lifecycleValue<T>(operation: WireLifecycleOperation, options: CommandOptions): Promise<T> {
+		assertCancellationOptions(options, "lifecycle state read");
+		const response = await this.lifecycleOperation(operation, {...options, mode: "immediate"});
+		operationResult(response, "lifecycle state read", new Error().stack);
+		return parseJson(response.observedJson) as T;
+	}
+	async #lifecycleCommand(operation: WireLifecycleOperation, options: CommandOptions): Promise<void> {
+		assertCancellationOptions(options, "lifecycle command");
+		operationResult(await this.lifecycleOperation(operation, {...options, mode: "immediate"}), "lifecycle command", new Error().stack);
+	}
+
+	invalidate(): void {
+		if (this.closed) return;
+		this.closed = true;
+		this.#onClose();
+	}
 
   async close(): Promise<void> {
     if (this.closed) return;
     this.closed = true;
     try {
-      await this.#transport.closeSession({sessionId: this.id});
+			const response = await this.#transport.closeSession({sessionId: this.id});
+			this.#invalidateSessions(response.invalidatedSessionIds ?? []);
     } finally {
       this.#onClose();
     }
@@ -357,8 +517,9 @@ class ClientSession implements Session {
     }, options, callsiteStack);
   }
 
-  async holdResponse(expectedUrl: ExpectedValue, options: WaitOptions = {}): Promise<ResponseHold> {
+  async holdResponse(expectedUrl: ExpectedValue, options: CommandOptions = {}): Promise<ResponseHold> {
     this.#assertOpen();
+    assertCancellationOptions(options, "holdResponse");
     const response = await this.#transport.holdResponse({
       sessionId: this.id,
       expectation: wireExpectation(expectedUrl),
@@ -370,13 +531,7 @@ class ClientSession implements Session {
     return new ClientResponseHold(this.id, observed.holdId, this.#transport);
   }
 
-  async url(): Promise<string> {
-    const result = await this.assert({
-      kind: "URL",
-      expectation: {kind: "ANYTHING"},
-    }, {mode: "immediate"}, new Error().stack);
-    return result.observed as string;
-  }
+	async url(options: CommandOptions = {}): Promise<string> { return await this.#lifecycleValue<string>({kind: "URL"}, options); }
 
   async assert(
     assertion: WireAssertion,
@@ -482,6 +637,18 @@ class ClientSession implements Session {
   }
 }
 
+class ClientStorage implements BrowserStorage {
+	constructor(private readonly session: ClientSession, private readonly area: StorageArea) {}
+	async set(key: string, value: SerializableValue, options: CommandOptions = {}): Promise<void> { operationResult(await this.session.lifecycleOperation({kind: "STORAGE_SET", area: this.area, key, valueJson: JSON.stringify(value)}, {...options, mode: "immediate"}), "storage set", new Error().stack); }
+	async get<T = unknown>(key: string, options: CommandOptions = {}): Promise<StorageItem<T>> { const response = await this.session.lifecycleOperation({kind: "STORAGE_GET", area: this.area, key}, {...options, mode: "immediate"}); operationResult(response, "storage get", new Error().stack); const item = parseJson(response.observedJson) as {found: boolean; value?: T}; return item.found ? {found: true, value: item.value as T} : {found: false}; }
+	async getAll(options: CommandOptions = {}): Promise<Readonly<Record<string, unknown>>> { const response = await this.session.lifecycleOperation({kind: "STORAGE_GET_ALL", area: this.area}, {...options, mode: "immediate"}); return parseJson(response.observedJson) as Readonly<Record<string, unknown>>; }
+	async remove(key: string, options: CommandOptions = {}): Promise<void> { operationResult(await this.session.lifecycleOperation({kind: "STORAGE_REMOVE", area: this.area, key}, {...options, mode: "immediate"}), "storage remove", new Error().stack); }
+	async clear(options: CommandOptions = {}): Promise<void> { operationResult(await this.session.lifecycleOperation({kind: "STORAGE_CLEAR", area: this.area}, {...options, mode: "immediate"}), "storage clear", new Error().stack); }
+	async length(options: CommandOptions = {}): Promise<number> { const response = await this.session.lifecycleOperation({kind: "STORAGE_LENGTH", area: this.area}, {...options, mode: "immediate"}); return parseJson(response.observedJson) as number; }
+	async expectItem<T = unknown>(key: string, expected: ExpectedValue = {kind: "anything"}, options: PollOptions = {}): Promise<T> { const response = await this.session.lifecycleOperation({kind: "STORAGE_GET", area: this.area, key}, options, wireExpectation(expected)); operationResult(response, "storage item assertion", new Error().stack); return parseJson(response.observedJson) as T; }
+	async expectLength(expected: number | Expectation, options: PollOptions = {}): Promise<AssertionResult> { return assertionResult(await this.session.lifecycleOperation({kind: "STORAGE_LENGTH", area: this.area}, options, wireExpectation(expected)), new Error().stack); }
+}
+
 class ClientResponseHold implements ResponseHold {
   constructor(
     private readonly sessionId: string,
@@ -489,12 +656,14 @@ class ClientResponseHold implements ResponseHold {
     private readonly transport: DriverTransport,
   ) {}
 
-  async await(options: WaitOptions = {}): Promise<HeldResponse> {
+  async await(options: WaitingCommandOptions = {}): Promise<HeldResponse> {
+    assertWaitingCommandOptions(options, "responseHold.await");
     const response = await this.transport.awaitResponseHold({sessionId: this.sessionId, holdId: this.holdId}, options);
     return parseJson(response.observedJson) as HeldResponse;
   }
 
-  async release(options: WaitOptions = {}): Promise<void> {
+  async release(options: CommandOptions = {}): Promise<void> {
+    assertCancellationOptions(options, "responseHold.release");
     const response = await this.transport.releaseResponseHold({sessionId: this.sessionId, holdId: this.holdId}, options);
     operationResult(response, "release response hold operation", new Error().stack);
   }
@@ -987,6 +1156,64 @@ function wireLocator(locator: Locator | string): WireLocator {
   throw new BilobaError({code: "INVALID_ARGUMENT", message: "locator belongs to a different Biloba client"});
 }
 
+function wireTabQuery(query: TabQuery): import("../generated/protocol.js").TabQueryRequest {
+	return {
+		...(query.title !== undefined && {title: wireExpectation(query.title)}),
+		...(query.url !== undefined && {url: wireExpectation(query.url)}),
+		...(query.has !== undefined && {has: wireLocator(query.has)}),
+	};
+}
+
+function wireCookieQuery(query: CookieQuery): import("../generated/protocol.js").CookieQuery {
+	return {
+		...(query.name !== undefined && {name: wireExpectation(query.name)}),
+		...(query.value !== undefined && {value: wireExpectation(query.value)}),
+		...(query.domain !== undefined && {domain: wireExpectation(query.domain)}),
+		...(query.path !== undefined && {path: wireExpectation(query.path)}),
+		...(query.sameSite !== undefined && {sameSite: wireExpectation(query.sameSite)}),
+		...(query.secure !== undefined && {secure: query.secure}),
+		...(query.httpOnly !== undefined && {httpOnly: query.httpOnly}),
+	};
+}
+
+function cookieFromWire(cookie: import("../generated/protocol.js").Cookie): Cookie {
+	return {
+		name: cookie.name,
+		value: cookie.value,
+		...(cookie.domain !== undefined && {domain: cookie.domain}),
+		...(cookie.path !== undefined && {path: cookie.path}),
+		...(cookie.expiresUnix !== undefined && cookie.expiresUnix !== 0 && {expires: new Date(cookie.expiresUnix * 1_000)}),
+		...(cookie.secure !== undefined && {secure: cookie.secure}),
+		...(cookie.httpOnly !== undefined && {httpOnly: cookie.httpOnly}),
+		...(cookie.sameSite !== undefined && {sameSite: cookie.sameSite}),
+		...(cookie.session !== undefined && {session: cookie.session}),
+	};
+}
+
+function currentCookieMatches(cookie: Cookie, query: CookieQuery): boolean {
+	for (const [expected, observed] of [[query.name, cookie.name], [query.value, cookie.value], [query.domain, cookie.domain ?? ""], [query.path, cookie.path ?? ""], [query.sameSite, cookie.sameSite ?? ""]] as const) {
+		if (expected !== undefined && !currentValueMatches(observed, expected)) return false;
+	}
+	return (query.secure === undefined || cookie.secure === query.secure) && (query.httpOnly === undefined || cookie.httpOnly === query.httpOnly);
+}
+
+function currentValueMatches(observed: string, expected: ExpectedValue): boolean {
+	if (expected instanceof RegExp) return expected.test(observed);
+	if (!isExpectation(expected)) return observed === expected;
+	switch (expected.kind) {
+		case "equal": return observed === expected.expected;
+		case "contains": return observed.includes(expected.expected);
+		case "prefix": return observed.startsWith(expected.expected);
+		case "suffix": return observed.endsWith(expected.expected);
+		case "regexp": return new RegExp(expected.expected).test(observed);
+		case "anything": return true;
+		case "not": return !currentValueMatches(observed, expected.child);
+		case "all": return expected.children.every((child) => currentValueMatches(observed, child));
+		case "any": return expected.children.some((child) => currentValueMatches(observed, child));
+		default: return false;
+	}
+}
+
 function wireNames(names: readonly NameSpec[]): NonNullable<WireDOMOperation["names"]> {
   return names.map((name) => typeof name === "string" ? {name} : {name: name.name, allowMissing: true});
 }
@@ -1002,6 +1229,14 @@ function assertCancellationOptions(options: CancellationOptions, operation: stri
   for (const key of Object.keys(options)) {
     if (key !== "signal") {
       throw new BilobaError({code: "INVALID_ARGUMENT", message: `${operation} only accepts cancellation options`});
+    }
+  }
+}
+
+function assertWaitingCommandOptions(options: WaitingCommandOptions, operation: string): void {
+  for (const key of Object.keys(options)) {
+    if (key !== "signal" && key !== "timeoutMs") {
+      throw new BilobaError({code: "INVALID_ARGUMENT", message: `${operation} only accepts timeout and cancellation options`});
     }
   }
 }

--- a/typescript/src/internal/stdio-transport.ts
+++ b/typescript/src/internal/stdio-transport.ts
@@ -9,6 +9,12 @@ import type {
   EvaluateRequest,
   HandshakeRequest,
   HandshakeResponse,
+	HandleListResponse,
+	InvalidationResponse,
+	LifecycleRequest,
+	CookieListResponse,
+	ListHandlesRequest,
+	WaitForTabRequest,
   HoldResponseRequest,
   LocatorRequest,
   NavigateRequest,
@@ -107,10 +113,10 @@ export class StdioTransport {
   activate(request: SessionRequest, options: TransportOptions = {}): Promise<OperationResult> {
     return this.#request("activate", request, withDefaultDeadline(options));
   }
-  prepareSession(request: SessionRequest, options: TransportOptions = {}): Promise<Record<string, never>> {
+	prepareSession(request: SessionRequest, options: TransportOptions = {}): Promise<InvalidationResponse> {
     return this.#request("prepareSession", request, withDefaultDeadline(options));
   }
-  closeSession(request: SessionRequest, options: TransportOptions = {}): Promise<Record<string, never>> {
+  closeSession(request: SessionRequest, options: TransportOptions = {}): Promise<InvalidationResponse> {
     return this.#request("closeSession", request, withDefaultDeadline(options));
   }
   navigate(request: NavigateRequest, options: TransportOptions = {}): Promise<OperationResult> {
@@ -119,6 +125,27 @@ export class StdioTransport {
   setCookies(request: SetCookiesRequest, options: TransportOptions = {}): Promise<OperationResult> {
     return this.#request("setCookies", request, withDefaultDeadline(options));
   }
+	getCookies(request: SessionRequest, options: TransportOptions = {}): Promise<CookieListResponse> {
+		return this.#request("getCookies", request, withDefaultDeadline(options));
+	}
+	clearCookies(request: SessionRequest, options: TransportOptions = {}): Promise<OperationResult> {
+		return this.#request("clearCookies", request, withDefaultDeadline(options));
+	}
+	listTabs(request: ListHandlesRequest, options: TransportOptions = {}): Promise<HandleListResponse> {
+		return this.#request("listTabs", request, withDefaultDeadline(options));
+	}
+	listFrames(request: ListHandlesRequest, options: TransportOptions = {}): Promise<HandleListResponse> {
+		return this.#request("listFrames", request, withDefaultDeadline(options));
+	}
+	waitForTab(request: WaitForTabRequest, options: TransportOptions = {}): Promise<OpenSessionResponse> {
+		return this.#request("waitForTab", request, options);
+	}
+	waitForFrame(request: WaitForTabRequest, options: TransportOptions = {}): Promise<OpenSessionResponse> {
+		return this.#request("waitForFrame", request, options);
+	}
+	lifecycle(request: LifecycleRequest, options: TransportOptions = {}): Promise<OperationResult> {
+		return this.#request("lifecycle", request, options);
+	}
   click(request: LocatorRequest, options: TransportOptions = {}): Promise<OperationResult> {
     return this.#request("click", request, options);
   }

--- a/typescript/test/client.test.ts
+++ b/typescript/test/client.test.ts
@@ -91,9 +91,26 @@ describe("Biloba TypeScript client", () => {
     const respond: Respond = reply;
     switch (envelope.method) {
       case "handshake": reply({protocolVersion: "1", capabilities: ["assertions", "evaluate"]} satisfies HandshakeResponse); break;
-      case "openSession": reply({sessionId: `session-${++openedSessions}`} satisfies OpenSessionResponse); break;
-      case "newTab": reply({sessionId: `session-${++openedSessions}`} satisfies OpenSessionResponse); break;
+      case "openSession": reply({sessionId: `session-${++openedSessions}`, contextId: `context-${openedSessions}`, targetId: `target-${openedSessions}`, ownsContext: true} satisfies OpenSessionResponse); break;
+      case "newTab": reply({sessionId: `session-${++openedSessions}`, contextId: "context-1", targetId: `target-${openedSessions}`, openerId: "target-1"} satisfies OpenSessionResponse); break;
+			case "listTabs": reply({handles: [{sessionId: "session-2", contextId: "context-1", targetId: "target-2", openerId: "target-1"}]}); break;
+			case "listFrames": reply({handles: [{sessionId: "frame-1", contextId: "context-1", targetId: "frame-target", frame: true, url: "https://frame.test/"}]}); break;
+			case "waitForTab": reply({sessionId: "session-2", contextId: "context-1", targetId: "target-2", openerId: "target-1"}); break;
+			case "waitForFrame": reply({sessionId: "frame-1", contextId: "context-1", targetId: "frame-target", frame: true, url: "https://frame.test/"}); break;
       case "evaluate": respond(operationResult({observedJson: JSON.stringify({ready: true})})); break;
+			case "getCookies": reply({cookies: [{name: "auth", value: "abc", path: "/", session: true}]}); break;
+			case "lifecycle": {
+				const operation = request.operation as {kind?: string};
+				const values: Record<string, unknown> = {
+					STORAGE_GET: {found: true, value: 3}, STORAGE_GET_ALL: {count: 3}, STORAGE_LENGTH: 1,
+					WAIT_FOR_DEFINED: 42, URL: "https://app.test/ready", TITLE: "Ready", WINDOW_SIZE: {width: 800, height: 600},
+					OUTLINE: "<body>Ready</body>", ACCESSIBILITY_OUTLINE: "document\n  button \"Save\"",
+					CONSOLE_MESSAGES: [{type: "log", text: "ready", args: ["ready"], timestamp: "2026-01-01T00:00:00Z"}],
+					COOKIE_QUERY: {name: "auth", value: "abc", path: "/", session: true},
+				};
+				respond(operationResult({observedJson: JSON.stringify(values[operation.kind ?? ""])}));
+				break;
+			}
       case "holdResponse": respond(operationResult({observedJson: JSON.stringify({holdId: "hold-1"})})); break;
       case "awaitResponseHold": respond(operationResult({observedJson: JSON.stringify({url: "/saved", status: 200})})); break;
       case "assert": assertImplementation(request, respond); break;
@@ -215,6 +232,40 @@ describe("Biloba TypeScript client", () => {
     ]);
   });
 
+	it("returns typed lifecycle snapshots with context identity", async () => {
+		browser = await connectClient();
+		const session = await browser.openSession();
+		expect(session).toMatchObject({contextId: "context-1", targetId: "target-1", ownsContext: true, isFrame: false});
+		expect(await session.getCookies()).toEqual([{name: "auth", value: "abc", path: "/", session: true}]);
+	});
+
+	it("serializes live handles, storage, page state, and emulation through typed lifecycle operations", async () => {
+		browser = await connectClient();
+		const session = await browser.openSession();
+		const tabs = await session.spawnedTabs();
+		expect(tabs[0]).toMatchObject({contextId: session.contextId, openerId: session.targetId});
+		expect((await session.frames())[0]).toMatchObject({isFrame: true, frameUrl: "https://frame.test/"});
+		expect((await session.localStorage().get<number>("count"))).toEqual({found: true, value: 3});
+		expect(await session.waitForDefined<number>("window.ready", {timeoutMs: 50})).toBe(42);
+		expect(await session.url()).toBe("https://app.test/ready");
+		expect(await session.title()).toBe("Ready");
+		expect(await session.windowSize()).toEqual({width: 800, height: 600});
+		expect(await session.outline()).toContain("Ready");
+		expect(await session.accessibilityOutline()).toContain("button");
+		expect(await session.consoleMessages()).toHaveLength(1);
+		await session.setGeolocation({latitude: 0, longitude: 0});
+		await session.setPermissions("https://app.test", {clipboardReadWrite: "granted", geolocation: "denied"});
+		await session.setMedia({colorScheme: "dark", reducedMotion: "reduce"});
+
+		expect(requests).toEqual(expect.arrayContaining([
+			expect.objectContaining({method: "ListTabs", request: expect.objectContaining({spawnedOnly: true})}),
+			expect.objectContaining({method: "Lifecycle", request: expect.objectContaining({operation: {kind: "STORAGE_GET", area: "localStorage", key: "count"}})}),
+			expect.objectContaining({method: "Lifecycle", request: expect.objectContaining({operation: {kind: "WAIT_FOR_DEFINED", expression: "window.ready"}, poll: {timeoutMs: 50}})}),
+			expect.objectContaining({method: "Lifecycle", request: expect.objectContaining({operation: {kind: "SET_GEOLOCATION", geolocation: {latitude: 0, longitude: 0}}})}),
+			expect.objectContaining({method: "Lifecycle", request: expect.objectContaining({operation: {kind: "SET_PERMISSIONS", origin: "https://app.test", permissions: {clipboardReadWrite: "granted", geolocation: "denied"}}})}),
+		]));
+	});
+
   it("expresses every pilot locator and assertion as one RPC", async () => {
     browser = await connectClient();
     const session = await browser.openSession();
@@ -278,6 +329,9 @@ describe("Biloba TypeScript client", () => {
     await expect(rows.clickAll({timeoutMs: 10} as never)).rejects.toMatchObject({code: "INVALID_ARGUMENT"});
     await expect(rows.setProperty("dataset.ready", true, {all: true} as never)).rejects.toMatchObject({code: "INVALID_ARGUMENT"});
     await expect(session.sendKeys("x", {timeoutMs: 10} as never)).rejects.toMatchObject({code: "INVALID_ARGUMENT"});
+		await expect(session.getCookies({intervalMs: 10} as never)).rejects.toMatchObject({code: "INVALID_ARGUMENT"});
+		await expect(session.navigate("http://localhost", {intervalMs: 10} as never)).rejects.toMatchObject({code: "INVALID_ARGUMENT"});
+		await expect(session.holdResponse("/held", {timeoutMs: 10} as never)).rejects.toMatchObject({code: "INVALID_ARGUMENT"});
   });
 
   it("serializes composed locators as a typed tree", async () => {

--- a/typescript/test/parity.test.ts
+++ b/typescript/test/parity.test.ts
@@ -291,6 +291,97 @@ describe.skipIf(process.env.BILOBA_SKIP_PARITY === "true")("Go and TypeScript pa
     expect(await session.normalizeColor("#0a141e")).toBe("rgb(10, 20, 30)");
   });
 
+	it("keeps lifecycle state and live handles coherent through the real daemon", async () => {
+		await session.prepare();
+		const startingSize = await session.windowSize();
+		await session.navigate(baseUrl);
+		const startingEmulation = await session.evaluate(`[Intl.NumberFormat().resolvedOptions().locale, Intl.DateTimeFormat().resolvedOptions().timeZone, matchMedia('(prefers-color-scheme: dark)').matches, innerWidth, innerHeight, devicePixelRatio]`);
+		const startingPermission = await session.evaluateAsync<string>(`navigator.permissions.query({name: "geolocation"}).then(result => result.state)`);
+		expect(await session.url()).toBe(baseUrl + "/");
+		await session.expectUrl(endsWith("/"));
+		expect(await session.title()).toBe("");
+		await session.evaluate(`document.title = "Biloba lifecycle"`);
+		await session.expectTitle(contains("Biloba"));
+
+		await session.setCookies([{name: "lifecycle", value: "ready", domain: "127.0.0.1", path: "/"}]);
+		expect(await session.expectCookie({name: "lifecycle", value: "ready"})).toMatchObject({name: "lifecycle", value: "ready"});
+		await session.expectCookieCount(numeric(">=", 1));
+		expect(await session.findCookie({name: "lifecycle"})).toBeDefined();
+		await session.clearCookies();
+		expect(await session.getCookies()).toEqual([]);
+		await session.setCookies([{name: "lifecycle", value: "ready", domain: "127.0.0.1", path: "/"}]);
+		await session.localStorage().set("count", 3);
+		await session.sessionStorage().set("token", {ready: true});
+		expect(await session.localStorage().get<number>("count")).toEqual({found: true, value: 3});
+		expect(await session.localStorage().getAll()).toEqual({count: 3});
+		await session.localStorage().remove("count");
+		expect(await session.localStorage().get("count")).toEqual({found: false});
+		await session.localStorage().set("count", 3);
+		expect(await session.sessionStorage().expectItem("token", {ready: true})).toEqual({ready: true});
+		await session.sessionStorage().clear();
+		expect(await session.sessionStorage().get("token")).toEqual({found: false});
+		await session.sessionStorage().set("token", {ready: true});
+		await session.localStorage().expectLength(1);
+		await session.addInitScript(`window.lifecycleInit = "installed"`);
+
+		await session.evaluate(`setTimeout(() => { window.lifecycleReady = 42 }, 25)`);
+		expect(await session.waitForDefined<number>("window.lifecycleReady", {timeoutMs: 1_000})).toBe(42);
+		const cancelled = new AbortController();
+		const pendingWait = session.waitForDefined("window.neverDefined", {timeoutMs: 1_000, signal: cancelled.signal});
+		cancelled.abort();
+		await expect(pendingWait).rejects.toMatchObject({code: "CANCELLED"});
+		expect(await session.outline()).toContain("Biloba parity");
+		expect(await session.accessibilityOutline()).toContain("Biloba parity");
+		await session.evaluate(`console.error("lifecycle-console")`);
+		expect((await session.expectConsoleMessage("lifecycle-console", {type: "error"})).text).toBe("lifecycle-console");
+
+		await session.setGeolocation({latitude: 0, longitude: 0, accuracy: 1});
+		await session.setPermissions(baseUrl, {geolocation: "granted"});
+		const position = await session.evaluateAsync<{latitude: number; longitude: number}>(`new Promise((resolve, reject) => navigator.geolocation.getCurrentPosition(p => resolve({latitude:p.coords.latitude, longitude:p.coords.longitude}), reject))`);
+		expect(position).toEqual({latitude: 0, longitude: 0});
+		await session.setLocale("fr-FR");
+		await session.setTimezone("Europe/Paris");
+		await session.setMedia({colorScheme: "dark", reducedMotion: "reduce"});
+		await session.setDeviceMetrics({width: 320, height: 640, deviceScaleFactor: 2, mobile: true});
+		expect(await session.evaluate(`[Intl.NumberFormat().resolvedOptions().locale, Intl.DateTimeFormat().resolvedOptions().timeZone, matchMedia('(prefers-color-scheme: dark)').matches]`)).toEqual(["fr-FR", "Europe/Paris", true]);
+		expect(await session.evaluate(`[screen.width, screen.height, devicePixelRatio, innerWidth]`)).toEqual([320, 640, 2, 980]);
+		await session.navigate(baseUrl);
+		expect(await session.evaluate("window.lifecycleInit")).toBe("installed");
+
+		await session.setWindowSize(640, 480);
+		expect(await session.windowSize()).toEqual({width: 640, height: 480});
+		const closedSibling = await session.newTab();
+		await closedSibling.navigate(baseUrl);
+		expect((await session.tabs()).map((tab) => tab.id)).toEqual(expect.arrayContaining([session.id, closedSibling.id]));
+		await expect(closedSibling.prepare()).rejects.toMatchObject({code: "INVALID_ARGUMENT"});
+		await closedSibling.close();
+		await expect(closedSibling.title()).rejects.toMatchObject({code: "DRIVER_CLOSED"});
+		expect(await session.title()).toBe("");
+		const sibling = await session.newTab();
+		await sibling.navigate(baseUrl);
+		await session.evaluate(`(() => { window.open(${JSON.stringify(baseUrl + "/?popup=1")}, "_blank"); return true })()`);
+		const popup = await session.waitForTab({url: contains("popup=1")}, {timeoutMs: 2_000});
+		expect(popup.contextId).toBe(session.contextId);
+		expect((await session.spawnedTabs()).map((tab) => tab.id)).toContain(popup.id);
+		expect((await session.findTab({url: contains("popup=1")}))?.id).toBe(popup.id);
+
+		const prepared = await session.prepare();
+		expect(prepared.invalidatedSessionIds).toEqual(expect.arrayContaining([sibling.id, popup.id]));
+		await expect(sibling.title()).rejects.toMatchObject({code: "DRIVER_CLOSED"});
+		expect(await session.windowSize()).toEqual(startingSize);
+		expect(await session.consoleMessages()).toEqual([]);
+		await session.navigate(baseUrl);
+		expect(await session.evaluate(`[Intl.NumberFormat().resolvedOptions().locale, Intl.DateTimeFormat().resolvedOptions().timeZone, matchMedia('(prefers-color-scheme: dark)').matches, innerWidth, innerHeight, devicePixelRatio]`)).toEqual(startingEmulation);
+		expect(await session.evaluateAsync<string>(`navigator.permissions.query({name: "geolocation"}).then(result => result.state)`)).toBe(startingPermission);
+		await session.setPermissions(baseUrl, {geolocation: "granted"});
+		const resetGeolocation = await session.evaluateAsync<number>(`new Promise(resolve => navigator.geolocation.getCurrentPosition(() => resolve(0), error => resolve(error.code), {timeout: 100}))`);
+		expect(resetGeolocation).not.toBe(0);
+		await session.resetPermissions();
+		expect(await session.evaluate("typeof window.lifecycleInit")).toBe("undefined");
+		expect(await session.localStorage().get("count")).toEqual({found: false});
+		expect(await session.getCookies()).toEqual([]);
+	});
+
   it("treats a non-200 page as navigable when the caller asks for that status", async () => {
     // Pairs with "treats a non-200 page as navigable when the spec asks for that status" in
     // graft_parity_test.go.  Go has Navigate/NavigateWithStatus; if TypeScript has only the former,


### PR DESCRIPTION
**Stack 11 of 17** · base [#26](https://github.com/onsi/biloba/pull/26) · next: [#28](https://github.com/onsi/biloba/pull/28)

This slice adds the browser lifecycle and state foundations used by the remaining parity work. It is intentionally reviewable as one vertical path from the engine through the typed protocol and TypeScript client.

## Included

- cookies, storage, JavaScript state, console snapshots, and emulation controls
- explicit tabs, discovered page-created tabs, and context ownership
- cross-origin frame handles with prepare-time invalidation
- deterministic prepare, close, crash recovery, and sibling isolation behavior
- headless-shell, full-headless, and headful engine launch modes
- validated Chrome arguments, window sizing, and opt-in shell installation
- Go shell resolution delegated to the runner-neutral engine
- typed lifecycle protocol operations and idiomatic TypeScript APIs

## Review guide

1. Review `engine/tabs.go`, `engine/frame.go`, and the lifecycle state files for ownership and reset behavior.
2. Review the Chrome launch policy and installer bounds.
3. Review protocol validation and observation preservation.
4. Review the TypeScript surface and real-daemon lifecycle coverage.

## Size

29 files, +3,617 / −267.

## Verification

`make driver-test` passed independently at this stack boundary:

- TypeScript: 38/38, plus typecheck and build
- engine: 60/60
- protocol: 50/50
- bilobad: 30/30