### PR TITLE
16/17 feat: add immediate action shorthand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 
 ## 0.15.2
 
+### Features
+
+- TypeScript polling options now accept `{immediate: true}` as the action-friendly shorthand for `{mode: "immediate"}`, matching Go's `b.Immediate()` spelling while using the existing one-attempt protocol mode.
+
 ### Fixes
 
 - A handler registered through a *view* of a tab now actually registers on that tab.  Every lightweight view - `b.Realistic()`, `b.WithTimeout(d)`, `b.Immediate()`, and the rest - is a shallow copy of the Biloba struct, and the handler lists were plain slice fields on it, so an append through a view updated the copy's slice header and nothing else.  `b.WithTimeout(15*time.Second).HoldResponse(url)` intercepted nothing and `Await` burned exactly the deadline you tuned; `b.Realistic().StubRequest(...)`, `.AbortRequest`, `.ModifyRequest`, `.ModifyResponse` and `.HandleAlertDialogs(...)` were all silently registered nowhere.  Reads were affected too - a list read through a view was frozen at the instant the view was made, so `rb.Dialogs()` and `rb.AllRequests()` went stale, and a view held across a navigation could report `window._biloba` still installed after the page had taken it away.  The state a tab owns now lives behind a pointer, the way `lock` already did, so a view and its tab reach the same state - which is what every view's documentation already promised.
@@ -774,4 +778,3 @@ The two artifact options added during 0.2.0 development follow the same shape: `
 ## 0.1.0
 
 - First release!
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -4405,7 +4405,13 @@ await session.expectUrl("/dashboard", {pathname: true});
 await session.expectEvaluation("window.app.ready", true);
 ```
 
