### PR TITLE
Add a repeatable npm publishing step for the TypeScript client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ TODO
 .DS_Store
 browser
 /.bin/
+/.release/
 # Process artifacts from the agent-improvement work (kept locally, not tracked)
 report.md
 CHANGELOG-TMP.md

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,31 @@
 
 GINKGO := go run github.com/onsi/ginkgo/v2/ginkgo
 
-.PHONY: test test-all stress-test update-chrome driver-test driver-parity driver-e2e check-plugins sync-plugin-versions
+.PHONY: test test-all stress-test update-chrome driver-test driver-parity driver-e2e check-plugins check-release npm-pack npm-publish sync-plugin-versions
 
 ## check-plugins: validate plugin manifests, versions, namespaces, skill names, and client separation.
 check-plugins:
 	./scripts/check-plugins.sh
 
-## sync-plugin-versions: release-tool hook; copy BILOBA_VERSION into every Biloba plugin manifest.
+## sync-plugin-versions: release-tool hook; copy BILOBA_VERSION into plugin and npm manifests.
 ## Onsi's shipit should run this after updating BILOBA_VERSION and before creating the release commit.
 sync-plugin-versions:
 	./scripts/sync-plugin-versions.sh
+
+## check-release: verify npm/package metadata and the optional TAG (for example TAG=v0.15.4).
+check-release:
+	node ./scripts/check-npm-release.mjs "$(TAG)"
+
+## npm-pack: build once and stage dry-run packages for both npm names under .release/npm.
+npm-pack: check-release
+	cd typescript && pnpm build
+	node ./scripts/prepare-npm-packages.mjs
+	cd .release/npm/scoped && npm pack --dry-run
+	cd .release/npm/unscoped && npm pack --dry-run
+
+## npm-publish: publish both npm names using the caller's npm credentials; safe to retry.
+npm-publish:
+	./scripts/publish-npm-packages.sh --publish
 
 ## test: standard headless (chrome-headless-shell) suite - parallel + randomized. Your default.
 test:
@@ -33,7 +48,7 @@ test-all:
 ## protocol/generated_test.go), which compare what is on disk against what the generator renders -
 ## so they are right on a dirty working tree too.  Run the generators yourself after editing
 ## biloba.js or the protocol wire structs.
-driver-test:
+driver-test: check-release
 	cd typescript && pnpm install --frozen-lockfile && pnpm test && pnpm typecheck && pnpm build
 	$(GINKGO) --randomize-all ./engine ./protocol ./cmd/bilobad
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,11 @@ The former `biloba@biloba` plugin remains as a deprecated compatibility alias fo
 
 ### Vitest Support
 
