### PR TITLE
15/17 docs: finish parity guidance and hardening

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -538,7 +538,7 @@ This installs a family of `biloba:*` skills that activate automatically while yo
 | `biloba:explore-unfamiliar-page` | Orienting to a page you haven't seen, then drafting a starter spec. |
 | `biloba:debug-failures` | DOM outlines, screenshots, and the env/config knobs that surface them. |
 | `biloba:flaky-specs` | A spec that's flaky, order-dependent, or only fails under `-p`/CI — the smells and their polling fixes. |
-| `biloba:typescript` | Driving Biloba from a `vitest` suite instead of Go — the daemon topology, locators, assertions, and what isn't ported yet. |
+| `biloba:typescript` | Driving Biloba from a `vitest` suite — shared-browser setup, the complete TypeScript API, visual assertions, and diagnostics. |
 
 ### `chromedp`: Breaking the Fourth Wall
 
@@ -4288,8 +4288,12 @@ if (!daemonExecutable) throw new Error("BILOBA_DAEMON_EXECUTABLE is not set");
 let browser: SharedBrowserProcess | undefined;
 
 export async function setup(project: TestProject): Promise<void> {
-  browser = await startSharedBrowser({executable: daemonExecutable});
-  project.provide("chromeWsUrl", browser.wsURL);
+  browser = await startSharedBrowser({
+    executable: daemonExecutable,
+    mode: "headless-shell",
+    windowSize: {width: 1024, height: 768},
+  });
+  project.provide("chromeConnection", browser.connection);
 }
 
 export async function teardown(): Promise<void> {
@@ -4307,14 +4311,16 @@ let browser: Browser;
 let session: Session;
 
 beforeAll(async () => {
-  browser = await connect({chromeWsUrl: inject("chromeWsUrl")});
+  browser = await connect({chromeConnection: inject("chromeConnection")});
   session = await browser.openSession();
 });
 
 afterAll(async () => { await browser.close(); });
 ```
 
-`connect` reads the daemon's path from `BILOBA_DAEMON_EXECUTABLE` when you don't pass `daemonExecutable`, which is usually how you'll wire it up; pass it explicitly when you'd rather not depend on the environment.  Omit `chromeWsUrl` and the daemon will launch a Chrome of its own - fine for a single file, wasteful for a suite.
+`connect` reads the daemon's path from `BILOBA_DAEMON_EXECUTABLE` when you don't pass `daemonExecutable`, which is usually how you'll wire it up; pass it explicitly when you'd rather not depend on the environment.  Omit `chromeConnection` and the daemon launches Chrome itself - fine for a single file, wasteful for a suite.  The older `chromeWsUrl` attachment remains available, but it cannot report how an external Chrome was launched; prefer `chromeConnection` so every worker receives the host's validated launch metadata.
+
+Both `startSharedBrowser` and a self-launching `connect` accept `mode: "headless-shell" | "headless" | "headful"`, `chromePath`, `autoInstall`, ordered `chromeArgs`, and `windowSize`.  The default is the fast headless shell at 1024×768.  `browser.launch` reports the resolved executable, mode, arguments, size, and whether Biloba installed the shell.  Set `BILOBA_INTERACTIVE=true` for the headful interactive default, or select a mode explicitly.
 
 A `Session` is the TypeScript analogue of a Biloba tab.  A session returned by `browser.openSession()` owns its own browser context, so its cookies and storage are isolated from every other root session.  `session.prepare()` is `b.Prepare()` - it resets the session between tests and is what makes reuse cheap:
 
@@ -4331,7 +4337,7 @@ await popup.activate();
 await popup.close();
 ```
 
-This is the basic tab lifecycle.  The Go API still has richer helpers for enumerating and switching among spawned tabs.
+Use `tabs()` and `spawnedTabs()` for snapshots, `findTab()` for an optional match, and `waitForTab()` when a popup is expected.  `frames()` and `waitForFrame()` expose cross-origin frame targets as typed sessions.  Closing or preparing an owning session invalidates all of its descendant handles.
 
 ### Navigating and selecting
 
@@ -4351,6 +4357,10 @@ session.locator("#content")                            // css
 session.getByTestId("name")                            // [data-testid="name"]
 session.getByText("Save", {exact: true})               // by text content
 session.getByRole("button", {name: "Increment"})       // by ARIA role, optionally by accessible name
+session.getByLabel("Email")                            // by associated label
+session.getByPlaceholder("Search")                     // by placeholder
+session.getByAltText("Profile photo")                  // by image alt text
+session.getByTitle("Close")                            // by title
 session.xpath("//button[@name='save']")                 // a raw XPath expression
 session.locator(".row").first()                        // just the first match
 ```
@@ -4404,7 +4414,7 @@ await session.getByRole("button", {name: "Pay"}).realistic().click();
 await session.getByTestId("card-number").realistic().setValue("4242 4242 4242 4242");
 ```
 
-The TypeScript realistic track currently covers `click`, `setValue`, and `type`: Biloba scrolls the target into view, checks actionability, and uses real CDP input.  Go remains the complete realistic-interaction API for hover, click variants, tap, wheel, and realistic drag.
+The realistic track covers clicks and click variants, tap, hover, typing and value changes, wheel input, and drag.  Biloba scrolls the target into view, checks actionability, and uses real CDP input.  The fast default keeps each action atomic in the page runtime.
 
 An assertion resolves to an `AssertionResult` describing how it got there, which is occasionally useful and always available:
 
@@ -4425,16 +4435,26 @@ const now = await session.evaluate<number>("() => Date.now()", []);
 
 The distinction is the *presence* of the array, not its length - `[]` still means "call this".  That's deliberate: it means a zero-argument function doesn't have to be spelled differently from a two-argument one.
 
-Cookies work the way [they do in Go](#cookies), with `Date` accepted for expiry:
+Cookies work the way [they do in Go](#cookies), with `Date` accepted for expiry.  You can read, filter, wait for, count, and clear them as well as set them:
 
 ```ts
 await session.setCookies([{name: "session", value: "abc123", path: "/"}]);
+const cookie = await session.expectCookie({name: "session"});
+await session.clearCookies();
 ```
 
-TypeScript also supports request observation and response holding:
+`localStorage()` and `sessionStorage()` expose typed set/get/remove/clear, snapshot, length, and polling assertions.
+
+TypeScript supports request and response history, stubbing, aborting, request and response modification, callback-based response routing, response holding, cache control, and network emulation:
 
 ```ts
 await session.expectRequest(endsWith("/orders"), {method: "POST"});
+
+const stub = await session.stubRequest(endsWith("/feature-flags"), {
+  status: 200,
+  headers: [{name: "content-type", value: "application/json"}],
+  body: new TextEncoder().encode('{"available":true}'),
+});
 
 const hold = await session.holdResponse(endsWith("/inventory"));
 try {
@@ -4446,7 +4466,40 @@ try {
 }
 ```
 
-Import `endsWith` (or another Biloba expectation) from the package.  Always release a hold.  Arbitrary response stubbing, aborting, modifying, and the Go API's richer request inspection remain Go-only.
+Import `endsWith` (or another Biloba expectation) from the package.  Always release a hold.  Network handlers are first-match-wins; use each handler's `count()` or `stats()` and `networkShadowDiagnostics()` to prove that the intended handler claimed the request.
+
+Dialog handlers are newest-first and removable.  Dialog history records both explicitly handled and safely auto-handled dialogs.  Downloads expose lifecycle metadata, bounded binary content, cancellation, snapshot filters, and polling assertions.
+
+```ts
+const prompts = await session.handleDialogs("prompt", {message: "Name?", promptText: "Ada"});
+const download = await session.expectDownload({filename: endsWith(".csv")});
+const bytes = await download.content();
+await prompts.remove();
+```
+
+### Screenshots and visual assertions
+
+Capture a page or locator as bounded bytes, or ask the daemon to write a sanitized artifact path:
+
+```ts
+const png = await session.captureScreenshot();
+const path = await session.getByTestId("chart").captureScreenshot({output: "path", name: "chart"});
+```
+
+`expectScreenshot()` is the TypeScript equivalent of Go's `HaveScreenshot`.  It supports page and element baselines, masks, exact or tolerant pixel comparison, animation freezing with an opt-out, light and dark color schemes, update mode, diff artifacts, and structured diagnosis.
+
+```ts
+const result = await session.getByTestId("chart").expectScreenshot("revenue-chart", {
+  mask: [session.getByTestId("last-updated")],
+  colorSchemes: ["light", "dark"],
+  pixelTolerance: 0.001,
+});
+expect(result.match).toBe(true);
+```
+
+A mismatch throws, and the message carries the same diagnosis Go renders - the pixel counts, the amplitude verdict, and the baseline, actual, and diff paths - so a CI log tells you what changed without opening anything.  Capture warnings (a baseline that never settled, two color schemes that rendered identically) go to stderr; pass `onScreenshotWarning` to `connect` to route them somewhere else.
+
+When you need to absorb rendering noise, reach for `channelTolerance` before `pixelTolerance`: rasterization differences are a small delta spread over many pixels, while a pixel budget lets a handful of pixels change by any amount - which is exactly the one-pixel border or small glyph worth catching.
 
 ### When something fails
 
@@ -4462,11 +4515,18 @@ try {
   failure.expected;        // "ready"
   failure.trajectory;      // every attempt, with what it observed and why it retried
   failure.domOutline;      // the DOM at failure time
-  failure.screenshotPath;  // a PNG, when the daemon was given an artifactDir
+  failure.screenshotPath;  // the primary PNG path, when disk artifacts are enabled
+  failure.diagnostics;     // context-wide tab artifacts, when available
+  failure.visual;          // structured visual comparison, for expectScreenshot
+  failure.artifactPaths;   // all associated artifact paths
 }
 ```
 
 That trajectory is the [poll trajectory](#outline) the Go suite attaches on failure, handed to you as data instead of rendered as text.  Pass `artifactDir` to `connect` to get screenshots written to disk.
+
+For runner-level capture, load `installBilobaVitestHooks` from `@onsi/biloba-vitest-prototype/vitest` in a Vitest setup file.  The hook captures every live tab after any failed test, can capture a slow test after `progressAfterMs`, replays browser errors, and turns `console.assert` into a test-boundary failure.  `session.captureDiagnostics()` provides the same context-wide capture on demand.  Configure screenshots, outlines, artifact paths, inline output, viewport, byte limits, and poll trajectories under `connect({diagnostics: {...}})`; explicit members override CI and interactive defaults independently.
+
+Use `consoleMessages()` for bounded history and `onConsoleMessage()` for live delivery.  `warnings()` and `onWarning()` expose auto-handled dialog and dropped-event warnings.  Pass `debugLog` to `connect` for bounded structured daemon/CDP diagnostics; Biloba never mixes them into framed stdout.
 
 `failure.code` is worth narrowing on, because a few of the codes mean something quite specific:
 
@@ -4484,8 +4544,10 @@ That trajectory is the [poll trajectory](#outline) the Go suite attaches on fail
 
 The last three exist so that a crash reports itself as a crash.  Chrome doesn't fail calls to a dead renderer - it stops answering them - so without a dedicated signal a crashed page looks exactly like an assertion that never came true, and sends you off to debug a test that was fine.
 
-### What isn't here yet
+### Parity and TypeScript naming
 
-The TypeScript client does not yet cover dialog handling, download capture and assertions, or an equivalent of the Go `HaveScreenshot` visual assertion.  These are unported APIs, not limitations of the daemon architecture: dialog and download events can be surfaced by the engine and protocol, and visual comparison can have a TypeScript assertion API even though the literal Gomega matcher is Go-specific.  TypeScript supports the XPath DSL, basic tab lifecycle, realistic `click`/`setValue`/`type`, request observation, and response holding; the broader Go APIs in the remaining areas have not yet been threaded through the runner-neutral layers.
+The TypeScript client supports the observable behavior of Biloba's public Go API: selectors and locator algebra; DOM reads, collections, mutations, geometry, styles, input, and polling assertions; tabs and cross-origin frames; cookies, storage, navigation, JavaScript, emulation, dialogs, downloads, network interception, screenshots, visual comparison, and structured diagnostics.
+
+The spelling follows TypeScript conventions.  Async `expect*` methods replace Gomega matchers, `expectScreenshot()` replaces `HaveScreenshot`, and arrays and typed objects replace Go matcher captures and collection helpers.  Ginkgo hooks, Gomega failure formatting, and OS-signal progress reports are runner syntax rather than browser behavior; the Vitest integration provides failure capture, timed or explicit progress capture, console replay, and `console.assert` failure policy.
 
 {% endraw  %}

--- a/engine/session.go
+++ b/engine/session.go
@@ -961,7 +961,12 @@ func (s *Session) serial(requestCtx context.Context, operation string, run func(
 
 func requestContextError(operation string, requestCtx context.Context, err error) *Error {
 	if requestErr := requestCtx.Err(); requestErr != nil {
-		err = requestErr
+		result := contextError(operation, requestErr)
+		var engineErr *Error
+		if errors.As(err, &engineErr) {
+			result.Operation = engineErr.Operation
+		}
+		return result
 	}
 	return contextError(operation, err)
 }

--- a/engine/session.go
+++ b/engine/session.go
@@ -937,6 +937,9 @@ func (s *Session) serial(requestCtx context.Context, operation string, run func(
 	if !recovers && s.hasCrashed() {
 		return pageCrashed()
 	}
+	if requestCtx.Err() != nil {
+		return requestContextError(operation, requestCtx, err)
+	}
 	var engineErr *Error
 	if errors.As(err, &engineErr) {
 		return engineErr
@@ -952,6 +955,13 @@ func (s *Session) serial(requestCtx context.Context, operation string, run func(
 			Message:   "the browser is no longer available (it exited, crashed, or was closed)",
 			Cause:     err,
 		}
+	}
+	return requestContextError(operation, requestCtx, err)
+}
+
+func requestContextError(operation string, requestCtx context.Context, err error) *Error {
+	if requestErr := requestCtx.Err(); requestErr != nil {
+		err = requestErr
 	}
 	return contextError(operation, err)
 }

--- a/engine/session_internal_test.go
+++ b/engine/session_internal_test.go
@@ -23,6 +23,22 @@ func TestRequestContextErrorPreservesDeadlineCause(t *testing.T) {
 	g.Expect(engineErr.Code).To(gomega.Equal(CodeDeadline))
 }
 
+func TestRequestContextErrorPreservesNestedOperation(t *testing.T) {
+	g := gomega.NewWithT(t)
+	requestCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := requestContextError("prepare", requestCtx, &Error{
+		Code:      CodeCanceled,
+		Operation: "list tabs",
+		Message:   context.Canceled.Error(),
+		Cause:     context.Canceled,
+	})
+
+	g.Expect(err.Operation).To(gomega.Equal("list tabs"))
+	g.Expect(errors.Is(err, context.Canceled)).To(gomega.BeTrue())
+}
+
 // These are plain testing-based units (not Ginkgo specs) because dot-importing Gomega into package
 // engine collides with the engine's own Assertion type.  They need no browser: the diagnostics
 // outline just has to be truncated exactly the way the Go runner's Outline() truncates it (see the

--- a/engine/session_internal_test.go
+++ b/engine/session_internal_test.go
@@ -1,10 +1,27 @@
 package engine
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/onsi/gomega"
 )
+
+func TestRequestContextErrorPreservesDeadlineCause(t *testing.T) {
+	g := gomega.NewWithT(t)
+	requestCtx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	<-requestCtx.Done()
+
+	err := requestContextError("evaluate", requestCtx, context.Canceled)
+
+	g.Expect(errors.Is(err, context.DeadlineExceeded)).To(gomega.BeTrue())
+	var engineErr *Error
+	g.Expect(errors.As(err, &engineErr)).To(gomega.BeTrue())
+	g.Expect(engineErr.Code).To(gomega.Equal(CodeDeadline))
+}
 
 // These are plain testing-based units (not Ginkgo specs) because dot-importing Gomega into package
 // engine collides with the engine's own Assertion type.  They need no browser: the diagnostics

--- a/plugins/biloba/skills/api/SKILL.md
+++ b/plugins/biloba/skills/api/SKILL.md
@@ -5,7 +5,7 @@ description: One-line reference for every Biloba method and matcher, grouped by 
 
 # Biloba API reference
 
-Terse lookup for the **Go** API. The TypeScript client has its own, much smaller surface → `biloba:typescript`. Docs: <https://onsi.github.io/biloba/>.
+Terse lookup for the **Go** spelling. The TypeScript client provides equivalent observable behavior with async `expect*` methods and TypeScript-native result types → `biloba:typescript`. Docs: <https://onsi.github.io/biloba/>.
 
 **Naming conventions — assume these, they're only restated where an entry breaks them:**
 

--- a/plugins/biloba/skills/debug-failures/SKILL.md
+++ b/plugins/biloba/skills/debug-failures/SKILL.md
@@ -44,6 +44,8 @@ On by default; `BilobaConfigPollTrajectory(false)` disables it (and the detached
 
 ### Visual diagnosis (a failed `b.HaveScreenshot`) → `biloba:visual-assertions`
 
+The TypeScript equivalent is a rejected `expectScreenshot()` with structured `BilobaError.visual` and `artifactPaths`; the same diagnosis and artifact guidance applies.
+
 Two extra PNGs land in the screenshots dir — `<name>.actual.png` (what Biloba saw) and `<name>.diff.png` (the actual, washed out, differing pixels in magenta) — and the failure message says what moved:
 
 ```

--- a/plugins/biloba/skills/flaky-specs/SKILL.md
+++ b/plugins/biloba/skills/flaky-specs/SKILL.md
@@ -304,6 +304,8 @@ Same for `HaveBoundingBox`, `HaveScrollOffset`, `HaveOffsetTopWithin`/`HaveOffse
 
 **A visual baseline that was never reviewed asserts nothing.** If a missing baseline were written on first sight and the spec passed, the very first run would certify whatever the page happened to look like — a broken page included — and the assertion would be green from birth, so nobody would ever open the image. Biloba refuses: a missing baseline is a **failure** that writes the captured `.actual.png` and tells you to re-run with `BILOBA_UPDATE_SCREENSHOTS=1`.
 
+TypeScript `expectScreenshot()` follows the same missing-baseline and update-mode rule.
+
 Don't work around it. Pre-writing baselines blind — a scripted "run with update until it's green", or committing whatever the first run produced without looking — recreates exactly the vacuous assertion the refusal exists to prevent. Read the `.actual.png`, then update.
 
 **`BILOBA_UPDATE_SCREENSHOTS` set in CI turns the entire visual suite green.** In update mode every visual assertion captures, writes its baseline, and passes — no comparison happens at all. It's an environment variable, so it gets added to a CI config once, during a legitimate baseline refresh, and then stays. Nothing fails, nothing looks wrong, and the suite reads as coverage while proving nothing. Grep the CI config for it before trusting a green visual run, and keep the variable to local, scoped invocations (`ginkgo --focus=…`).

--- a/plugins/biloba/skills/typescript/SKILL.md
+++ b/plugins/biloba/skills/typescript/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typescript
-description: Drive Biloba from a TypeScript/vitest suite instead of Go — daemon topology, sessions and sibling tabs, CSS/semantic/XPath locators, actions and assertions, realistic click/setValue/type, poll modes, request observation and response holding, navigation, evaluation, and structured failures. Use when writing or debugging browser tests in TypeScript/vitest against Biloba, or when deciding between the Go and TypeScript clients. For the Go API use biloba:write-tests.
+description: Drive Biloba from a TypeScript/vitest suite — shared Chrome and launch modes, sessions/tabs/frames, CSS/semantic/XPath locators, complete DOM and realistic input APIs, cookies/storage, dialogs/downloads/network, screenshots/visual assertions, polling, diagnostics, and structured failures. Use when writing or debugging browser tests in TypeScript/vitest against Biloba. For the Go API use biloba:write-tests.
 ---
 
 # Biloba from TypeScript
@@ -48,7 +48,7 @@ let browser: SharedBrowserProcess | undefined;
 
 export async function setup(project: TestProject): Promise<void> {
   browser = await startSharedBrowser({executable: daemonExecutable});
-  project.provide("chromeWsUrl", browser.wsURL);
+  project.provide("chromeConnection", browser.connection);
 }
 
 export async function teardown(): Promise<void> {
@@ -66,7 +66,7 @@ let browser: Browser;
 let session: Session;
 
 beforeAll(async () => {
-  browser = await connect({chromeWsUrl: inject("chromeWsUrl")});
+  browser = await connect({chromeConnection: inject("chromeConnection")});
   session = await browser.openSession();
 });
 beforeEach(async () => { await session.prepare(); });
@@ -74,10 +74,11 @@ afterAll(async () => { await browser.close(); });
 ```
 
 - `connect` falls back to `BILOBA_DAEMON_EXECUTABLE` when `daemonExecutable` is omitted.
-- Omit `chromeWsUrl` and the daemon launches its own Chrome — fine for one file, wasteful for a suite.
-- Pass `artifactDir` to `connect` to get failure screenshots written to disk.
+- Omit `chromeConnection` and the daemon launches its own Chrome — fine for one file, wasteful for a suite. Legacy `chromeWsUrl` works but cannot preserve honest host launch metadata.
+- `startSharedBrowser` and self-launching `connect` accept `mode`, `chromePath`, `autoInstall`, ordered `chromeArgs`, and `windowSize`. The mode is `"headless-shell"`, `"headless"`, or `"headful"`; the default size is 1024×768.
+- Configure failure/progress/on-demand capture with `diagnostics`; `artifactDir` remains a compatibility alias.
 - A root `Session` has its own browser context, so cookies and storage are isolated. `session.prepare()` is `b.Prepare()` — reset between tests rather than opening a new session.
-- `await session.newTab()` opens a sibling tab in the same context. It shares cookies and storage and has its own `navigate`, `activate`, and `close` lifecycle. Go still has richer spawned-tab enumeration and switching helpers.
+- `await session.newTab()` opens a sibling tab in the same context. Use `tabs()`/`spawnedTabs()` for snapshots, `findTab()`/`waitForTab()` for popup workflows, and `frames()`/`waitForFrame()` for cross-origin frame targets.
 
 ## 3. Locators
 
@@ -89,6 +90,10 @@ Lazy; building one talks to nobody.
 | `session.getByTestId("name")` | `[data-testid="name"]` |
 | `session.getByText("Save", {exact: true})` | by text content |
 | `session.getByRole("button", {name: "Increment"})` | by ARIA role, optionally accessible name |
+| `session.getByLabel("Email")` | associated label |
+| `session.getByPlaceholder("Search")` | placeholder |
+| `session.getByAltText("Profile")` | image alt text |
+| `session.getByTitle("Close")` | title |
 | `session.xpath("//button[@name='save']")` | raw XPath |
 | `.first()` | narrow to the first match |
 
@@ -130,15 +135,17 @@ await session.expectEvaluation("window.app.ready", true);
 
 Assertions resolve to an `AssertionResult`: `observed`, `attemptCount`, `trajectory`, `rpcRequestCount`, `rpcResponseCount`, `elapsedMs`.
 
-Opt into browser-faithful CDP input for the interactions TypeScript currently supports:
+Opt into browser-faithful CDP input when realism matters:
 
 ```ts
 await session.getByRole("button", {name: "Pay"}).realistic().click();
 await session.getByTestId("card-number").realistic().setValue("4242");
 await session.getByTestId("card-number").realistic().type(" 4242");
+await session.getByTestId("card").realistic().dragTo(session.getByTestId("column"));
+await session.getByTestId("menu").realistic().hover();
 ```
 
-The Go realistic track additionally covers hover, click variants, tap, wheel, and realistic drag.
+The realistic track also covers click variants, tap, and wheel input. The fast default keeps find-and-act atomic in the page runtime.
 
 ## 5. Navigation
 
@@ -165,10 +172,15 @@ Cookies accept a `Date` for expiry:
 await session.setCookies([{name: "session", value: "abc123", path: "/"}]);
 ```
 
-## 7. Network observation and holding
+## 7. Dialogs, downloads, and network
 
 ```ts
 await session.expectRequest(endsWith("/orders"), {method: "POST"});
+
+const stub = await session.stubRequest(endsWith("/feature-flags"), {
+  status: 200,
+  body: new TextEncoder().encode('{"available":true}'),
+});
 
 const hold = await session.holdResponse(endsWith("/inventory"));
 try {
@@ -179,11 +191,38 @@ try {
 }
 ```
 
-Always release a hold. Arbitrary response stubbing, aborting, modifying, and richer request inspection remain Go-only.
+Always release a hold. Network handlers are first-match-wins, so assert `count()` or inspect `stats()` when the registration itself is part of the test.
 
-## 8. Failures
+Use `requests()`/`responses()` for history and `waitForRequest()` for an atomic winning observation. `stubRequest()`, `abortRequest()`, `modifyRequest()`, `modifyResponse()`, and `routeResponse()` return first-match-wins handlers with `count()`, `stats()`, and `remove()`. Network-state methods cover cache, offline mode, latency, throughput, and connection type.
 
-Everything rejects with a `BilobaError` carrying `code`, `locator`, `expected`, `observed`, `trajectory`, `domOutline`, `screenshotPath`, `daemonDetail`.
+`modifyResponse()` patches the response: what you leave out is inherited from the original. `routeResponse()` *replaces* it - an unset status means 200, and unset headers or body mean none - so hand back anything you want kept, including headers you read off the intercepted response.
+
+```ts
+const handler = await session.handleDialogs("prompt", {message: "Name?", promptText: "Ada"});
+const download = await session.expectDownload({filename: endsWith(".csv")});
+const bytes = await download.content();
+await handler.remove();
+```
+
+Dialog history includes safely auto-handled dialogs and warnings. Download snapshots preserve active, complete, and cancelled state; content is bounded binary data.
+
+## 8. Screenshots and visual assertions
+
+`captureScreenshot()` returns bounded `Uint8Array` data by default or a daemon-owned path with `{output: "path", name}`. It works on a session or locator.
+
+`expectScreenshot(name, options)` is the TypeScript equivalent of Go's `HaveScreenshot`. It supports masks, pixel and channel tolerances, automatic animation freezing, animated opt-out, light/dark schemes, baseline update mode, diff artifacts, and structured diagnosis.
+
+```ts
+const result = await session.getByTestId("chart").expectScreenshot("revenue-chart", {
+  mask: [session.getByTestId("timestamp")],
+  colorSchemes: ["light", "dark"],
+});
+expect(result.match).toBe(true);
+```
+
+## 9. Failures and diagnostics
+
+Everything rejects with a `BilobaError` carrying `code`, `locator`, `expected`, `observed`, `trajectory`, `domOutline`, `screenshotPath`, `diagnostics`, `visual`, `artifactPaths`, and `daemonDetail` as applicable.
 
 `trajectory` is the [poll trajectory](https://onsi.github.io/biloba/#outline) as data — every attempt with what it observed and why it retried. Read it before widening a timeout: a flat line is a product bug, a monotone approach is latency.
 
@@ -203,6 +242,12 @@ Narrow on `code` — several are specific and actionable:
 
 The last three exist so a crash reports itself as a crash: Chrome does not fail calls to a dead renderer, it stops answering them, so without a dedicated code a crashed page is indistinguishable from an assertion that never came true.
 
-## 9. Not implemented in TypeScript
+`session.captureDiagnostics()` captures every live page in the browser context and excludes frames, workers, and other contexts. `consoleMessages()`/`onConsoleMessage()` and `warnings()`/`onWarning()` provide bounded snapshots and live delivery. Pass `debugLog` to `connect` for structured driver/CDP records.
 
-Dialog handling, download capture and assertions, and an equivalent of Go's `HaveScreenshot` visual assertion have not yet been ported. These are gaps in the current engine/protocol surface, not architectural restrictions. TypeScript supports the XPath DSL, basic tab lifecycle, realistic `click`/`setValue`/`type`, request observation, and response holding. Do not attempt to recreate the missing APIs through `evaluate`.
+In a Vitest setup file, import `installBilobaVitestHooks` from `@onsi/biloba-vitest-prototype/vitest`. It captures ordinary and Biloba test failures, supports timed and explicit progress capture, replays browser errors, and can fail the test boundary on `console.assert` without throwing from the protocol reader.
+
+## 10. Parity and naming
+
+TypeScript supports Biloba's observable Go behavior across selectors and locator algebra; DOM reads, collections, mutations, geometry, styles, input, and polling assertions; tabs and frames; cookies and storage; navigation, JavaScript, and emulation; dialogs, downloads, and network interception; screenshots, visual comparison, and diagnostics.
+
+The spelling is intentionally TypeScript-native. Async `expect*` methods replace Gomega matchers, `expectScreenshot()` replaces `HaveScreenshot`, and arrays and typed objects replace Go captures and collection matchers. The Vitest adapter supplies the equivalent of Ginkgo-specific failure capture, progress capture, console replay, and `console.assert` policy.

--- a/plugins/biloba/skills/visual-assertions/SKILL.md
+++ b/plugins/biloba/skills/visual-assertions/SKILL.md
@@ -15,6 +15,8 @@ Eventually(".card").Should(SatisfyAll(b.BeInViewport(b.Fully()), b.HaveScreensho
 
 Docs: <https://onsi.github.io/biloba/#visual-assertions>.
 
+In TypeScript, use `session.expectScreenshot(...)` or `locator.expectScreenshot(...)`. The baseline, update, masking, tolerance, freeze, color-scheme, artifact, and diagnosis behavior is the same; see `biloba:typescript` for TypeScript option names.
+
 **Give it a real deadline.** Gomega's default `Eventually` is 1s and a capture-and-compare is not free:
 
 ```go

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -30,7 +30,9 @@ await session.locator("#count").expectText("1");
 ## Read this instead
 
 The narrative documentation lives with the rest of Biloba's docs:
-**[Biloba from TypeScript](https://onsi.github.io/biloba/#biloba-from-typescript)** — the topology and why it's shaped this way, setup, locators, actions and assertions, `evaluate`, failure output and what each error code means, and what the client doesn't cover yet.
+**[Biloba from TypeScript](https://onsi.github.io/biloba/#biloba-from-typescript)** — setup and shared-browser topology; launch modes; selectors; DOM, input, geometry, tabs, cookies, storage, dialogs, downloads, and network APIs; screenshots and visual assertions; diagnostics; and structured failures.
+
+The client preserves the observable behavior of Biloba's public Go API with TypeScript-native spelling. Async `expect*` methods replace Gomega matchers, `expectScreenshot()` replaces `HaveScreenshot`, and the Vitest adapter replaces Ginkgo-specific failure and progress hooks.
 
 ## Working in this directory
 


### PR DESCRIPTION
**Stack 15 of 17** · base [#30](https://github.com/onsi/biloba/pull/30) · next: [#32](https://github.com/onsi/biloba/pull/32)

This final slice documents the completed TypeScript surface and contains the small cross-cutting fixes found during final full-stack validation.

## Included

- complete TypeScript parity documentation
- refreshed API, visual, debugging, and flaky-spec agent guidance
- preservation of request deadline causes
- retention of nested cancellation operations
- direct system dependency declaration
- narrowly bounded race/CI scheduling tolerances in protocol and visual tests

## Review guide

1. Verify the TypeScript documentation agrees with the public API introduced by the preceding slices.
2. Review the cancellation/deadline fixes and their focused regression tests.
3. Review the three one-line build/test stability adjustments.

## Size

12 files, +189 / −32.

## Verification

`make driver-test` passed independently at this final stack boundary:

- TypeScript: 72/72, plus typecheck and build
- engine: 131/131
- protocol: 96/96
- bilobad: 51/51

The final Git tree is byte-for-byte identical to the previously published aggregate tip `b463d48`; only commit grouping and review boundaries changed.