-Every one of these takes `{timeoutMs, intervalMs, signal, mode}`.  The default mode is `"eventually"`; `"immediate"` makes one attempt, and `"consistently"` requires the condition to remain true for the timeout.  TypeScript still has no bare-matcher form - the [dual API](#interacting-with-elements) is a Gomega idiom, and TypeScript has no `Eventually` to hand a matcher to.
+Every one of these takes `{timeoutMs, intervalMs, signal, mode}`.  The default mode is `"eventually"`; `"immediate"` makes one attempt, and `"consistently"` requires the condition to remain true for the timeout.  For the action-oriented spelling that mirrors Go's `b.Immediate()`, `{immediate: true}` is shorthand for `{mode: "immediate"}`:
+
+```ts
+await session.getByRole("button", {name: "Save"}).click({immediate: true});
+```
+
+TypeScript still has no bare-matcher form - the [dual API](#interacting-with-elements) is a Gomega idiom, and TypeScript has no `Eventually` to hand a matcher to.
 
 For interactions where browser-faithful input matters, call `realistic()` on the locator:
 

--- a/plugins/biloba/skills/typescript/SKILL.md
+++ b/plugins/biloba/skills/typescript/SKILL.md
@@ -22,7 +22,7 @@ vitest worker 3  ──▶  bilobad  ──┘
 **Polling runs on the daemon, not in your test.** `expectText("ready", {timeoutMs: 1000, intervalMs: 5})` is **one** request — the retry loop runs next to Chrome and answers once with the outcome plus the trajectory it took.
 
 - Never write a client-side retry loop (`await expect.poll(...)` around a Biloba assertion, `waitFor`, a `for` loop with sleeps). You are re-polling a poll; the failure you get is the inner one, and you pay a round trip per attempt.
-- The default mode is `"eventually"`. Use `{mode: "immediate"}` for one attempt or `{mode: "consistently"}` to require the condition to remain true for the timeout.
+- The default mode is `"eventually"`. Use `{mode: "immediate"}` for one attempt or `{mode: "consistently"}` to require the condition to remain true for the timeout. On actions, `{immediate: true}` is the Go-shaped shorthand for `{mode: "immediate"}`.
 - There is no bare matcher form. The Go [dual API](https://onsi.github.io/biloba/#interacting-with-elements) is a Gomega idiom with no TypeScript equivalent.
 - Tune with `{timeoutMs, intervalMs, signal, mode}` on actions and assertions.
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -16,6 +16,9 @@ vitest worker 3  ──▶  bilobad  ──┘
 
 Polling happens on the daemon.  An assertion with a 1s timeout and a 5ms interval is *one* request, not two hundred - the retry loop runs next to Chrome and answers once with the outcome and the trajectory it took.
 
+Actions poll by default. Pass `{immediate: true}` to try exactly once and fail fast, matching Go's
+`b.Immediate()` behavior; it is shorthand for `{mode: "immediate"}`.
+
 ```ts
 const browser = await connect({chromeWsUrl});
 const session = await browser.openSession();

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -175,6 +175,8 @@ export interface WaitOptions {
   intervalMs?: number | undefined;
   signal?: AbortSignal | undefined;
   mode?: "eventually" | "immediate" | "consistently" | undefined;
+  /** Shorthand for mode: "immediate". Try exactly once and fail fast. */
+  immediate?: boolean | undefined;
 }
 export type PollOptions = WaitOptions;
 

--- a/typescript/src/internal/client.ts
+++ b/typescript/src/internal/client.ts
@@ -1852,10 +1852,17 @@ function operationResult(
 }
 
 function pollPolicy(options: WaitOptions): Record<string, number | string> {
+  if (options.immediate && options.mode !== undefined && options.mode !== "immediate") {
+    throw new BilobaError({
+      code: "INVALID_ARGUMENT",
+      message: `immediate: true conflicts with mode: ${JSON.stringify(options.mode)}`,
+    });
+  }
+  const mode = options.immediate ? "IMMEDIATE" : options.mode?.toUpperCase();
   return {
     ...(options.timeoutMs !== undefined && {timeoutMs: options.timeoutMs}),
     ...(options.intervalMs !== undefined && {intervalMs: options.intervalMs}),
-    ...(options.mode !== undefined && {mode: options.mode.toUpperCase()}),
+    ...(mode !== undefined && {mode}),
   };
 }
 

--- a/typescript/test/client.test.ts
+++ b/typescript/test/client.test.ts
@@ -720,6 +720,30 @@ describe("Biloba TypeScript client", () => {
     expect((requests.at(-1) as {request: {poll?: {mode?: string}}}).request.poll?.mode).toBeUndefined();
   });
 
+  it("accepts immediate as an action-friendly alias for immediate mode", async () => {
+    browser = await connectClient();
+    const session = await browser.openSession();
+
+    await session.locator("#save").click({immediate: true});
+    await session.getByTestId("name").setValue("Ada", {immediate: true});
+
+    expect(requests.filter(({method}) => method === "Click" || method === "SetValue")).toMatchObject([
+      {method: "Click", request: {poll: {mode: "IMMEDIATE"}}},
+      {method: "SetValue", request: {poll: {mode: "IMMEDIATE"}}},
+    ]);
+  });
+
+  it("rejects contradictory immediate action modes before sending a request", async () => {
+    browser = await connectClient();
+    const session = await browser.openSession();
+
+    const error = await session.locator("#save").click({immediate: true, mode: "consistently"})
+      .catch((reason: unknown) => reason);
+
+    expect(error).toMatchObject({code: "INVALID_ARGUMENT"});
+    expect(requests.filter(({method}) => method === "Click")).toHaveLength(0);
+  });
+
   it("serializes realistic pointer and keyboard actions", async () => {
     browser = await connectClient();
     const session = await browser.openSession();

--- a/typescript/test/parity.test.ts
+++ b/typescript/test/parity.test.ts
@@ -769,6 +769,19 @@ describe.skipIf(process.env.BILOBA_SKIP_PARITY === "true")("Go and TypeScript pa
     expect(failure.domOutline).toContain("Biloba parity");
   });
 
+  it("can try an action exactly once through the immediate alias", async () => {
+    await session.prepare();
+    await session.navigate(baseUrl);
+
+    const failure = await session.locator("#never").click({immediate: true})
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(BilobaError);
+    const error = failure as BilobaError;
+    expect(error.code).toBe("TIMEOUT");
+    expect(error.trajectory).toHaveLength(1);
+  });
+
   it("runs independent worker daemons concurrently against the shared Chrome", async () => {
     const secondBrowser = await connect({daemonExecutable: daemonExecutable!, chromeWsUrl: sharedBrowser.wsURL});
     const secondSession = await secondBrowser.openSession();


### PR DESCRIPTION
**Stack 16 of 17** · base [#31](https://github.com/onsi/biloba/pull/31) · next: [#33](https://github.com/onsi/biloba/pull/33)

TypeScript already exposes the same one-attempt behavior as Go through `{mode: "immediate"}`. This final slice adds the Go-shaped `{immediate: true}` shorthand and maps it onto that existing protocol mode.

## Included

- add `immediate?: boolean` to TypeScript polling options
- translate the shorthand to the existing `IMMEDIATE` wire mode
- reject contradictory `immediate: true` and non-immediate `mode` combinations
- document the Go/TypeScript spelling correspondence
- cover request serialization and a real-daemon one-attempt trajectory

## Verification

- TypeScript typecheck and unit tests: 76/76
- Go parity contract: 3/3
- TypeScript real-daemon parity: 16/16
- `git diff --check`