-Biloba's TypeScript client lets a `vitest` suite drive Chrome through Biloba.  **It's a prototype**: the package (`@onsi/biloba-vitest-prototype`) isn't published to npm yet — you build it from this repo — and its API will keep shifting before 1.0.  [**Biloba for Vitest**](https://onsi.github.io/biloba/vitest.html) is the documentation: setup and the shared-browser topology, launch modes, locators, actions and assertions, network control, screenshots and visual assertions, and structured failures.
+Biloba's TypeScript client lets a `vitest` suite drive Chrome through Biloba. **It's a prototype**:
+install the `biloba` package from npm, and expect its API to keep shifting before 1.0.
+[**Biloba for Vitest**](https://onsi.github.io/biloba/vitest.html) is the documentation: setup and
+the shared-browser topology, launch modes, locators, actions and assertions, network control,
+screenshots and visual assertions, and structured failures.
 
 Each `vitest` worker process spawns a small Go daemon (`bilobad`) and talks to it over framed JSON on stdin/stdout.  Every daemon attaches to one shared Chrome — the same "one browser, one isolated tab per parallel process" model that makes the Go suites fast.  Polling happens on the daemon, next to Chrome, so an assertion with a 1s timeout and a 5ms interval is *one* request rather than two hundred.
 
@@ -205,7 +209,7 @@ Here's the chat app from the top of this README, in TypeScript.  Actions and ass
 
 ```ts
 import {beforeEach, describe, it} from "vitest";
-import {contains, Keys, not, type Session} from "@onsi/biloba-vitest-prototype";
+import {contains, Keys, not, type Session} from "biloba";
 
 async function login(tab: Session, user: string, password: string) {
   await tab.navigate("/login");

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,36 @@
+# Releasing Biloba on npm
+
+Biloba uses `BILOBA_VERSION` in `biloba.go` as the version source for the Go module, Claude Code
+plugins, and TypeScript client. The same TypeScript build is published under the npm names `biloba`
+and `@biloba/biloba`.
+
+## Hook for the existing release script
+
+After the private release script updates `BILOBA_VERSION`, it should continue to invoke the existing
+`make sync-plugin-versions` hook. That target now also writes the version to
+`typescript/package.json`. Before creating the release tag, run:
+
+```bash
+./scripts/publish-npm-packages.sh --dry-run vX.Y.Z
+```
+
+After the normal release tests pass and the matching tag is created, publish with:
+
+```bash
+./scripts/publish-npm-packages.sh --publish vX.Y.Z
+```
+
+The publishing environment must already be authenticated with npm and authorized for both package
+names. The script contains and reads no credentials. It builds once, stages identical package trees
+under `.release/npm/`, validates both with `npm pack --dry-run`, and then publishes them. Published
+npm versions are immutable, so a retry skips a name whose matching version already exists and
+continues with the missing one.
+
+The equivalent Make targets are `make npm-pack TAG=vX.Y.Z` and `make npm-publish` (the latter derives
+the tag from the current package version).
+
+## Initial publication
+
+The first run claims each available package name. The publishing account must have 2FA enabled (or
+use an npm granular token allowed to publish) and must belong to the existing `biloba` npm
+organization to publish `@biloba/biloba`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 Biloba uses `BILOBA_VERSION` in `biloba.go` as the version source for the Go module, Claude Code
 plugins, and TypeScript client. The same TypeScript build is published under the npm names `biloba`
-and `@biloba/biloba`.
+and `@onsi/biloba`.
 
 ## Hook for the existing release script
 
@@ -32,5 +32,8 @@ the tag from the current package version).
 ## Initial publication
 
 The first run claims each available package name. The publishing account must have 2FA enabled (or
-use an npm granular token allowed to publish) and must belong to the existing `biloba` npm
-organization to publish `@biloba/biloba`.
+use an npm granular token allowed to publish) and must belong to the `onsi` npm organization to
+publish `@onsi/biloba`.
+
+The `@biloba` scope is not an option: the `biloba` npm org/user already exists and belongs to another
+account (the registry reports the scope with no public members), so nobody else can publish there.

--- a/docs/vitest.md
+++ b/docs/vitest.md
@@ -7,7 +7,8 @@ title: Biloba for Vitest
 
 Biloba's TypeScript client lets a `vitest` suite drive Biloba browser automation through a worker-local daemon and one shared Chrome.
 
-> **Status: prototype.**  The package (`@onsi/biloba-vitest-prototype`) is not published to npm yet - today you build it from this repo - and its API will continue to shift before 1.0.  See the [support policy](./#support-policy).  What follows describes what works today.
+> **Status: prototype.** The `biloba` package has an API that will continue to shift before 1.0.
+> See the [support policy](./#support-policy). What follows describes what works today.
 
 ### Claude Code skills
 
@@ -57,7 +58,7 @@ Start one Chrome for the whole run in vitest's global setup, and hand its websoc
 
 ```ts
 // global-setup.ts
-import {startSharedBrowser, type SharedBrowserProcess} from "@onsi/biloba-vitest-prototype";
+import {startSharedBrowser, type SharedBrowserProcess} from "biloba";
 import type {TestProject} from "vitest/node";
 
 const daemonExecutable = process.env.BILOBA_DAEMON_EXECUTABLE;
@@ -83,7 +84,7 @@ Then, in each test file, connect a daemon of your own and open a session:
 
 ```ts
 import {inject} from "vitest";
-import {connect, type Browser, type Session} from "@onsi/biloba-vitest-prototype";
+import {connect, type Browser, type Session} from "biloba";
 
 let browser: Browser;
 let session: Session;
@@ -148,7 +149,7 @@ Use semantic locators for user-facing behavior and stable CSS hooks for structur
 The XPath DSL is a runner-independent string builder.  Build an expression, then bind it to a session:
 
 ```ts
-import {relativeXPath, xpath} from "@onsi/biloba-vitest-prototype";
+import {relativeXPath, xpath} from "biloba";
 
 const save = xpath("button").withClass("primary").withText("Save");
 await session.xpath(save).click();
@@ -308,7 +309,7 @@ try {
 
 That trajectory records every polling attempt as structured data instead of reducing the failure to its final observation.  Pass `artifactDir` to `connect` to get screenshots written to disk.
 
-For runner-level capture, load `installBilobaVitestHooks` from `@onsi/biloba-vitest-prototype/vitest` in a Vitest setup file.  The hook captures every live tab after any failed test, can capture a slow test after `progressAfterMs`, replays browser errors, and turns `console.assert` into a test-boundary failure.  `session.captureDiagnostics()` provides the same context-wide capture on demand.  Configure screenshots, outlines, artifact paths, inline output, viewport, byte limits, and poll trajectories under `connect({diagnostics: {...}})`; explicit members override CI and interactive defaults independently.
+For runner-level capture, load `installBilobaVitestHooks` from `biloba/vitest` in a Vitest setup file.  The hook captures every live tab after any failed test, can capture a slow test after `progressAfterMs`, replays browser errors, and turns `console.assert` into a test-boundary failure.  `session.captureDiagnostics()` provides the same context-wide capture on demand.  Configure screenshots, outlines, artifact paths, inline output, viewport, byte limits, and poll trajectories under `connect({diagnostics: {...}})`; explicit members override CI and interactive defaults independently.
 
 Use `consoleMessages()` for bounded history and `onConsoleMessage()` for live delivery.  `warnings()` and `onWarning()` expose auto-handled dialog and dropped-event warnings.  Pass `debugLog` to `connect` for bounded structured daemon/CDP diagnostics; Biloba never mixes them into framed stdout.
 

--- a/plugins/biloba-vitest/skills/debug-failures/SKILL.md
+++ b/plugins/biloba-vitest/skills/debug-failures/SKILL.md
@@ -37,7 +37,7 @@ Do not turn crash codes into assertion timeouts. They identify which layer died 
 
 ## Runner-level diagnostics
 
-Install `installBilobaVitestHooks` from `@onsi/biloba-vitest-prototype/vitest` in a Vitest setup file. It captures live tabs after failures, can capture slow-test progress, replays browser errors, and reports `console.assert` at the test boundary.
+Install `installBilobaVitestHooks` from `biloba/vitest` in a Vitest setup file. It captures live tabs after failures, can capture slow-test progress, replays browser errors, and reports `console.assert` at the test boundary.
 
 - Call `session.captureDiagnostics()` for an explicit context-wide snapshot.
 - Use `consoleMessages()`/`onConsoleMessage()` and `warnings()`/`onWarning()` for history and live events.

--- a/plugins/biloba-vitest/skills/overview/SKILL.md
+++ b/plugins/biloba-vitest/skills/overview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: overview
-description: Explain Biloba's TypeScript/Vitest mental model — one shared Chrome, one bilobad process per Vitest worker, isolated reusable root sessions, server-side polling, fast versus realistic input, and structured diagnostics. Use first when adopting @onsi/biloba-vitest-prototype or deciding how to structure a Vitest browser suite. Route to the other biloba-vitest:* skills.
+description: Explain Biloba's TypeScript/Vitest mental model — one shared Chrome, one bilobad process per Vitest worker, isolated reusable root sessions, server-side polling, fast versus realistic input, and structured diagnostics. Use first when adopting biloba or deciding how to structure a Vitest browser suite. Route to the other biloba-vitest:* skills.
 ---
 
 # Biloba for Vitest

--- a/plugins/biloba-vitest/skills/setup/SKILL.md
+++ b/plugins/biloba-vitest/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: Wire Biloba's TypeScript client into Vitest — build and locate bilobad, start one shared Chrome in global setup, provide its connection to workers, create one daemon and reusable root Session per test file, prepare between tests, close cleanly, and choose launch modes/options. Use when installing @onsi/biloba-vitest-prototype or changing suite-level browser/daemon lifecycle.
+description: Wire Biloba's TypeScript client into Vitest — build and locate bilobad, start one shared Chrome in global setup, provide its connection to workers, create one daemon and reusable root Session per test file, prepare between tests, close cleanly, and choose launch modes/options. Use when installing biloba or changing suite-level browser/daemon lifecycle.
 ---
 
 # Setting up Biloba for Vitest
@@ -16,7 +16,7 @@ Start one Chrome for the entire run:
 
 ```ts
 // global-setup.ts
-import {startSharedBrowser, type SharedBrowserProcess} from "@onsi/biloba-vitest-prototype";
+import {startSharedBrowser, type SharedBrowserProcess} from "biloba";
 import type {TestProject} from "vitest/node";
 
 const executable = process.env.BILOBA_DAEMON_EXECUTABLE;
@@ -38,7 +38,7 @@ Create one daemon and root session in each test file:
 
 ```ts
 import {inject} from "vitest";
-import {connect, type Browser, type Session} from "@onsi/biloba-vitest-prototype";
+import {connect, type Browser, type Session} from "biloba";
 
 let browser: Browser;
 let session: Session;

--- a/plugins/biloba-vitest/skills/write-tests/SKILL.md
+++ b/plugins/biloba-vitest/skills/write-tests/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: write-tests
-description: Author Biloba browser tests in TypeScript/Vitest — sessions, tabs, frames, CSS/semantic/XPath locators, polling actions and assertions, realistic input, cookies/storage, dialogs/downloads/network, screenshots, and structured failures. Use when writing or reviewing tests against @onsi/biloba-vitest-prototype. For wiring the daemon and shared Chrome, use biloba-vitest:setup.
+description: Author Biloba browser tests in TypeScript/Vitest — sessions, tabs, frames, CSS/semantic/XPath locators, polling actions and assertions, realistic input, cookies/storage, dialogs/downloads/network, screenshots, and structured failures. Use when writing or reviewing tests against biloba. For wiring the daemon and shared Chrome, use biloba-vitest:setup.
 ---
 
 # Writing Biloba Vitest tests
 
 Assume the suite is wired with `biloba-vitest:setup` and apply the topology in `biloba-vitest:overview`. Visual assertions → `biloba-vitest:visual-assertions`. Failures → `biloba-vitest:debug-failures`. Flakes → `biloba-vitest:flaky-tests`. Docs: <https://onsi.github.io/biloba/vitest.html>.
 
-**Prototype.** The package (`@onsi/biloba-vitest-prototype`) is not on npm; it is built from the Biloba repo and its API will continue to shift before 1.0.
+**Prototype.** The `biloba` package is published in lockstep with the Go release and its API will continue to shift before 1.0.
 
 ## 1. The topology — know this before writing anything
 
@@ -38,7 +38,7 @@ One Chrome per run, in vitest's global setup:
 
 ```ts
 // global-setup.ts
-import {startSharedBrowser, type SharedBrowserProcess} from "@onsi/biloba-vitest-prototype";
+import {startSharedBrowser, type SharedBrowserProcess} from "biloba";
 import type {TestProject} from "vitest/node";
 
 const daemonExecutable = process.env.BILOBA_DAEMON_EXECUTABLE;
@@ -60,7 +60,7 @@ A daemon and session per test file:
 
 ```ts
 import {inject} from "vitest";
-import {connect, type Browser, type Session} from "@onsi/biloba-vitest-prototype";
+import {connect, type Browser, type Session} from "biloba";
 
 let browser: Browser;
 let session: Session;
@@ -102,7 +102,7 @@ Prefer `getByRole`/`getByTestId` over brittle styling classes.
 The XPath DSL is client-side. Build the expression, then bind it to the session:
 
 ```ts
-import {relativeXPath, xpath} from "@onsi/biloba-vitest-prototype";
+import {relativeXPath, xpath} from "biloba";
 
 const save = xpath("button").withClass("primary").withText("Save");
 await session.xpath(save).click();
@@ -244,4 +244,4 @@ The last three exist so a crash reports itself as a crash: Chrome does not fail 
 
 `session.captureDiagnostics()` captures every live page in the browser context and excludes frames, workers, and other contexts. `consoleMessages()`/`onConsoleMessage()` and `warnings()`/`onWarning()` provide bounded snapshots and live delivery. Pass `debugLog` to `connect` for structured driver/CDP records.
 
-In a Vitest setup file, import `installBilobaVitestHooks` from `@onsi/biloba-vitest-prototype/vitest`. It captures ordinary and Biloba test failures, supports timed and explicit progress capture, replays browser errors, and can fail the test boundary on `console.assert` without throwing from the protocol reader.
+In a Vitest setup file, import `installBilobaVitestHooks` from `biloba/vitest`. It captures ordinary and Biloba test failures, supports timed and explicit progress capture, replays browser errors, and can fail the test boundary on `console.assert` without throwing from the protocol reader.

--- a/scripts/check-npm-release.mjs
+++ b/scripts/check-npm-release.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+import {readFile} from "node:fs/promises";
+import {fileURLToPath} from "node:url";
+import {dirname, resolve} from "node:path";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const bilobaSource = await readFile(resolve(repoRoot, "biloba.go"), "utf8");
+const packageJSON = JSON.parse(await readFile(resolve(repoRoot, "typescript/package.json"), "utf8"));
+const versionMatch = bilobaSource.match(/^const BILOBA_VERSION = "([^"]+)"/m);
+
+if (!versionMatch) throw new Error("could not read BILOBA_VERSION from biloba.go");
+const version = versionMatch[1];
+if (packageJSON.version !== version) {
+  throw new Error(`typescript/package.json version ${packageJSON.version} does not match Biloba ${version}`);
+}
+if (packageJSON.name !== "biloba") {
+  throw new Error(`typescript/package.json name must be biloba, got ${packageJSON.name}`);
+}
+if (packageJSON.private) throw new Error("typescript/package.json must be publishable");
+if (packageJSON.publishConfig?.access !== "public") {
+  throw new Error("typescript/package.json publishConfig.access must be public");
+}
+if (packageJSON.repository?.url !== "git+https://github.com/onsi/biloba.git") {
+  throw new Error("typescript/package.json repository must match github.com/onsi/biloba for npm provenance");
+}
+
+const tag = process.env.GITHUB_REF_TYPE === "tag" ? process.env.GITHUB_REF_NAME : process.argv[2];
+if (tag && tag !== `v${version}`) throw new Error(`release tag ${tag} does not match Biloba v${version}`);
+
+console.log(`npm release metadata is consistent at Biloba ${version}`);

--- a/scripts/prepare-npm-packages.mjs
+++ b/scripts/prepare-npm-packages.mjs
@@ -9,7 +9,7 @@ const sourceRoot = resolve(repoRoot, "typescript");
 const releaseRoot = resolve(repoRoot, ".release/npm");
 const sourceManifest = JSON.parse(await readFile(resolve(sourceRoot, "package.json"), "utf8"));
 const variants = [
-  {directory: "scoped", name: "@biloba/biloba"},
+  {directory: "scoped", name: "@onsi/biloba"},
   {directory: "unscoped", name: "biloba"},
 ];
 
@@ -29,4 +29,4 @@ for (const variant of variants) {
   await writeFile(resolve(destination, "package.json"), `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
-console.log(`staged @biloba/biloba and biloba ${sourceManifest.version} in .release/npm`);
+console.log(`staged @onsi/biloba and biloba ${sourceManifest.version} in .release/npm`);

--- a/scripts/prepare-npm-packages.mjs
+++ b/scripts/prepare-npm-packages.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+import {cp, mkdir, readFile, rm, writeFile} from "node:fs/promises";
+import {fileURLToPath} from "node:url";
+import {dirname, resolve} from "node:path";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const sourceRoot = resolve(repoRoot, "typescript");
+const releaseRoot = resolve(repoRoot, ".release/npm");
+const sourceManifest = JSON.parse(await readFile(resolve(sourceRoot, "package.json"), "utf8"));
+const variants = [
+  {directory: "scoped", name: "@biloba/biloba"},
+  {directory: "unscoped", name: "biloba"},
+];
+
+await rm(releaseRoot, {recursive: true, force: true});
+
+for (const variant of variants) {
+  const destination = resolve(releaseRoot, variant.directory);
+  await mkdir(destination, {recursive: true});
+  await cp(resolve(sourceRoot, "dist"), resolve(destination, "dist"), {recursive: true});
+  await cp(resolve(sourceRoot, "README.md"), resolve(destination, "README.md"));
+  await cp(resolve(repoRoot, "LICENSE"), resolve(destination, "LICENSE"));
+
+  const manifest = {...sourceManifest, name: variant.name};
+  delete manifest.devDependencies;
+  delete manifest.packageManager;
+  delete manifest.scripts;
+  await writeFile(resolve(destination, "package.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+console.log(`staged @biloba/biloba and biloba ${sourceManifest.version} in .release/npm`);

--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -22,7 +22,7 @@ make npm-pack TAG="$tag"
 if [[ "$mode" == "--dry-run" ]]; then
 	npm publish .release/npm/unscoped --access public --dry-run
 	npm publish .release/npm/scoped --access public --dry-run
-	printf 'npm publish dry run passed for @biloba/biloba and biloba %s\n' "$version"
+	printf 'npm publish dry run passed for @onsi/biloba and biloba %s\n' "$version"
 	exit 0
 fi
 
@@ -42,4 +42,4 @@ publish_if_missing() {
 # the generally available name lands even if the scoped organization needs separate access. A retry
 # skips either immutable version that already succeeded and continues with the missing one.
 publish_if_missing biloba .release/npm/unscoped
-publish_if_missing @biloba/biloba .release/npm/scoped
+publish_if_missing @onsi/biloba .release/npm/scoped

--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$repo_root"
+
+usage() {
+	printf 'usage: %s --dry-run|--publish [vX.Y.Z]\n' "$0" >&2
+	exit 2
+}
+
+[[ $# -ge 1 && $# -le 2 ]] || usage
+mode=$1
+tag=${2:-}
+[[ "$mode" == "--dry-run" || "$mode" == "--publish" ]] || usage
+
+version=$(node -p 'require("./typescript/package.json").version')
+[[ -z "$tag" ]] && tag="v$version"
+
+make npm-pack TAG="$tag"
+
+if [[ "$mode" == "--dry-run" ]]; then
+	npm publish .release/npm/unscoped --access public --dry-run
+	npm publish .release/npm/scoped --access public --dry-run
+	printf 'npm publish dry run passed for @biloba/biloba and biloba %s\n' "$version"
+	exit 0
+fi
+
+publish_if_missing() {
+	local package_name=$1
+	local package_directory=$2
+
+	if npm view "$package_name@$version" version >/dev/null 2>&1; then
+		printf '%s@%s is already published; skipping\n' "$package_name" "$version"
+		return
+	fi
+
+	npm publish "$package_directory" --access public
+}
+
+# There is no registry transaction spanning two names. Publishing the unscoped package first means
+# the generally available name lands even if the scoped organization needs separate access. A retry
+# skips either immutable version that already succeeded and continues with the missing one.
+publish_if_missing biloba .release/npm/unscoped
+publish_if_missing @biloba/biloba .release/npm/scoped

--- a/scripts/sync-plugin-versions.sh
+++ b/scripts/sync-plugin-versions.sh
@@ -5,7 +5,7 @@ repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$repo_root"
 
 fail() {
-	printf 'plugin version sync failed: %s\n' "$*" >&2
+	printf 'release version sync failed: %s\n' "$*" >&2
 	exit 1
 }
 
@@ -24,4 +24,12 @@ for manifest in "${manifests[@]}"; do
 	PLUGIN_VERSION="$version" perl -pi -e 's/("version": ")[^"]*(",)/$1$ENV{PLUGIN_VERSION}$2/' "$manifest"
 done
 
-printf 'synced %s plugin manifests to Biloba %s\n' "${#manifests[@]}" "$version"
+PACKAGE_VERSION="$version" node -e '
+const fs = require("node:fs");
+const path = "typescript/package.json";
+const manifest = JSON.parse(fs.readFileSync(path, "utf8"));
+manifest.version = process.env.PACKAGE_VERSION;
+fs.writeFileSync(path, `${JSON.stringify(manifest, null, 2)}\n`);
+'
+
+printf 'synced %s plugin manifests and the npm package to Biloba %s\n' "${#manifests[@]}" "$version"

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -2,7 +2,11 @@
 
 A TypeScript client for [Biloba](https://onsi.github.io/biloba/) that lets a `vitest` suite drive Chrome through Biloba.
 
-**This is a prototype.**  The package is not published to npm, and its API will continue to shift before 1.0.
+**This is a prototype.** Its API will continue to shift before 1.0. Install it from npm:
+
+```bash
+pnpm add -D biloba
+```
 
 ## Claude Code skills
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,7 +1,22 @@
 {
-  "name": "@onsi/biloba-vitest-prototype",
-  "version": "0.0.0-private",
-  "private": true,
+  "name": "biloba",
+  "version": "0.15.4",
+  "description": "Fast, stable browser testing from TypeScript and Vitest through Biloba",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/onsi/biloba.git",
+    "directory": "typescript"
+  },
+  "homepage": "https://onsi.github.io/biloba/vitest.html",
+  "bugs": "https://github.com/onsi/biloba/issues",
+  "keywords": [
+    "browser-testing",
+    "chrome",
+    "testing",
+    "typescript",
+    "vitest"
+  ],
   "type": "module",
   "packageManager": "pnpm@11.20.0",
   "exports": {
@@ -9,11 +24,17 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./vitest": {"types": "./dist/vitest.d.ts", "import": "./dist/vitest.js"}
+    "./vitest": {
+      "types": "./dist/vitest.d.ts",
+      "import": "./dist/vitest.js"
+    }
   },
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "generate:protocol": "cd .. && go generate ./protocol",
     "build": "tsc -p tsconfig.build.json",
@@ -23,8 +44,14 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {},
-  "peerDependencies": {"vitest": ">=3 <4"},
-  "peerDependenciesMeta": {"vitest": {"optional": true}},
+  "peerDependencies": {
+    "vitest": ">=3 <4"
+  },
+  "peerDependenciesMeta": {
+    "vitest": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/node": "22.15.30",
     "typescript": "5.8.3",


### PR DESCRIPTION
## Summary

Wires npm publishing of the TypeScript client into the existing release flow so `shipit` can call one script.

- `BILOBA_VERSION` stays the single version source; `make sync-plugin-versions` now also writes it into `typescript/package.json`.
- `scripts/publish-npm-packages.sh --dry-run|--publish vX.Y.Z` builds once, stages identical package trees for `biloba` and `@onsi/biloba`, validates both with `npm pack --dry-run`, then publishes. It reads no credentials (ambient `npm login`) and is retry-safe: an already-published immutable version is skipped.
- `make npm-pack` / `make npm-publish` / `make check-release` wrap the same steps; `RELEASING.md` documents the hook points for the private release script.
- Docs and the Vitest plugin skills now reference the public `biloba` package name.

Note on scope: the `@biloba` npm scope already belongs to another account, so the scoped variant targets `@onsi/biloba` (the `onsi` org you own). Nothing has been published yet.

## Test plan

- [x] `make npm-pack` builds and dry-run packs both variants
- [x] `./scripts/publish-npm-packages.sh --dry-run` (npm publish dry run for both names)
- [x] `make check-plugins`
- [x] Go suite and TypeScript tests/typecheck/build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)